### PR TITLE
feat: add deposit and borrow cap indicators and enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.570",
+  "version": "0.1.578",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketDetailModal.tsx
+++ b/src/components/MarketDetailModal.tsx
@@ -15,6 +15,8 @@ import { useNetwork } from "@/contexts/NetworkContext";
 import { fetchUserGlobalData, fetchUserBorrowBalance } from "@/services/lendingService";
 import { getAllTokensWithDisplayInfo } from "@/config";
 import { APYCalculationResult } from "@/utils/apyCalculations";
+import { useToast } from "@/hooks/use-toast";
+import { isAtBorrowCap as isAtBorrowCapUtil } from "@/constants/lendingCaps";
 
 interface MarketDetailModalProps {
   isOpen: boolean;
@@ -32,6 +34,7 @@ interface MarketDetailModalProps {
     collateralFactor: number;
     supplyCap: number;
     supplyCapUSD: number;
+    borrowCap?: number;
     maxLTV: number;
     liquidationThreshold: number;
     liquidationPenalty: number;
@@ -70,7 +73,12 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
   } | null>(null);
   const [userBorrowBalance, setUserBorrowBalance] = useState<number>(0);
   const [isLoadingGlobalData, setIsLoadingGlobalData] = useState(false);
-  
+  const { toast } = useToast();
+
+  const borrowCap = Number(marketData.borrowCap ?? 0);
+  const totalBorrow = Number(marketData.totalBorrow ?? 0);
+  const isAtBorrowCap = isAtBorrowCapUtil(totalBorrow, borrowCap);
+
   const { activeAccount } = useWallet();
   const { currentNetwork } = useNetwork();
 
@@ -79,6 +87,15 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
   };
 
   const handleBorrowClick = async () => {
+    if (isAtBorrowCap) {
+      toast({
+        title: "Borrow cap reached",
+        description:
+          "This market has reached its borrow cap. Borrowing is not available.",
+        variant: "destructive",
+      });
+      return;
+    }
     setIsLoadingGlobalData(true);
     
     try {
@@ -144,6 +161,7 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
     collateralFactor: marketData.collateralFactor,
     liquidity: marketData.totalSupply - marketData.totalBorrow,
     liquidityUSD: marketData.totalSupplyUSD - marketData.totalBorrowUSD,
+    maxTotalBorrows: marketData.borrowCap ?? 0,
   });
 
   const supplyUtilization = (marketData.totalSupplyUSD / marketData.supplyCapUSD) * 100;
@@ -531,7 +549,9 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
               <Button
                 onClick={handleBorrowClick}
                 variant="outline"
-                className="border-ocean-teal text-ocean-teal hover:bg-ocean-teal/10 dark:border-ocean-teal dark:text-ocean-teal h-10 text-base font-semibold"
+                disabled={isAtBorrowCap}
+                title={isAtBorrowCap ? "Market at borrow cap" : undefined}
+                className="border-ocean-teal text-ocean-teal hover:bg-ocean-teal/10 dark:border-ocean-teal dark:text-ocean-teal h-10 text-base font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 Borrow {asset}
               </Button>

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -37,6 +37,7 @@ import {
   isMarketPaused,
 } from "@/services/lendingService";
 import { useToast } from "@/hooks/use-toast";
+import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import algosdk, { waitForConfirmation } from "algosdk";
 import { abi, CONTRACT } from "ulujs";
 import {
@@ -450,12 +451,12 @@ const MarketsTable = () => {
   };
 
   const handleDepositClick = async (asset: string, poolId?: string) => {
-    // Don't open modal if market is at or over deposit cap
+    // Don't open modal if market is at or over deposit cap (95% threshold)
     const assetData = getAssetData(asset, poolId);
     if (assetData) {
       const totalSupply = Number(assetData.totalSupply ?? 0);
       const maxTotalDeposits = Number(assetData.maxTotalDeposits ?? 0);
-      if (maxTotalDeposits > 0 && totalSupply >= maxTotalDeposits) {
+      if (isAtDepositCap(totalSupply, maxTotalDeposits)) {
         toast({
           title: "Deposit cap reached",
           description: "This market has reached its deposit cap. Deposits are not available.",
@@ -512,6 +513,22 @@ const MarketsTable = () => {
   };
 
   const handleBorrowClick = async (asset: string, poolId?: string) => {
+    // Don't open modal if market is at or over borrow cap (95% threshold)
+    const assetData = getAssetData(asset, poolId);
+    if (assetData) {
+      const totalBorrow = Number(assetData.totalBorrow ?? 0);
+      const maxTotalBorrows = Number(assetData.maxTotalBorrows ?? 0);
+      if (isAtBorrowCap(totalBorrow, maxTotalBorrows)) {
+        toast({
+          title: "Borrow cap reached",
+          description:
+            "This market has reached its borrow cap. Borrowing is not available.",
+          variant: "destructive",
+        });
+        return;
+      }
+    }
+
     setIsLoadingGlobalData(true);
 
     try {
@@ -2106,6 +2123,7 @@ const MarketsTable = () => {
       borrowApyCalculation: (market as { borrowApyCalculation?: { apy: number } }).borrowApyCalculation,
       apyParameters,
       maxTotalDeposits: market.supplyCap,
+      maxTotalBorrows: market.borrowCap,
       isSToken: market.isSToken,
     };
   };

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -5,6 +5,7 @@ import { useNetwork } from "@/contexts/NetworkContext";
 import { useAddressName } from "@/hooks/useAddressName";
 import { useAvatarImage } from "@/hooks/useAvatarImage";
 import { useToast } from "@/hooks/use-toast";
+import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import algosdk, { waitForConfirmation } from "algosdk";
 import BigNumber from "bignumber.js";
@@ -3390,7 +3391,7 @@ const Portfolio = () => {
     if (market) {
       const totalSupply = Number(market.totalDeposits ?? 0);
       const maxTotalDeposits = Number(market.maxTotalDeposits ?? 0);
-      if (maxTotalDeposits > 0 && totalSupply >= maxTotalDeposits) {
+      if (isAtDepositCap(totalSupply, maxTotalDeposits)) {
         toast({
           title: "Deposit cap reached",
           description:
@@ -3465,6 +3466,41 @@ const Portfolio = () => {
     poolId?: string,
     networkId?: string
   ) => {
+    if (marketData.length === 0) {
+      toast({
+        title: "Market data loading",
+        description: "Market data is loading. Please try again shortly.",
+        variant: "default",
+      });
+      return;
+    }
+
+    // Don't open modal if market is at or over borrow cap.
+    // marketData entries are MarketInfo from fetchAllMarkets (totalBorrows, maxTotalBorrows).
+    const market = marketData.find(
+      (m: any) =>
+        m.symbol === asset &&
+        (poolId != null && poolId !== ""
+          ? String(m.poolId) === String(poolId)
+          : true) &&
+        (networkId != null && networkId !== ""
+          ? m.networkId === networkId
+          : true)
+    ) as any;
+    if (market) {
+      const totalBorrows = Number(market.totalBorrows ?? 0);
+      const maxTotalBorrows = Number(market.maxTotalBorrows ?? 0);
+      if (isAtBorrowCap(totalBorrows, maxTotalBorrows)) {
+        toast({
+          title: "Borrow cap reached",
+          description:
+            "This market has reached its borrow cap. Borrowing is not available.",
+          variant: "destructive",
+        });
+        return;
+      }
+    }
+
     setIsLoadingBorrowData(true);
 
     try {
@@ -5860,10 +5896,10 @@ const Portfolio = () => {
                                 marketLiquidationThreshold =
                                   marketLiquidationThreshold / 100;
                               }
-                              const isAtDepositCap =
-                                Number(market?.maxTotalDeposits ?? 0) > 0 &&
-                                Number(market?.totalDeposits ?? 0) >=
-                                  Number(market?.maxTotalDeposits ?? 0);
+                              const depositCapReached = isAtDepositCap(
+                                Number(market?.totalDeposits ?? 0),
+                                Number(market?.maxTotalDeposits ?? 0),
+                              );
                               return (
                                 <PortfolioTableMobileCard
                                   key={`${deposit.asset}-${deposit.poolId || "default"
@@ -5886,7 +5922,7 @@ const Portfolio = () => {
                                   liquidationFactor={marketLiquidationThreshold}
                                   network={(deposit as ItemWithNetwork).network}
                                   poolId={deposit.poolId}
-                                  depositDisabled={isAtDepositCap}
+                                  depositDisabled={depositCapReached}
                                   onDepositClick={
                                     !isViewOnly && !market?.isPaused
                                       ? () =>
@@ -6712,10 +6748,10 @@ const Portfolio = () => {
                                   marketLiquidationThreshold / 10000;
                               }
                               const isCollateral = deposit.value > 0; // Simplified - in reality, check if it's enabled as collateral
-                              const isAtDepositCap =
-                                Number(market?.maxTotalDeposits ?? 0) > 0 &&
-                                Number(market?.totalDeposits ?? 0) >=
-                                  Number(market?.maxTotalDeposits ?? 0);
+                              const depositCapReached = isAtDepositCap(
+                                Number(market?.totalDeposits ?? 0),
+                                Number(market?.maxTotalDeposits ?? 0),
+                              );
 
                               // Token decimals for Supplied / Accrued Interest (e.g. 8 for goBTC)
                               const depositNetworkForToken =
@@ -6808,7 +6844,7 @@ const Portfolio = () => {
                                   key={index}
                                   className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-teal-400 hover:shadow-[0_0_16px_4px_rgba(13,255,190,0.15)] hover:z-20 cursor-pointer"
                                   onClick={() => {
-                                    if (isAtDepositCap) return;
+                                    if (depositCapReached) return;
                                     handleDepositClick(
                                       deposit.asset,
                                       deposit.poolId,
@@ -6921,9 +6957,9 @@ const Portfolio = () => {
                                                   (deposit as ItemWithNetwork).network
                                                 );
                                               }}
-                                              disabled={isAtDepositCap}
+                                              disabled={depositCapReached}
                                               title={
-                                                isAtDepositCap
+                                                depositCapReached
                                                   ? "Market at deposit cap"
                                                   : "Supply more of this asset to earn yield and use as collateral"
                                               }
@@ -7675,11 +7711,12 @@ const Portfolio = () => {
                                                   ? m.poolId === asset.poolId
                                                   : true)
                                             ) as any;
-                                            const isAtDepositCap =
+                                            const depositCapReached =
                                               atRiskMarket &&
-                                              Number(atRiskMarket?.maxTotalDeposits ?? 0) > 0 &&
-                                              Number(atRiskMarket?.totalDeposits ?? 0) >=
-                                                Number(atRiskMarket?.maxTotalDeposits ?? 0);
+                                              isAtDepositCap(
+                                                Number(atRiskMarket?.totalDeposits ?? 0),
+                                                Number(atRiskMarket?.maxTotalDeposits ?? 0),
+                                              );
                                             return !atRiskMarket?.isPaused && (
                                               <DorkFiButton
                                                 variant="secondary"
@@ -7690,9 +7727,9 @@ const Portfolio = () => {
                                                     asset.poolId
                                                   )
                                                 }
-                                                disabled={isAtDepositCap}
+                                                disabled={depositCapReached}
                                                 title={
-                                                  isAtDepositCap
+                                                  depositCapReached
                                                     ? "Market at deposit cap"
                                                     : undefined
                                                 }
@@ -7937,7 +7974,13 @@ const Portfolio = () => {
                                   (borrow.poolId
                                     ? m.poolId === borrow.poolId
                                     : true)
-                              );
+                              ) as any;
+                              const borrowCapReached =
+                                market &&
+                                isAtBorrowCap(
+                                  Number(market?.totalBorrows ?? 0),
+                                  Number(market?.maxTotalBorrows ?? 0),
+                                );
                               const liquidationThreshold =
                                 market?.liquidationThreshold || 0.85;
                               const liquidationThresholdNum =
@@ -7995,6 +8038,7 @@ const Portfolio = () => {
                                   liquidationPrice={liquidationPrice}
                                   network={(borrow as ItemWithNetwork).network}
                                   poolId={borrow.poolId}
+                                  borrowDisabled={borrowCapReached}
                                   onDepositClick={
                                     !isViewOnly && !market?.isPaused
                                       ? () =>
@@ -8391,10 +8435,16 @@ const Portfolio = () => {
                               const market = marketData.find(
                                 (m) =>
                                   m.symbol === borrow.asset &&
-                                  (borrow.poolId
+                                    (borrow.poolId
                                     ? m.poolId === borrow.poolId
                                     : true)
-                              );
+                              ) as any;
+                              const borrowCapReached =
+                                market &&
+                                isAtBorrowCap(
+                                  Number(market?.totalBorrows ?? 0),
+                                  Number(market?.maxTotalBorrows ?? 0),
+                                );
                               const liquidationThreshold =
                                 market?.liquidationThreshold || 0.85;
 
@@ -8599,13 +8649,19 @@ const Portfolio = () => {
                                               variant="borrow-outline"
                                               onClick={(e) => {
                                                 e.stopPropagation();
+                                                if (borrowCapReached) return;
                                                 handleBorrowClick(
                                                   borrow.asset,
                                                   borrow.poolId,
                                                   (borrow as ItemWithNetwork).network
                                                 );
                                               }}
-                                              title="Borrow more of this asset against your collateral"
+                                              disabled={borrowCapReached}
+                                              title={
+                                                borrowCapReached
+                                                  ? "Market at borrow cap"
+                                                  : "Borrow more of this asset against your collateral"
+                                              }
                                               aria-label="Borrow"
                                               className="min-w-[92px] h-8 px-2 gap-1"
                                             >

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -793,6 +793,7 @@ const PortfolioModals = ({
       liquidity: totalSupply - totalBorrow,
       liquidityUSD: (totalSupply - totalBorrow) * tokenPrice,
       maxTotalDeposits: parseFloat(market.maxTotalDeposits) || 0,
+      maxTotalBorrows: parseFloat((market as { maxTotalBorrows?: string }).maxTotalBorrows ?? "0") || 0,
       reserveFactor: market.reserveFactor != null ? (market.reserveFactor <= 1 ? market.reserveFactor * 10000 : market.reserveFactor) : undefined,
       apyCalculation: market.apyCalculation,
       borrowApyCalculation: market.borrowApyCalculation,

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -70,6 +70,7 @@ interface SupplyBorrowModalProps {
     liquidity: number;
     liquidityUSD: number;
     maxTotalDeposits?: number;
+    maxTotalBorrows?: number;
     isSToken?: boolean;
     reserveFactor?: number;
     apyCalculation?: { apy: number; utilizationRate?: number };
@@ -241,6 +242,14 @@ const SupplyBorrowModal = ({
         const totalDeposits = assetData.totalSupply;
         const totalBorrowed = assetData.totalBorrow;
 
+        // Cap by market borrow cap (amount remaining)
+        const capByBorrowCap = (value: number) => {
+          const borrowCap = assetData.maxTotalBorrows ?? 0;
+          if (borrowCap <= 0) return value;
+          const remaining = Math.max(0, borrowCap - (assetData.totalBorrow ?? 0));
+          return Math.min(value, remaining);
+        };
+
         // Calculate total deposits - total borrowed
         const depositsMinusBorrowed = totalDeposits - totalBorrowed;
 
@@ -277,10 +286,12 @@ const SupplyBorrowModal = ({
             }
           }
 
-          // Take minimum of (total deposits - total borrowed) and current borrowable value
-          const finalMaxBorrow = Math.max(
-            0,
-            Math.min(adjustedMaxBorrow, depositsMinusBorrowed)
+          // Take minimum of (total deposits - total borrowed) and current borrowable value, then cap by borrow cap
+          const finalMaxBorrow = capByBorrowCap(
+            Math.max(
+              0,
+              Math.min(adjustedMaxBorrow, depositsMinusBorrowed)
+            )
           );
 
           setCalculatedMaxBorrow(finalMaxBorrow);
@@ -304,14 +315,15 @@ const SupplyBorrowModal = ({
           const collateralForBorrow =
             poolData != null ? poolData.totalCollateralValue : userGlobalData.totalCollateralValue;
           const maxBorrowUSD = collateralForBorrow * (assetData.collateralFactor / 100);
-          const calculatedMaxBorrow =
+          const calculatedMaxBorrow = capByBorrowCap(
             tokenPrice != null && tokenPrice > 0
               ? (maxBorrowUSD / tokenPrice) * Math.pow(10, 6) / Math.pow(10, decimals)
-              : 0;
+              : 0
+          );
           setCalculatedMaxBorrow(calculatedMaxBorrow);
         } else {
-          // Even if maxBorrowBigInt is 0, we should still check deposits - borrowed
-          const finalMaxBorrow = Math.max(0, depositsMinusBorrowed);
+          // Even if maxBorrowBigInt is 0, we should still check deposits - borrowed, then cap by borrow cap
+          const finalMaxBorrow = capByBorrowCap(Math.max(0, depositsMinusBorrowed));
           setCalculatedMaxBorrow(finalMaxBorrow);
           console.log(
             "SupplyBorrowModal: Max borrow amount (deposits - borrowed):",
@@ -333,7 +345,7 @@ const SupplyBorrowModal = ({
     };
 
     fetchMaxBorrowAmount();
-  }, [isOpen, mode, activeAccount?.address, asset, poolId, networkToUse, tokenPrice]);
+  }, [isOpen, mode, activeAccount?.address, asset, poolId, networkToUse, tokenPrice, assetData.totalBorrow, assetData.maxTotalBorrows]);
 
   // Reset states when modal opens/closes
   useEffect(() => {
@@ -971,8 +983,14 @@ const SupplyBorrowModal = ({
                 walletBalance={propWalletBalance}
                 walletBalanceUSD={propWalletBalanceUSD}
                 availableToSupplyOrBorrow={
-                  mode === "borrow" && calculatedMaxBorrow !== null
-                    ? calculatedMaxBorrow
+                  mode === "borrow"
+                    ? (() => {
+                        const raw = calculatedMaxBorrow !== null ? calculatedMaxBorrow : assetData.liquidity;
+                        const borrowCap = assetData.maxTotalBorrows ?? 0;
+                        if (borrowCap <= 0) return raw;
+                        const remaining = Math.max(0, borrowCap - (assetData.totalBorrow ?? 0));
+                        return Math.min(raw, remaining);
+                      })()
                     : assetData.liquidity
                 }
                 supplyAPY={assetData.supplyAPY}

--- a/src/components/SupplyBorrowStats.tsx
+++ b/src/components/SupplyBorrowStats.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { InfoIcon, ChevronDown, ChevronUp } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { calculateDepositAPY, calculateBorrowAPY } from "@/utils/apyCalculations";
+import { isAtDepositCap } from "@/constants/lendingCaps";
+import { useTokenPrice } from "@/hooks/useTokenPrice";
 import { useState } from "react";
 
 interface AssetData {
@@ -16,6 +18,7 @@ interface AssetData {
   totalBorrowUSD?: number;
   reserveFactor?: number;
   maxTotalDeposits?: number;
+  maxTotalBorrows?: number;
   apyCalculation?: { apy: number; [key: string]: unknown };
   borrowApyCalculation?: { apy: number };
   apyParameters?: { borrowRateBps: number; slopeBps: number; reserveFactorBps: number };
@@ -38,6 +41,7 @@ interface SupplyBorrowStatsProps {
 }
 
 const SupplyBorrowStats = ({ mode, asset, assetData, userGlobalData, depositAmount = 0, borrowAmount = 0, userBorrowBalance = 0, userDepositBalance = 0, isSToken = false }: SupplyBorrowStatsProps) => {
+  const { price: tokenPrice } = useTokenPrice(asset);
   const safeSupplyAPY = Number.isFinite(assetData.supplyAPY) ? assetData.supplyAPY : 0;
   const safeBorrowAPY = Number.isFinite(assetData.borrowAPY) ? assetData.borrowAPY : 0;
 
@@ -271,7 +275,7 @@ const SupplyBorrowStats = ({ mode, asset, assetData, userGlobalData, depositAmou
                 {assetData.maxTotalDeposits.toLocaleString()} {asset}
               </div>
               <div className="text-xs text-slate-500 dark:text-slate-400">
-                {assetData.totalSupply && assetData.maxTotalDeposits > assetData.totalSupply 
+                {assetData.totalSupply != null && assetData.maxTotalDeposits > 0 && !isAtDepositCap(assetData.totalSupply, assetData.maxTotalDeposits)
                   ? `${((assetData.maxTotalDeposits - assetData.totalSupply) / assetData.maxTotalDeposits * 100).toFixed(1)}% available`
                   : "At capacity"
                 }
@@ -374,10 +378,16 @@ const SupplyBorrowStats = ({ mode, asset, assetData, userGlobalData, depositAmou
                 </div>
                 <span className="text-sm font-medium text-teal-600 dark:text-teal-400">
                   ${(() => {
-                    // Calculate max borrowable amount based on collateral
-                    // Formula: max(0, collateral * cf - borrows)
-                    const collateralFactorDecimal = assetData.collateralFactor / 100; // Convert percentage to decimal
-                    const maxBorrowable = Math.max(0, (userGlobalData.totalCollateralValue * collateralFactorDecimal) - userGlobalData.totalBorrowValue);
+                    // Max borrowable from collateral; cap by remaining borrow cap when applicable.
+                    // assetData.totalBorrow and maxTotalBorrows are in same token units; tokenPrice is USD per token.
+                    const collateralFactorDecimal = assetData.collateralFactor / 100;
+                    let maxBorrowable = Math.max(0, (userGlobalData.totalCollateralValue * collateralFactorDecimal) - userGlobalData.totalBorrowValue);
+                    const borrowCap = Number(assetData.maxTotalBorrows ?? 0);
+                    if (borrowCap > 0 && tokenPrice > 0) {
+                      const totalBorrow = Number(assetData.totalBorrow ?? 0);
+                      const remainingBorrowCapUSD = Math.max(0, borrowCap - totalBorrow) * tokenPrice;
+                      maxBorrowable = Math.min(maxBorrowable, remainingBorrowCapUSD);
+                    }
                     return maxBorrowable.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
                   })()}
                 </span>

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -12,6 +12,7 @@ import { useWallet } from "@txnlab/use-wallet-react";
 import STokenCard from "./STokenCard";
 import { ArrowRightLeft } from "lucide-react";
 import { getTokenConfig, getAllTokensWithDisplayInfo } from "@/config";
+import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
@@ -249,20 +250,26 @@ const MarketCardView = ({
                 <DorkFiButton
                   variant="secondary"
                   onClick={e => { e.stopPropagation(); onDepositClick(market.asset, market.marketInfo?.poolId || market.poolId); }}
-                  disabled={
-                    (Number(market.supplyCap ?? 0) > 0 &&
-                     Number(market.totalSupply ?? 0) >= Number(market.supplyCap ?? 0))
-                  }
+                  disabled={isAtDepositCap(Number(market.totalSupply ?? 0), Number(market.supplyCap ?? 0))}
                   title={
-                    (Number(market.supplyCap ?? 0) > 0 &&
-                     Number(market.totalSupply ?? 0) >= Number(market.supplyCap ?? 0))
+                    isAtDepositCap(Number(market.totalSupply ?? 0), Number(market.supplyCap ?? 0))
                       ? "Market at deposit cap"
                       : undefined
                   }
                 >Deposit</DorkFiButton>
                 <DorkFiButton
                   variant="borrow-outline"
-                  onClick={e => { e.stopPropagation(); onBorrowClick(market.asset, market.marketInfo?.poolId || market.poolId); }}
+                  onClick={e => {
+                    e.stopPropagation();
+                    if (isAtBorrowCap(Number(market.totalBorrow ?? 0), Number(market.borrowCap ?? 0))) return;
+                    onBorrowClick(market.asset, market.marketInfo?.poolId || market.poolId);
+                  }}
+                  disabled={isAtBorrowCap(Number(market.totalBorrow ?? 0), Number(market.borrowCap ?? 0))}
+                  title={
+                    isAtBorrowCap(Number(market.totalBorrow ?? 0), Number(market.borrowCap ?? 0))
+                      ? "Market at borrow cap"
+                      : undefined
+                  }
                 >Borrow</DorkFiButton>
               </div>
               {(() => {

--- a/src/components/markets/MarketsDesktopTable.tsx
+++ b/src/components/markets/MarketsDesktopTable.tsx
@@ -21,6 +21,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { useNetwork } from "@/contexts/NetworkContext";
 import { useWallet } from "@txnlab/use-wallet-react";
 import { getTokenConfig, getAllTokensWithDisplayInfo, getNetworkConfig } from "@/config";
+import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
@@ -601,8 +602,10 @@ const MarketsDesktopTable = ({
             const finalPoolId = market.poolId || token?.poolId || poolId || market.marketInfo?.poolId;
             const totalSupply = Number(market.totalSupply ?? 0);
             const supplyCap = Number(market.supplyCap ?? 0);
-            const isAtDepositCap =
-              supplyCap > 0 && totalSupply >= supplyCap;
+            const depositCapReached = isAtDepositCap(totalSupply, supplyCap);
+            const totalBorrow = Number(market.totalBorrow ?? 0);
+            const borrowCap = Number(market.borrowCap ?? 0);
+            const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
             return (
               <MarketsTableActions
@@ -621,7 +624,8 @@ const MarketsDesktopTable = ({
                 migrationBalance={migrationBalance || undefined}
                 isLoadingBalance={isLoadingBalance}
                 isSToken={market.isSToken}
-                depositDisabled={isAtDepositCap}
+                depositDisabled={depositCapReached}
+                borrowDisabled={borrowCapReached}
               />
             );
           })()}
@@ -1015,8 +1019,10 @@ const MarketsDesktopTable = ({
                       const finalPoolId = mainMarket.poolId || token?.poolId || poolId || mainMarket.marketInfo?.poolId;
                       const totalSupply = Number(mainMarket.totalSupply ?? 0);
                       const supplyCap = Number(mainMarket.supplyCap ?? 0);
-                      const isAtDepositCap =
-                        supplyCap > 0 && totalSupply >= supplyCap;
+                      const depositCapReached = isAtDepositCap(totalSupply, supplyCap);
+                      const totalBorrow = Number(mainMarket.totalBorrow ?? 0);
+                      const borrowCap = Number(mainMarket.borrowCap ?? 0);
+                      const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
                       return (
                         <MarketsTableActions
@@ -1035,7 +1041,8 @@ const MarketsDesktopTable = ({
                           migrationBalance={migrationBalance || undefined}
                           isLoadingBalance={isLoadingBalance}
                           isSToken={mainMarket.isSToken}
-                          depositDisabled={isAtDepositCap}
+                          depositDisabled={depositCapReached}
+                          borrowDisabled={borrowCapReached}
                         />
                       );
                     })()}

--- a/src/components/markets/MarketsTableActions.tsx
+++ b/src/components/markets/MarketsTableActions.tsx
@@ -14,19 +14,26 @@ interface MarketsTableActionsProps {
   isSToken?: boolean;
   /** When true, deposit is disabled (e.g. market at or over deposit cap). */
   depositDisabled?: boolean;
+  /** When true, borrow is disabled (e.g. market at or over borrow cap). */
+  borrowDisabled?: boolean;
 }
 
-const MarketsTableActions = ({ 
+/**
+ * Deposit / Borrow (or Mint for sToken) actions.
+ * For sToken the second button is "Mint"; it is not disabled by borrowDisabled by design (mint is independent of borrow cap).
+ */
+const MarketsTableActions = ({
   asset,
   poolId,
-  onDepositClick, 
-  onBorrowClick, 
+  onDepositClick,
+  onBorrowClick,
   onMintClick,
   onMigrateClick,
   migrationBalance,
   isLoadingBalance = false,
   isSToken = false,
   depositDisabled = false,
+  borrowDisabled = false,
 }: MarketsTableActionsProps) => {
   return (
     <div className="flex flex-col space-y-2">
@@ -50,10 +57,12 @@ const MarketsTableActions = ({
             e.stopPropagation();
             if (isSToken && onMintClick) {
               onMintClick(asset, poolId);
-            } else {
+            } else if (!borrowDisabled) {
               onBorrowClick(asset, poolId);
             }
           }}
+          disabled={!isSToken && borrowDisabled}
+          title={!isSToken && borrowDisabled ? "Market at borrow cap" : undefined}
           className={isSToken ? "min-w-[140px] flex-1" : ""}
         >
           {isSToken ? "Mint" : "Borrow"}

--- a/src/components/markets/MarketsTabletTable.tsx
+++ b/src/components/markets/MarketsTabletTable.tsx
@@ -11,6 +11,7 @@ import STokenTabletRow from "./STokenTabletRow";
 import { useNetwork } from "@/contexts/NetworkContext";
 import { useWallet } from "@txnlab/use-wallet-react";
 import { getTokenConfig, getAllTokensWithDisplayInfo, getNetworkConfig } from "@/config";
+import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
@@ -745,8 +746,10 @@ const MarketsTabletTable = ({
                       const migrationBalance = migrationBalances[mainMarket.asset];
                       const totalSupply = Number(mainMarket.totalSupply ?? 0);
                       const supplyCap = Number(mainMarket.supplyCap ?? 0);
-                      const isAtDepositCap =
-                        supplyCap > 0 && totalSupply >= supplyCap;
+                      const depositCapReached = isAtDepositCap(totalSupply, supplyCap);
+                      const totalBorrow = Number(mainMarket.totalBorrow ?? 0);
+                      const borrowCap = Number(mainMarket.borrowCap ?? 0);
+                      const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
                       return (
                         <MarketsTableActions
@@ -765,7 +768,8 @@ const MarketsTabletTable = ({
                           migrationBalance={migrationBalance || undefined}
                           isLoadingBalance={isLoadingBalance}
                           isSToken={mainMarket.isSToken}
-                          depositDisabled={isAtDepositCap}
+                          depositDisabled={depositCapReached}
+                          borrowDisabled={borrowCapReached}
                         />
                       );
                     })()}

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -27,6 +27,8 @@ interface PortfolioTableMobileCardProps {
   type?: "deposit" | "borrow";
   /** When true, deposit button is disabled (e.g. market at or over deposit cap). */
   depositDisabled?: boolean;
+  /** When true, borrow button is disabled (e.g. market at or over borrow cap). */
+  borrowDisabled?: boolean;
 }
 
 const PortfolioTableMobileCard = ({
@@ -50,6 +52,7 @@ const PortfolioTableMobileCard = ({
   isRefreshing,
   type = "deposit",
   depositDisabled = false,
+  borrowDisabled = false,
 }: PortfolioTableMobileCardProps) => {
   const { currentNetwork } = useNetwork();
   const tokenConfigRaw = getTokenConfig(currentNetwork, asset);
@@ -325,11 +328,13 @@ const PortfolioTableMobileCard = ({
               size="sm"
               onClick={onDepositClick}
               className="flex-1 min-w-0"
-              disabled={isDeposit ? depositDisabled : false}
+              disabled={isDeposit ? depositDisabled : borrowDisabled}
               title={
                 isDeposit && depositDisabled
                   ? "Market at deposit cap"
-                  : undefined
+                  : !isDeposit && borrowDisabled
+                    ? "Market at borrow cap"
+                    : undefined
               }
             >
               <Plus className="w-4 h-4 mr-1" />

--- a/src/constants/lendingCaps.ts
+++ b/src/constants/lendingCaps.ts
@@ -1,0 +1,22 @@
+/**
+ * UI threshold for deposit/borrow caps. When utilization reaches this fraction of the cap,
+ * the market is shown as "at capacity" and deposit/borrow actions are disabled.
+ * 0.95 = 95%.
+ */
+export const CAP_UTILIZATION_THRESHOLD = 0.95;
+
+/**
+ * True when market supply is at or over the deposit cap (≥ threshold of max).
+ * Both args must be in the same units (e.g. human-readable token amount).
+ */
+export function isAtDepositCap(totalSupply: number, maxTotalDeposits: number): boolean {
+  return maxTotalDeposits > 0 && totalSupply >= maxTotalDeposits * CAP_UTILIZATION_THRESHOLD;
+}
+
+/**
+ * True when market borrows are at or over the borrow cap (≥ threshold of max).
+ * Both args must be in the same units (e.g. human-readable token amount).
+ */
+export function isAtBorrowCap(totalBorrow: number, maxTotalBorrows: number): boolean {
+  return maxTotalBorrows > 0 && totalBorrow >= maxTotalBorrows * CAP_UTILIZATION_THRESHOLD;
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -23,6 +23,7 @@ export interface OnDemandMarketData {
   walletBalance: number;
   supplyCap: number;
   supplyCapUSD: number;
+  borrowCap: number;
   maxLTV: number;
   liquidationThreshold: number;
   liquidationPenalty: number;
@@ -137,6 +138,7 @@ export const useOnDemandMarketData = ({
         walletBalance: 0,
         supplyCap: 0,
         supplyCapUSD: 0,
+        borrowCap: 0,
         maxLTV: 0,
         liquidationThreshold: 0,
         liquidationPenalty: 0,
@@ -252,6 +254,7 @@ export const useOnDemandMarketData = ({
             const totalSupplyAmount = parseFloat(marketInfo.totalDeposits) || 0;
             const totalBorrowAmount = parseFloat(marketInfo.totalBorrows) || 0;
             const supplyCapAmount = parseFloat(marketInfo.maxTotalDeposits) || 0;
+            const borrowCapAmount = parseFloat(marketInfo.maxTotalBorrows) || 0;
 
             console.log(`USD calculations for ${token.symbol}:`, {
               tokenPrice,
@@ -304,6 +307,7 @@ export const useOnDemandMarketData = ({
               walletBalance: 0, // This would need wallet integration
               supplyCap: supplyCapAmount,
               supplyCapUSD: supplyCapAmount * tokenPrice,
+              borrowCap: borrowCapAmount,
               maxLTV: marketInfo.collateralFactor * 100,
               liquidationThreshold: marketInfo.liquidationThreshold * 100,
               liquidationPenalty: marketInfo.liquidationBonus * 100,

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -264,6 +264,23 @@ function totalDepositsIncludingInterest(
     .toFixed(4);
 }
 
+/**
+ * Market total borrows including accrued interest, for borrow cap validation.
+ * Formula: (totalScaledBorrows * borrowIndex) / SCALE / 10^decimals.
+ * Use this so cap checks match contract semantics (principal + interest). See issue #248.
+ */
+function totalBorrowsIncludingInterest(
+  totalScaledBorrows: string,
+  borrowIndex: string,
+  decimals: number
+): string {
+  return new BigNumber(totalScaledBorrows)
+    .times(borrowIndex)
+    .div(DEPOSIT_SCALE)
+    .div(new BigNumber(10).pow(decimals))
+    .toFixed(4);
+}
+
 export const enhanceAVMMarketInfo = (
   market: any,
   token?: TokenConfig
@@ -303,7 +320,12 @@ export const enhanceAVMMarketInfo = (
     decimals
   );
 
-  const totalBorrows = formatDeposit(market.totalScaledBorrows.toString());
+  // Include accrued interest so borrow cap validation matches contract (see issue #248)
+  const totalBorrows = totalBorrowsIncludingInterest(
+    market.totalScaledBorrows.toString(),
+    market.borrowIndex.toString(),
+    decimals
+  );
 
   // For b market (poolId 47139781), use 2% (200 basis points) as base borrow rate
   // Otherwise use the borrow rate from the contract
@@ -650,7 +672,12 @@ export const fetchMarketInfo = async (
         tokenDecimals
       );
 
-      const totalBorrows = formatDeposit(market.totalScaledBorrows);
+      // Include accrued interest so borrow cap validation matches contract (see issue #248)
+      const totalBorrows = totalBorrowsIncludingInterest(
+        market.totalScaledBorrows.toString(),
+        market.borrowIndex.toString(),
+        tokenDecimals
+      );
 
       // For b market (poolId 47139781), use 2% (200 basis points) as base borrow rate
       // Otherwise use the borrow rate from the contract


### PR DESCRIPTION
## Summary
Add deposit and borrow cap indicators and enforce caps in supply/borrow flows.

## Changes
- **lendingCaps.ts**: `CAP_UTILIZATION_THRESHOLD` (95%) and `isAtDepositCap` / `isAtBorrowCap` helpers
- Disable supply/borrow and show indicators when market is at deposit or borrow cap
- **SupplyBorrowModal**: cap max borrow and available-to-borrow by market borrow cap
- **SupplyBorrowStats**: "At capacity" / "% available" via `isAtDepositCap`; cap max borrowable USD by borrow cap
- Wire cap checks across MarketDetailModal, MarketCardView, MarketsTable, Portfolio, and table views
- Pass `maxTotalBorrows` through market data and useOnDemandMarketData; extend lendingService
- Use `depositCapReached` / `borrowCapReached` locals in Portfolio to avoid shadowing imported helpers

Made with [Cursor](https://cursor.com)