### PR TITLE
feat(markets): enforce deposit caps in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.563",
+  "version": "0.1.570",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -450,8 +450,20 @@ const MarketsTable = () => {
   };
 
   const handleDepositClick = async (asset: string, poolId?: string) => {
-    console.log("=== HANDLE DEPOSIT CLICK DEBUG ===");
-    console.log("Received params:", { asset, poolId });
+    // Don't open modal if market is at or over deposit cap
+    const assetData = getAssetData(asset, poolId);
+    if (assetData) {
+      const totalSupply = Number(assetData.totalSupply ?? 0);
+      const maxTotalDeposits = Number(assetData.maxTotalDeposits ?? 0);
+      if (maxTotalDeposits > 0 && totalSupply >= maxTotalDeposits) {
+        toast({
+          title: "Deposit cap reached",
+          description: "This market has reached its deposit cap. Deposits are not available.",
+          variant: "destructive",
+        });
+        return;
+      }
+    }
 
     setIsLoadingBalance(true);
 
@@ -2595,19 +2607,18 @@ const MarketsTable = () => {
                           }
                         }
 
-                        // Debug logging
-                        console.log("=== Direct Deposit APY Debug ===", {
-                          voiTokenSymbol: voiToken.symbol,
-                          poolId: voiToken.poolId,
-                          voiAssetData,
-                          apyCalculation: voiAssetData?.apyCalculation,
-                          supplyAPY: voiAssetData?.supplyAPY,
-                          allMarkets: markets.map((m) => ({
-                            asset: m.asset,
-                            poolId: m.poolId,
-                            supplyAPY: m.supplyAPY,
-                          })),
-                        });
+                        // Hide "Deposit & Earn" if deposit amount + total supply (incl. interest) would exceed cap
+                        const totalSupply = Number(voiAssetData?.totalSupply ?? 0);
+                        const maxTotalDeposits = Number(voiAssetData?.maxTotalDeposits ?? 0);
+                        const depositAmountHuman =
+                          totalClaimableThisBatch / Math.pow(10, rewardDecimals);
+                        const wouldExceedDepositCap =
+                          maxTotalDeposits > 0 &&
+                          depositAmountHuman + totalSupply > maxTotalDeposits;
+
+                        if (wouldExceedDepositCap) {
+                          return null;
+                        }
 
                         // Use effective APY from apyCalculation if available, otherwise fallback to supplyAPY
                         const apy =

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -3367,28 +3367,45 @@ const Portfolio = () => {
       return;
     }
 
-    console.log("[Portfolio] handleDepositClick called with:", {
-      asset,
-      poolId,
-      networkId,
-      currentNetwork,
-    });
+    if (marketData.length === 0) {
+      toast({
+        title: "Market data loading",
+        description: "Market data is loading. Please try again shortly.",
+        variant: "default",
+      });
+      return;
+    }
+
+    // Don't open modal if market is at or over deposit cap
+    const market = marketData.find(
+      (m: any) =>
+        m.symbol === asset &&
+        (poolId != null && poolId !== ""
+          ? String(m.poolId) === String(poolId)
+          : true) &&
+        (networkId != null && networkId !== ""
+          ? m.networkId === networkId
+          : true)
+    ) as any;
+    if (market) {
+      const totalSupply = Number(market.totalDeposits ?? 0);
+      const maxTotalDeposits = Number(market.maxTotalDeposits ?? 0);
+      if (maxTotalDeposits > 0 && totalSupply >= maxTotalDeposits) {
+        toast({
+          title: "Deposit cap reached",
+          description:
+            "This market has reached its deposit cap. Deposits are not available.",
+          variant: "destructive",
+        });
+        return;
+      }
+    }
 
     setIsLoadingWalletBalance(true);
 
     try {
       // Fetch wallet balance before opening modal using the deposit's network
-      console.log("[Portfolio] Fetching wallet balance for:", {
-        asset,
-        networkId,
-        currentNetwork,
-      });
       const balanceResult = await fetchWalletBalance(asset, networkId, true);
-      console.log("[Portfolio] Wallet balance fetched:", {
-        asset,
-        networkId,
-        balance: balanceResult,
-      });
 
       // In the background, prefetch wallet balances for other deposit assets
       if (deposits.length > 0) {
@@ -5843,6 +5860,10 @@ const Portfolio = () => {
                                 marketLiquidationThreshold =
                                   marketLiquidationThreshold / 100;
                               }
+                              const isAtDepositCap =
+                                Number(market?.maxTotalDeposits ?? 0) > 0 &&
+                                Number(market?.totalDeposits ?? 0) >=
+                                  Number(market?.maxTotalDeposits ?? 0);
                               return (
                                 <PortfolioTableMobileCard
                                   key={`${deposit.asset}-${deposit.poolId || "default"
@@ -5865,6 +5886,7 @@ const Portfolio = () => {
                                   liquidationFactor={marketLiquidationThreshold}
                                   network={(deposit as ItemWithNetwork).network}
                                   poolId={deposit.poolId}
+                                  depositDisabled={isAtDepositCap}
                                   onDepositClick={
                                     !isViewOnly && !market?.isPaused
                                       ? () =>
@@ -6690,6 +6712,10 @@ const Portfolio = () => {
                                   marketLiquidationThreshold / 10000;
                               }
                               const isCollateral = deposit.value > 0; // Simplified - in reality, check if it's enabled as collateral
+                              const isAtDepositCap =
+                                Number(market?.maxTotalDeposits ?? 0) > 0 &&
+                                Number(market?.totalDeposits ?? 0) >=
+                                  Number(market?.maxTotalDeposits ?? 0);
 
                               // Token decimals for Supplied / Accrued Interest (e.g. 8 for goBTC)
                               const depositNetworkForToken =
@@ -6781,13 +6807,14 @@ const Portfolio = () => {
                                 <TableRow
                                   key={index}
                                   className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-teal-400 hover:shadow-[0_0_16px_4px_rgba(13,255,190,0.15)] hover:z-20 cursor-pointer"
-                                  onClick={() =>
+                                  onClick={() => {
+                                    if (isAtDepositCap) return;
                                     handleDepositClick(
                                       deposit.asset,
                                       deposit.poolId,
                                       (deposit as ItemWithNetwork).network
-                                    )
-                                  }
+                                    );
+                                  }}
                                 >
                                   <TableCell className="min-w-0">
                                     <div className="flex flex-col items-center gap-1 min-w-0">
@@ -6894,7 +6921,12 @@ const Portfolio = () => {
                                                   (deposit as ItemWithNetwork).network
                                                 );
                                               }}
-                                              title="Supply more of this asset to earn yield and use as collateral"
+                                              disabled={isAtDepositCap}
+                                              title={
+                                                isAtDepositCap
+                                                  ? "Market at deposit cap"
+                                                  : "Supply more of this asset to earn yield and use as collateral"
+                                              }
                                               aria-label="Supply"
                                               className="min-w-[92px] h-8 px-2 gap-1"
                                             >
@@ -7642,7 +7674,12 @@ const Portfolio = () => {
                                                 (asset.poolId
                                                   ? m.poolId === asset.poolId
                                                   : true)
-                                            );
+                                            ) as any;
+                                            const isAtDepositCap =
+                                              atRiskMarket &&
+                                              Number(atRiskMarket?.maxTotalDeposits ?? 0) > 0 &&
+                                              Number(atRiskMarket?.totalDeposits ?? 0) >=
+                                                Number(atRiskMarket?.maxTotalDeposits ?? 0);
                                             return !atRiskMarket?.isPaused && (
                                               <DorkFiButton
                                                 variant="secondary"
@@ -7652,6 +7689,12 @@ const Portfolio = () => {
                                                     asset.asset,
                                                     asset.poolId
                                                   )
+                                                }
+                                                disabled={isAtDepositCap}
+                                                title={
+                                                  isAtDepositCap
+                                                    ? "Market at deposit cap"
+                                                    : undefined
                                                 }
                                                 className="min-w-0 w-8 h-8 p-0"
                                               >

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -249,6 +249,16 @@ const MarketCardView = ({
                 <DorkFiButton
                   variant="secondary"
                   onClick={e => { e.stopPropagation(); onDepositClick(market.asset, market.marketInfo?.poolId || market.poolId); }}
+                  disabled={
+                    (Number(market.supplyCap ?? 0) > 0 &&
+                     Number(market.totalSupply ?? 0) >= Number(market.supplyCap ?? 0))
+                  }
+                  title={
+                    (Number(market.supplyCap ?? 0) > 0 &&
+                     Number(market.totalSupply ?? 0) >= Number(market.supplyCap ?? 0))
+                      ? "Market at deposit cap"
+                      : undefined
+                  }
                 >Deposit</DorkFiButton>
                 <DorkFiButton
                   variant="borrow-outline"

--- a/src/components/markets/MarketsDesktopTable.tsx
+++ b/src/components/markets/MarketsDesktopTable.tsx
@@ -599,15 +599,10 @@ const MarketsDesktopTable = ({
             // Use poolId from market object (most reliable - set when market data is loaded)
             // Fallback to token poolId, then marketInfo poolId
             const finalPoolId = market.poolId || token?.poolId || poolId || market.marketInfo?.poolId;
-            
-            console.log("=== MARKETS TABLE ACTIONS DEBUG ===", {
-              asset: market.asset,
-              marketPoolId: market.poolId,
-              marketInfoPoolId: market.marketInfo?.poolId,
-              tokenPoolId: token?.poolId,
-              finalPoolId,
-              hasMarketInfo: !!market.marketInfo,
-            });
+            const totalSupply = Number(market.totalSupply ?? 0);
+            const supplyCap = Number(market.supplyCap ?? 0);
+            const isAtDepositCap =
+              supplyCap > 0 && totalSupply >= supplyCap;
 
             return (
               <MarketsTableActions
@@ -626,6 +621,7 @@ const MarketsDesktopTable = ({
                 migrationBalance={migrationBalance || undefined}
                 isLoadingBalance={isLoadingBalance}
                 isSToken={market.isSToken}
+                depositDisabled={isAtDepositCap}
               />
             );
           })()}
@@ -1017,7 +1013,11 @@ const MarketsDesktopTable = ({
 
                       // Use poolId from market object (most reliable - set when market data is loaded)
                       const finalPoolId = mainMarket.poolId || token?.poolId || poolId || mainMarket.marketInfo?.poolId;
-                      
+                      const totalSupply = Number(mainMarket.totalSupply ?? 0);
+                      const supplyCap = Number(mainMarket.supplyCap ?? 0);
+                      const isAtDepositCap =
+                        supplyCap > 0 && totalSupply >= supplyCap;
+
                       return (
                         <MarketsTableActions
                           asset={mainMarket.asset}
@@ -1035,6 +1035,7 @@ const MarketsDesktopTable = ({
                           migrationBalance={migrationBalance || undefined}
                           isLoadingBalance={isLoadingBalance}
                           isSToken={mainMarket.isSToken}
+                          depositDisabled={isAtDepositCap}
                         />
                       );
                     })()}

--- a/src/components/markets/MarketsTableActions.tsx
+++ b/src/components/markets/MarketsTableActions.tsx
@@ -12,6 +12,8 @@ interface MarketsTableActionsProps {
   migrationBalance?: string; // Formatted balance to display
   isLoadingBalance?: boolean;
   isSToken?: boolean;
+  /** When true, deposit is disabled (e.g. market at or over deposit cap). */
+  depositDisabled?: boolean;
 }
 
 const MarketsTableActions = ({ 
@@ -23,7 +25,8 @@ const MarketsTableActions = ({
   onMigrateClick,
   migrationBalance,
   isLoadingBalance = false,
-  isSToken = false 
+  isSToken = false,
+  depositDisabled = false,
 }: MarketsTableActionsProps) => {
   return (
     <div className="flex flex-col space-y-2">
@@ -35,7 +38,8 @@ const MarketsTableActions = ({
               e.stopPropagation();
               onDepositClick(asset, poolId);
             }}
-            disabled={isLoadingBalance}
+            disabled={isLoadingBalance || depositDisabled}
+            title={depositDisabled ? "Market at deposit cap" : undefined}
           >
             {isLoadingBalance ? "Loading..." : "Deposit"}
           </DorkFiButton>

--- a/src/components/markets/MarketsTabletTable.tsx
+++ b/src/components/markets/MarketsTabletTable.tsx
@@ -743,6 +743,10 @@ const MarketsTabletTable = ({
                         : tokenConfigRaw;
                       const hasMigration = !!tokenConfig?.migration;
                       const migrationBalance = migrationBalances[mainMarket.asset];
+                      const totalSupply = Number(mainMarket.totalSupply ?? 0);
+                      const supplyCap = Number(mainMarket.supplyCap ?? 0);
+                      const isAtDepositCap =
+                        supplyCap > 0 && totalSupply >= supplyCap;
 
                       return (
                         <MarketsTableActions
@@ -761,6 +765,7 @@ const MarketsTabletTable = ({
                           migrationBalance={migrationBalance || undefined}
                           isLoadingBalance={isLoadingBalance}
                           isSToken={mainMarket.isSToken}
+                          depositDisabled={isAtDepositCap}
                         />
                       );
                     })()}

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -25,6 +25,8 @@ interface PortfolioTableMobileCardProps {
   onRefreshClick?: () => void;
   isRefreshing?: boolean;
   type?: "deposit" | "borrow";
+  /** When true, deposit button is disabled (e.g. market at or over deposit cap). */
+  depositDisabled?: boolean;
 }
 
 const PortfolioTableMobileCard = ({
@@ -47,6 +49,7 @@ const PortfolioTableMobileCard = ({
   onRefreshClick,
   isRefreshing,
   type = "deposit",
+  depositDisabled = false,
 }: PortfolioTableMobileCardProps) => {
   const { currentNetwork } = useNetwork();
   const tokenConfigRaw = getTokenConfig(currentNetwork, asset);
@@ -322,6 +325,12 @@ const PortfolioTableMobileCard = ({
               size="sm"
               onClick={onDepositClick}
               className="flex-1 min-w-0"
+              disabled={isDeposit ? depositDisabled : false}
+              title={
+                isDeposit && depositDisabled
+                  ? "Market at deposit cap"
+                  : undefined
+              }
             >
               <Plus className="w-4 h-4 mr-1" />
               {isDeposit ? "Deposit" : "Borrow"}

--- a/src/components/ui/DorkFiButton.tsx
+++ b/src/components/ui/DorkFiButton.tsx
@@ -40,23 +40,30 @@ const variantClasses: Record<Variant, string> = {
 
 // All buttons standardized: min-h-[44px] min-w-[92px] px-4 py-2 text-sm font-semibold rounded-lg btn-hover-lift shadow-sm/hover:shadow-md transition-all, flex/center content, gap-1
 const DorkFiButton = React.forwardRef<HTMLButtonElement, DorkFiButtonProps>(
-  ({ variant = "primary", size = 'md', className, children, ...props }, ref) => (
-    <button
-      ref={ref}
-      className={cn(
-        "rounded-lg font-semibold min-h-[44px] min-w-[92px] btn-hover-lift shadow-sm hover:shadow-md transition-all flex items-center justify-center gap-1",
-        size === 'sm' ? 'px-3 py-1.5 text-xs' : size === 'lg' ? 'px-5 py-3 text-base' : 'px-4 py-2 text-sm',
-        variantClasses[variant],
-        className
-      )}
-      type={props.type || "button"}
-      tabIndex={props.onClick ? 0 : -1}
-      style={{ pointerEvents: props.onClick ? "auto" : "none" }}
-      {...props}
-    >
-      {children}
-    </button>
-  )
+  ({ variant = "primary", size = 'md', className, children, disabled, ...props }, ref) => {
+    const isDisabled = Boolean(disabled);
+    return (
+      <button
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          "rounded-lg font-semibold min-h-[44px] min-w-[92px] shadow-sm transition-all flex items-center justify-center gap-1",
+          size === 'sm' ? 'px-3 py-1.5 text-xs' : size === 'lg' ? 'px-5 py-3 text-base' : 'px-4 py-2 text-sm',
+          !isDisabled && "btn-hover-lift hover:shadow-md",
+          !isDisabled && variantClasses[variant],
+          isDisabled &&
+            "!opacity-60 !cursor-not-allowed !bg-slate-200 !border !border-slate-300 !text-slate-500 hover:!bg-slate-200 hover:!border-slate-300 hover:!text-slate-500 hover:!shadow-sm hover:!translate-y-0 dark:!bg-slate-700 dark:!border-slate-600 dark:!text-slate-400 dark:hover:!bg-slate-700 dark:hover:!border-slate-600",
+          className
+        )}
+        type={props.type || "button"}
+        tabIndex={isDisabled ? -1 : (props.onClick ? 0 : -1)}
+        style={{ pointerEvents: props.onClick && !isDisabled ? "auto" : "none" }}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
 );
 
 DorkFiButton.displayName = "DorkFiButton";

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -244,12 +244,30 @@ export const decodeUser = (user: any[]) => {
   } as User;
 };
 
+/** SCALE used by contract for index math (1e18). */
+const DEPOSIT_SCALE = new BigNumber(1e18);
+
+/**
+ * Market total supply including accrued interest, for deposit cap validation.
+ * Formula: (totalScaledDeposits * depositIndex) / SCALE / 10^decimals.
+ * Use this so cap checks match contract semantics (principal + interest).
+ */
+function totalDepositsIncludingInterest(
+  totalScaledDeposits: string,
+  depositIndex: string,
+  decimals: number
+): string {
+  return new BigNumber(totalScaledDeposits)
+    .times(depositIndex)
+    .div(DEPOSIT_SCALE)
+    .div(new BigNumber(10).pow(decimals))
+    .toFixed(4);
+}
+
 export const enhanceAVMMarketInfo = (
   market: any,
   token?: TokenConfig
 ): MarketInfo => {
-  console.log("enhanceAVMMarketInfo", { market, token });
-
   const poolId = market.poolId || market.appId;
   const utilizationRate =
     market.totalScaledDeposits.toString() == "0"
@@ -277,7 +295,13 @@ export const enhanceAVMMarketInfo = (
       .toFixed(4);
   };
 
-  const totalDeposits = formatDeposit(market.totalScaledDeposits.toString());
+  const decimals = token?.decimals ?? 6;
+  // Include accrued interest so deposit cap validation matches contract (see issue #246)
+  const totalDeposits = totalDepositsIncludingInterest(
+    market.totalScaledDeposits.toString(),
+    market.depositIndex.toString(),
+    decimals
+  );
 
   const totalBorrows = formatDeposit(market.totalScaledBorrows.toString());
 
@@ -325,7 +349,7 @@ export const enhanceAVMMarketInfo = (
     tokenContractId: market.ntokenId.toString(),
     name: token?.name || "",
     symbol: token?.symbol || "",
-    decimals: token?.decimals ?? 6,
+    decimals,
     collateralFactor: parseFloat(market.collateralFactor.toString()) / 10000,
     liquidationThreshold:
       parseFloat(market.liquidationThreshold.toString()) / 10000,
@@ -333,10 +357,10 @@ export const enhanceAVMMarketInfo = (
     borrowRate: parseFloat(market.borrowRate.toString()) / 10000,
     slope: parseFloat(market.slope.toString()) / 10000,
     maxTotalDeposits: BigNumber(market.maxTotalDeposits.toString())
-      .div(10 ** (token?.decimals ?? 6))
+      .div(10 ** decimals)
       .toFixed(0),
     maxTotalBorrows: BigNumber(market.maxTotalBorrows.toString())
-      .div(10 ** (token?.decimals ?? 6))
+      .div(10 ** decimals)
       .toFixed(0),
     liquidationBonus: parseFloat(market.liquidationBonus.toString()) / 10000,
     closeFactor: parseFloat(market.closeFactor.toString()) / 10000,
@@ -613,13 +637,18 @@ export const fetchMarketInfo = async (
         return new BigNumber(price).div(new BigNumber(10).pow(18)).toFixed(12);
       };
 
+      const tokenDecimals = token?.decimals ?? 6;
       const formatDeposit = (deposit: string) => {
         return new BigNumber(deposit)
-          .div(new BigNumber(10).pow(token?.decimals || 0))
+          .div(new BigNumber(10).pow(tokenDecimals))
           .toFixed(4);
       };
-
-      const totalDeposits = formatDeposit(market.totalScaledDeposits);
+      // Include accrued interest so deposit cap validation matches contract (see issue #246)
+      const totalDeposits = totalDepositsIncludingInterest(
+        market.totalScaledDeposits.toString(),
+        market.depositIndex.toString(),
+        tokenDecimals
+      );
 
       const totalBorrows = formatDeposit(market.totalScaledBorrows);
 


### PR DESCRIPTION
- Disable Deposit button and show "Market at deposit cap" when total supply meets or exceeds supply cap (card, desktop, tablet views)
- Block opening deposit modal when at cap; show destructive toast
- Hide "Deposit & Earn" in rewards when deposit would exceed cap
- Compute total supply including accrued interest in lendingService (totalScaledDeposits * depositIndex) so cap checks match contract
- DorkFiButton: add disabled state styling and accessibility

Made-with: Cursor