### PR TITLE
fix: resolve interest accrual display mismatch (#242)

### DIFF
--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -641,18 +641,25 @@ const Portfolio = () => {
           if (userDepositIndex && scaledDeposits > 0n && depositIndex > 0n) {
             const userDepositIndexBigInt = BigInt(userDepositIndex);
             if (userDepositIndexBigInt > 0n) {
-              const currentDepositValueRaw =
-                (scaledDeposits * depositIndex) / SCALE;
-              const originalDepositRaw =
-                (scaledDeposits * userDepositIndexBigInt) / SCALE;
-              const currentDepositValue =
-                Number(currentDepositValueRaw) / Math.pow(10, token.decimals);
-              const originalDeposit =
-                Number(originalDepositRaw) / Math.pow(10, token.decimals);
-              accruedInterest = Math.max(
-                0,
-                currentDepositValue - originalDeposit
-              );
+              if (userDepositIndexBigInt > depositIndex) {
+                console.warn(
+                  "Invalid deposit index relationship: userDepositIndex > currentDepositIndex",
+                  {
+                    userDepositIndex: userDepositIndex,
+                    currentDepositIndex: depositIndex.toString(),
+                    tokenSymbol: token.symbol,
+                    marketId,
+                  }
+                );
+                accruedInterest = 0;
+              } else {
+                const interestRaw =
+                  (scaledDeposits * (depositIndex - userDepositIndexBigInt)) / SCALE;
+                accruedInterest = Math.max(
+                  0,
+                  Number(interestRaw) / Math.pow(10, token.decimals)
+                );
+              }
             }
           }
 
@@ -821,17 +828,11 @@ const Portfolio = () => {
                 // If indices are invalid, assume no interest accrued
                 accruedInterest = 0;
               } else {
-                const currentBorrowValueRaw =
-                  (scaledBorrows * borrowIndex) / SCALE;
-                const originalBorrowRaw =
-                  (scaledBorrows * userBorrowIndexBigInt) / SCALE;
-                const currentBorrowValue =
-                  Number(currentBorrowValueRaw) / Math.pow(10, token.decimals);
-                const originalBorrow =
-                  Number(originalBorrowRaw) / Math.pow(10, token.decimals);
+                const interestRaw =
+                  (scaledBorrows * (borrowIndex - userBorrowIndexBigInt)) / SCALE;
                 accruedInterest = Math.max(
                   0,
-                  currentBorrowValue - originalBorrow
+                  Number(interestRaw) / Math.pow(10, token.decimals)
                 );
               }
             }

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -526,9 +526,20 @@ export const usePortfolioData = () => {
   const totalCollateral =
     userGlobalData?.totalCollateralValue ||
     deposits.reduce((sum, deposit) => sum + deposit.value, 0);
-  const totalBorrowed =
-    userGlobalData?.totalBorrowValue ||
-    borrows.reduce((sum, borrow) => sum + borrow.value, 0);
+  // Derive totalBorrowed from per-position sums so it stays consistent
+  // with the per-position accrued interest displayed alongside it.
+  // Note: healthFactor / netLTV below also use this position-derived value.
+  const totalBorrowed = borrows.reduce((sum, borrow) => sum + borrow.value, 0);
+
+  // Reconciliation: warn when position-sum drifts from global contract value
+  const globalBorrowed = userGlobalData?.totalBorrowValue || 0;
+  if (globalBorrowed > 0 && Math.abs(totalBorrowed - globalBorrowed) / globalBorrowed > 0.01) {
+    console.warn('[Portfolio] Borrow value mismatch between position sum and global data', {
+      positionSum: totalBorrowed,
+      globalValue: globalBorrowed,
+      drift: totalBorrowed - globalBorrowed,
+    });
+  }
 
   // Calculate weighted liquidation threshold based on borrowed assets only
   const calculateWeightedLiquidationThreshold = () => {

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1138,30 +1138,25 @@ export const fetchUserBorrowBalance = async (
             ? 0n
             : (BigInt(scaledBorrows) * BigInt(currentBorrowIndex)) / SCALE;
 
-        // Calculate original borrow amount using user's stored borrow index (without accrued interest):
-        // original_amount = (scaled_borrows * user_borrow_index) / SCALE
-        const originalBorrowsRaw =
-          BigInt(scaledBorrows) === 0n
-            ? 0n
-            : (BigInt(scaledBorrows) * BigInt(userBorrowIndex)) / SCALE;
-
         // Convert to human-readable format by accounting for token decimals
         const actualBorrowAmount =
           Number(actualBorrowsRaw) / Math.pow(10, token.decimals);
-        const originalBorrowAmount =
-          Number(originalBorrowsRaw) / Math.pow(10, token.decimals);
 
-        // Calculate accrued interest as the difference
-        const accruedInterest = actualBorrowAmount - originalBorrowAmount;
+        // Single-division interest: compute index delta before dividing to
+        // avoid double-truncation from two independent BigInt divisions.
+        const interestRaw =
+          BigInt(scaledBorrows) === 0n
+            ? 0n
+            : (BigInt(scaledBorrows) * (BigInt(currentBorrowIndex) - BigInt(userBorrowIndex))) / SCALE;
+        const accruedInterest = Number(interestRaw) / Math.pow(10, token.decimals);
 
         console.log(`User borrow balance for ${token.symbol}:`, {
           scaledBorrows: scaledBorrows.toString(),
           userBorrowIndex: userBorrowIndex.toString(),
           currentBorrowIndex: currentBorrowIndex.toString(),
           actualBorrowsRaw: actualBorrowsRaw.toString(),
-          originalBorrowsRaw: originalBorrowsRaw.toString(),
+          interestRaw: interestRaw.toString(),
           actualBorrowAmount,
-          originalBorrowAmount,
           accruedInterest,
           tokenDecimals: token.decimals,
           formula: `(${scaledBorrows} * ${currentBorrowIndex}) / ${SCALE.toString()} = ${actualBorrowsRaw.toString()}`,


### PR DESCRIPTION
## Summary

- **Derive `totalBorrowed` from per-position sums** instead of `userGlobalData.totalBorrowValue` so the displayed total stays consistent with per-position accrued interest (fixes the ~10k base-unit drift reported on pool `47139778`).
- **Replace double-division BigInt interest formulas** with a single-division approach `(scaled * (currentIndex - userIndex)) / SCALE` in `Portfolio.tsx` (both deposit and borrow paths) and `lendingService.ts` to eliminate truncation drift.
- **Add reconciliation warning** when the position-sum drifts >1% from the contract's global value.

Closes #242

## Test plan

- [ ] Fetch position for `25K52U4A2NLZULKQFYPPXKWLX2Y6YADPHBBVEFTPKB32R5JN66ZZALCV7E` on Main Pool (47139778)
- [ ] Verify `accruedInterest == totalBorrowed - originalPrincipal` (within 1 base unit)
- [ ] Verify the accrued interest table and total borrowed stat remain consistent after page refresh
- [ ] Confirm no console reconciliation warnings appear under normal conditions

Made with [Cursor](https://cursor.com)