### PR TITLE
feat(ui): market modal polish, pricing accuracy, mobile responsiveness

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -64,29 +64,77 @@ import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 
 const MAX_CLAIMS_PER_TX = 3;
 
+/** Map on-demand market row → PremiumMarketModal `MarketData` (USD fields in whole dollars like the markets table). */
 function normalizeMarketData(md: Record<string, unknown>) {
+  const totalSupplyUSD = Number(md.totalSupplyUSD ?? 0);
+  const totalBorrowUSD = Number(md.totalBorrowUSD ?? 0);
+  const supplyUsdWhole = Math.max(0, Math.round(totalSupplyUSD / 1_000_000));
+  const borrowUsdWhole = Math.max(0, Math.round(totalBorrowUSD / 1_000_000));
+  const availableUsdWhole = Math.max(0, supplyUsdWhole - borrowUsdWhole);
+
+  const mi = md.marketInfo as Record<string, unknown> | undefined;
+  /** USD per 1 whole token — same basis as `useOnDemandMarketData` TVL (micro-USD / human supply). */
+  const supplyTokensHuman = Number(md.totalSupply ?? 0);
+  let price = 1;
+  if (
+    supplyTokensHuman > 0 &&
+    Number.isFinite(totalSupplyUSD) &&
+    totalSupplyUSD > 0
+  ) {
+    price = totalSupplyUSD / 1_000_000 / supplyTokensHuman;
+  } else if (mi?.price != null) {
+    const tokenPrice = parseFloat(String(mi.price)) || 0;
+    const decimals = Number(mi.decimals ?? 6);
+    if (tokenPrice > 0 && Number.isFinite(decimals)) {
+      price =
+        (tokenPrice * Math.pow(10, decimals + 6)) / Math.pow(10, 12);
+    }
+  }
+
+  const utilization = Number(md.utilization ?? 0);
+
   return {
-    icon: md.icon || "",
-    name: md.asset ?? md.name ?? "Unknown",
-    symbol: md.asset ?? md.symbol ?? "???",
-    price: md.price ?? 1,
-    priceChange24h: md.priceChange24h ?? 0,
-    priceHistory: md.priceHistory ?? [],
-    totalSupply: md.totalSupply ?? 0,
-    totalBorrow: md.totalBorrow ?? 0,
-    availableLiquidity: md.availableLiquidity ?? 0,
-    utilization: md.utilization ?? 0,
-    supplyAPY: md.supplyAPY ?? 0,
-    borrowAPY: md.borrowAPY ?? 0,
-    maxLTV: md.maxLTV ?? 0,
-    liquidationThreshold: md.liquidationThreshold ?? 0,
-    liquidationBonus: md.liquidationBonus ?? 0,
-    reserveFactor: md.reserveFactor ?? 0,
-    supplyCap: md.supplyCap ?? 0,
-    borrowCap: md.borrowCap ?? 0,
-    oracleStatus: md.oracleStatus ?? "live",
-    auditProvider: md.auditProvider ?? "N/A",
+    icon: String(md.icon ?? ""),
+    name: String(md.asset ?? md.name ?? "Unknown"),
+    symbol: String(md.asset ?? md.symbol ?? "???"),
+    price,
+    priceChange24h: Number(md.priceChange24h ?? 0),
+    priceHistory:
+      (md.priceHistory as { time: number; price: number }[]) ?? [],
+    totalSupply: supplyUsdWhole,
+    totalBorrow: borrowUsdWhole,
+    availableLiquidity: availableUsdWhole,
+    utilization,
+    supplyAPY: Number(md.supplyAPY ?? 0),
+    borrowAPY: Number(md.borrowAPY ?? 0),
+    maxLTV: Number(md.maxLTV ?? md.collateralFactor ?? 0),
+    liquidationThreshold: Number(md.liquidationThreshold ?? 0),
+    liquidationBonus: Number(
+      md.liquidationPenalty ?? md.liquidationBonus ?? 0
+    ),
+    reserveFactor: Number(md.reserveFactor ?? 0),
+    supplyCap: Number(md.supplyCap ?? 0),
+    borrowCap: Number(md.borrowCap ?? 0),
+    oracleStatus:
+      md.oracleStatus === "stale"
+        ? ("stale" as const)
+        : ("live" as const),
+    auditProvider: String(md.auditProvider ?? "N/A"),
   };
+}
+
+function poolIdFromMarketRow(market: Record<string, unknown>): string | undefined {
+  const direct = market.poolId;
+  if (direct != null && String(direct) !== "") return String(direct);
+  const mi = market.marketInfo as { poolId?: string } | undefined;
+  if (mi?.poolId != null && String(mi.poolId) !== "") return String(mi.poolId);
+  return undefined;
+}
+
+function networkIdToChainId(
+  networkId: string
+): "voi" | "algorand" {
+  return networkId.toLowerCase().includes("algorand") ? "algorand" : "voi";
 }
 
 const MarketsTable = () => {
@@ -95,9 +143,14 @@ const MarketsTable = () => {
   const [sortField, setSortField] = useState<SortField>("default");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [marketFilter, setMarketFilter] = useState<MarketFilter>("all");
-  const [depositModal, setDepositModal] = useState({
+  const [depositModal, setDepositModal] = useState<{
+    isOpen: boolean;
+    asset: string | null;
+    poolId?: string;
+  }>({
     isOpen: false,
     asset: null,
+    poolId: undefined,
   });
   const [withdrawModal, setWithdrawModal] = useState({
     isOpen: false,
@@ -112,9 +165,15 @@ const MarketsTable = () => {
     asset: string | null;
     poolId?: string;
   }>({ isOpen: false, asset: null });
-  const [detailModal, setDetailModal] = useState({
+  const [detailModal, setDetailModal] = useState<{
+    isOpen: boolean;
+    asset: string | null;
+    poolId?: string;
+    marketData: Record<string, unknown> | null;
+  }>({
     isOpen: false,
     asset: null,
+    poolId: undefined,
     marketData: null,
   });
   const [walletBalances, setWalletBalances] = useState<
@@ -883,17 +942,34 @@ const MarketsTable = () => {
     }
   };
 
+  const openMarketDetailModal = (market: Record<string, unknown>) => {
+    const asset = typeof market.asset === "string" ? market.asset : null;
+    if (!asset) return;
+    const poolId = poolIdFromMarketRow(market);
+    setDetailModal({
+      isOpen: true,
+      asset,
+      poolId,
+      marketData: market,
+    });
+  };
+
   const handleRowClick = (market: Record<string, unknown>) => {
-    //setDetailModal({ isOpen: true, asset: market.asset, marketData: market });
+    openMarketDetailModal(market);
   };
 
   const handleInfoClick = (e: React.MouseEvent, market: Record<string, unknown>) => {
     e.stopPropagation();
-    setDetailModal({ isOpen: true, asset: market.asset, marketData: market });
+    openMarketDetailModal(market);
   };
 
   const handleCloseDetailModal = () => {
-    setDetailModal({ isOpen: false, asset: null, marketData: null });
+    setDetailModal({
+      isOpen: false,
+      asset: null,
+      poolId: undefined,
+      marketData: null,
+    });
   };
 
   // Load all markets when component mounts
@@ -2358,11 +2434,10 @@ const MarketsTable = () => {
             isOpen={detailModal.isOpen}
             onClose={handleCloseDetailModal}
             asset={detailModal.asset}
-            marketData={
-              detailModal.marketData
-                ? normalizeMarketData(detailModal.marketData)
-                : undefined
-            }
+            chainId={networkIdToChainId(currentNetwork)}
+            networkId={currentNetwork}
+            rawMarket={detailModal.marketData}
+            marketData={normalizeMarketData(detailModal.marketData)}
             userPosition={{
               supplied: 100,
               borrowed: 0,
@@ -2371,24 +2446,28 @@ const MarketsTable = () => {
               healthFactor: 2.5,
               earnings: 5.25,
             }}
-            onDeposit={() => handleDepositClick(detailModal.asset!)}
+            onDeposit={() =>
+              handleDepositClick(detailModal.asset!, detailModal.poolId)
+            }
             onWithdraw={() => handleWithdrawClick(detailModal.asset!)}
-            onBorrow={() => handleBorrowClick(detailModal.asset!)}
-            onRepay={() => { }}
+            onBorrow={() =>
+              handleBorrowClick(detailModal.asset!, detailModal.poolId)
+            }
+            onRepay={() => {}}
           />
         )}
 
         {/* Deposit Modal */}
         {depositModal.isOpen &&
           depositModal.asset &&
-          getAssetData(depositModal.asset) && (
+          getAssetData(depositModal.asset, depositModal.poolId) && (
             <SupplyBorrowModal
               isOpen={depositModal.isOpen}
               onClose={handleCloseDepositModal}
               asset={depositModal.asset}
               poolId={depositModal.poolId}
               mode="deposit"
-              assetData={getAssetData(depositModal.asset)}
+              assetData={getAssetData(depositModal.asset, depositModal.poolId)!}
               walletBalance={walletBalances[depositModal.asset]?.balance || 0}
               walletBalanceUSD={
                 walletBalances[depositModal.asset]?.balanceUSD || 0

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -4410,23 +4410,40 @@ const Portfolio = () => {
                       .filter((item) => item.value > 0)
                       .sort((a, b) => b.value - a.value);
                   } else {
-                    // Show allocation by asset for selected network
+                    // Show allocation by asset (and A/B pool) for selected network
                     const filteredDeposits = deposits.filter((deposit) => {
-                      // This is a simplified filter - in a real scenario, you'd match by network
-                      return true; // For now, show all deposits
+                      const depositNetwork = (deposit as ItemWithNetwork).network;
+                      if (!depositNetwork) return true;
+                      const normalized = depositNetwork.toLowerCase();
+                      if (selectedNetworkFilter === "algorand") {
+                        return normalized.includes("algorand");
+                      }
+                      if (selectedNetworkFilter === "voi") {
+                        return normalized.includes("voi");
+                      }
+                      return true;
                     });
 
                     const assetMap = new Map<string, number>();
                     filteredDeposits.forEach((deposit) => {
-                      const current = assetMap.get(deposit.asset) || 0;
-                      assetMap.set(deposit.asset, current + deposit.value);
+                      const depositNetworkForLabel =
+                        (deposit as ItemWithNetwork).network || currentNetwork;
+                      const label = getMarketLabel(
+                        depositNetworkForLabel,
+                        deposit.poolId
+                      );
+                      const displayName = label
+                        ? `${deposit.asset} · ${label}`
+                        : deposit.asset;
+                      const current = assetMap.get(displayName) || 0;
+                      assetMap.set(displayName, current + deposit.value);
                     });
 
                     return Array.from(assetMap.entries())
-                      .map(([asset, value]) => ({
-                        name: asset,
+                      .map(([name, value]) => ({
+                        name,
                         value,
-                        asset,
+                        asset: name,
                       }))
                       .filter((item) => item.value > 0)
                       .sort((a, b) => b.value - a.value);
@@ -6354,11 +6371,25 @@ const Portfolio = () => {
                                 >
                                   <TableCell className="min-w-0">
                                     <div className="flex flex-col items-center gap-1 min-w-0">
-                                      <img
-                                        src={deposit.icon}
-                                        alt={deposit.asset}
-                                        className="w-8 h-8 rounded-full shrink-0"
-                                      />
+                                      <div className="relative shrink-0">
+                                        <img
+                                          src={deposit.icon}
+                                          alt={deposit.asset}
+                                          className="w-8 h-8 rounded-full shrink-0"
+                                        />
+                                        {depositMarketLabel && (
+                                          <div
+                                            className={`absolute -top-1 -right-1 w-4 h-4 rounded-full ${depositMarketLabel === "A"
+                                              ? "bg-blue-500 dark:bg-blue-600"
+                                              : "bg-purple-500 dark:bg-purple-600"
+                                              } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+                                          >
+                                            <span className="text-[9px] font-bold text-white leading-none">
+                                              {depositMarketLabel}
+                                            </span>
+                                          </div>
+                                        )}
+                                      </div>
                                       <span className="font-medium truncate text-center">
                                         {deposit.asset}
                                       </span>
@@ -8060,14 +8091,28 @@ const Portfolio = () => {
                                   key={index}
                                   className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-teal-400 hover:shadow-[0_0_16px_4px_rgba(13,255,190,0.15)] hover:z-20"
                                 >
-                                  <TableCell>
-                                    <div className="flex items-center gap-2">
-                                      <img
-                                        src={borrow.icon}
-                                        alt={borrow.asset}
-                                        className="w-6 h-6 rounded-full"
-                                      />
-                                      <span className="font-medium">
+                                  <TableCell className="min-w-0">
+                                    <div className="flex flex-col items-center gap-1 min-w-0">
+                                      <div className="relative shrink-0">
+                                        <img
+                                          src={borrow.icon}
+                                          alt={borrow.asset}
+                                          className="w-8 h-8 rounded-full shrink-0"
+                                        />
+                                        {borrowMarketLabel && (
+                                          <div
+                                            className={`absolute -top-1 -right-1 w-4 h-4 rounded-full ${borrowMarketLabel === "A"
+                                              ? "bg-blue-500 dark:bg-blue-600"
+                                              : "bg-purple-500 dark:bg-purple-600"
+                                              } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+                                          >
+                                            <span className="text-[9px] font-bold text-white leading-none">
+                                              {borrowMarketLabel}
+                                            </span>
+                                          </div>
+                                        )}
+                                      </div>
+                                      <span className="font-medium truncate text-center">
                                         {borrow.asset}
                                       </span>
                                     </div>

--- a/src/components/liquidation/AccountOverview.tsx
+++ b/src/components/liquidation/AccountOverview.tsx
@@ -133,6 +133,7 @@ export default function AccountOverview({
     .filter((asset) => asset.depositBalance > 0)
     .map((asset) => ({
       symbol: asset.symbol,
+      poolId: asset.poolId,
       amount: asset.depositBalance,
       valueUSD: asset.depositValueUSD,
       collateralFactor: asset.collateralFactor,
@@ -143,6 +144,7 @@ export default function AccountOverview({
     .filter((asset) => asset.borrowBalance > 0)
     .map((asset) => ({
       symbol: asset.symbol,
+      poolId: asset.poolId,
       amount: asset.borrowBalance,
       valueUSD: asset.borrowValueUSD,
       collateralFactor: asset.collateralFactor,
@@ -573,6 +575,7 @@ export default function AccountOverview({
                 title="Collateral Assets"
                 assets={collateralAssets}
                 colorScheme="collateral"
+                networkId={currentNetwork}
                 totalBorrowed={totalBorrowValue}
                 accountHealthFactor={realHealthFactor}
                 weightedCollateralValue={weightedCollateralValue}
@@ -583,6 +586,7 @@ export default function AccountOverview({
                 title="Borrowed Assets"
                 assets={borrowedAssets}
                 colorScheme="borrowed"
+                networkId={currentNetwork}
                 totalBorrowed={totalBorrowValue}
                 accountHealthFactor={realHealthFactor}
                 weightedCollateralValue={weightedCollateralValue}

--- a/src/components/liquidation/AssetList.tsx
+++ b/src/components/liquidation/AssetList.tsx
@@ -2,8 +2,9 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { AlertTriangle, Shield } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { getMarketLabel, type NetworkId } from '@/config';
 
 interface Asset {
   symbol: string;
@@ -11,12 +12,15 @@ interface Asset {
   valueUSD: number;
   collateralFactor?: number;
   liquidationThreshold?: number;
+  poolId?: string;
 }
 
 interface AssetListProps {
   title: string;
   assets: Asset[];
   colorScheme: 'collateral' | 'borrowed';
+  /** Current chain/network id for resolving A/B pool labels */
+  networkId?: NetworkId | string | null;
   totalBorrowed?: number; // For calculating LTV per asset
   accountHealthFactor?: number; // Overall account health factor
   weightedCollateralValue?: number; // Weighted collateral value for proper calculations
@@ -26,6 +30,7 @@ export default function AssetList({
   title, 
   assets, 
   colorScheme, 
+  networkId,
   totalBorrowed = 0, 
   accountHealthFactor = 3.0,
   weightedCollateralValue = 0 
@@ -63,6 +68,7 @@ export default function AssetList({
         <div className="space-y-2">
           {assets.map((asset, index) => {
             const liquidatable = isAssetLiquidatable(asset);
+            const marketLabel = getMarketLabel(networkId, asset.poolId);
             return (
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
@@ -76,8 +82,21 @@ export default function AssetList({
                         <span className={`text-xs font-bold ${colors.text}`}>
                           {asset.symbol.substring(0, 2)}
                         </span>
+                        {marketLabel && (
+                          <div
+                            className={`absolute -bottom-0.5 -left-0.5 w-4 h-4 rounded-full ${
+                              marketLabel === "A"
+                                ? "bg-blue-500 dark:bg-blue-600"
+                                : "bg-purple-500 dark:bg-purple-600"
+                            } border border-white dark:border-slate-800 flex items-center justify-center z-[1]`}
+                          >
+                            <span className="text-[9px] font-bold text-white leading-none">
+                              {marketLabel}
+                            </span>
+                          </div>
+                        )}
                         {liquidatable && (
-                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full flex items-center justify-center">
+                          <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full flex items-center justify-center z-[1]">
                             <AlertTriangle className="w-2 h-2 text-white" />
                           </div>
                         )}

--- a/src/components/market-modal/AdvancedDetails.tsx
+++ b/src/components/market-modal/AdvancedDetails.tsx
@@ -2,23 +2,53 @@ import React, { useState } from 'react';
 import { MarketData } from './types';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 
-const InterestRateCurve = ({baseRate, slope}: { baseRate:number, slope:number }) => (
-  <svg viewBox="0 0 300 80" width="100%" height="70" className="mb-2">
-    <line x1="24" y1="5" x2="24" y2="70" stroke="#2c3752" strokeWidth="1.5" />
-    <line x1="24" y1="70" x2="290" y2="70" stroke="#2c3752" strokeWidth="1.5" />
-    <polyline fill="none" stroke="#5ef8bb" strokeWidth="2" points="24,62 157,39 290,15" />
-    <text x="8" y="70" fill="#708bbd" fontSize="10">0%</text>
-    <text x="6" y="62" fill="#708bbd" fontSize="10">4%</text>
-    <text x="3" y="39" fill="#708bbd" fontSize="10">8%</text>
-    <text x="3" y="16" fill="#708bbd" fontSize="10">16%</text>
-    <text x="24" y="78" fill="#708bbd" fontSize="10">0%</text>
-    <text x="72" y="78" fill="#708bbd" fontSize="10">16%</text>
-    <text x="120" y="78" fill="#708bbd" fontSize="10">32%</text>
-    <text x="170" y="78" fill="#708bbd" fontSize="10">56%</text>
-    <text x="220" y="78" fill="#708bbd" fontSize="10">80%</text>
-    <text x="275" y="78" fill="#708bbd" fontSize="10">100%</text>
-  </svg>
-);
+const InterestRateCurve = ({ baseRate: _baseRate, slope: _slope }: { baseRate: number; slope: number }) => {
+  void _baseRate;
+  void _slope;
+  return (
+    <svg viewBox="0 0 300 80" width="100%" height="70" className="mb-2 text-muted-foreground">
+      <line x1="24" y1="5" x2="24" y2="70" stroke="currentColor" strokeWidth="1.5" className="opacity-40" />
+      <line x1="24" y1="70" x2="290" y2="70" stroke="currentColor" strokeWidth="1.5" className="opacity-40" />
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="text-ocean-teal"
+        points="24,62 157,39 290,15"
+      />
+      <text x="8" y="70" fill="currentColor" fontSize="10" className="opacity-70">
+        0%
+      </text>
+      <text x="6" y="62" fill="currentColor" fontSize="10" className="opacity-70">
+        4%
+      </text>
+      <text x="3" y="39" fill="currentColor" fontSize="10" className="opacity-70">
+        8%
+      </text>
+      <text x="3" y="16" fill="currentColor" fontSize="10" className="opacity-70">
+        16%
+      </text>
+      <text x="24" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        0%
+      </text>
+      <text x="72" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        16%
+      </text>
+      <text x="120" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        32%
+      </text>
+      <text x="170" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        56%
+      </text>
+      <text x="220" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        80%
+      </text>
+      <text x="275" y="78" fill="currentColor" fontSize="10" className="opacity-70">
+        100%
+      </text>
+    </svg>
+  );
+};
 
 export const AdvancedDetails = ({ marketData }: { marketData: MarketData }) => {
   const [expanded, setExpanded] = useState(true);
@@ -30,58 +60,130 @@ export const AdvancedDetails = ({ marketData }: { marketData: MarketData }) => {
   const borrowCap = marketData.borrowCap;
   const totalBorrow = marketData.totalBorrow;
 
+  const panelClass =
+    'p-4 rounded-lg border border-border bg-muted/30 dark:bg-muted/20 mb-4';
+
   return (
     <Card className="p-0 border-0 bg-transparent shadow-none mt-5 mb-3">
-      <CardHeader className="pb-4 px-4 cursor-pointer select-none flex flex-row items-center justify-between" onClick={() => setExpanded(e => !e)}>
-        <CardTitle className="flex items-center gap-2 text-white text-lg font-semibold">
-          <svg className="w-6 h-6 text-cyan-400" fill="none" viewBox="0 0 24 24"><path d="M4 12h16M12 4v16" stroke="#67e8f9" strokeWidth="2" strokeLinecap="round"/></svg>
-          Advanced Details
+      <CardHeader
+        className="pb-4 px-4 cursor-pointer select-none flex flex-row items-center justify-between"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <CardTitle className="flex items-center gap-2 text-foreground text-lg font-semibold">
+          <svg
+            className="w-6 h-6 text-ocean-teal shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <path
+              d="M4 12h16M12 4v16"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          Advanced details
         </CardTitle>
-        <svg className={`w-6 h-6 transition-transform duration-300 text-blue-100 ml-3 ${expanded ? '' : '-rotate-90'}`} fill="none" viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>
+        <svg
+          className={`w-6 h-6 transition-transform duration-300 text-muted-foreground ml-3 shrink-0 ${expanded ? '' : '-rotate-90'}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </CardHeader>
       {expanded && (
         <CardContent className="space-y-6 px-4 py-0">
-          <div className="p-4 bg-[#111b32] rounded mb-4">
-            <div className="flex items-center mb-2 text-base text-white font-semibold"><svg className="w-5 h-5 mr-2 text-teal-400" fill="none" viewBox="0 0 24 24"><polyline points="4 14 10 10 15.5 13.5 21 8" stroke="#5ef8bb" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>Interest Rate Curve</div>
+          <div className={panelClass}>
+            <div className="flex items-center mb-2 text-base text-foreground font-semibold">
+              <svg
+                className="w-5 h-5 mr-2 text-ocean-teal shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden
+              >
+                <polyline
+                  points="4 14 10 10 15.5 13.5 21 8"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              Interest rate curve
+            </div>
             <InterestRateCurve baseRate={baseRate} slope={slope} />
-            <div className="text-xs text-blue-300/60 mt-1">Utilization: 0%</div>
+            <div className="text-xs text-muted-foreground mt-1">Utilization: 0%</div>
           </div>
-          <div className="p-4 bg-[#111b32] rounded mb-4">
-            <div className="mb-2 font-semibold text-base text-white">Rate Parameters</div>
+          <div className={panelClass}>
+            <div className="mb-2 font-semibold text-base text-foreground">Rate parameters</div>
             <div className="grid grid-cols-2 gap-x-6 gap-y-3 mb-4">
               <div className="flex flex-col items-start">
-                <span className="text-xs text-muted-foreground">Base Rate</span>
-                <span className="font-semibold text-lg">2.00%</span>
+                <span className="text-xs text-muted-foreground">Base rate</span>
+                <span className="font-semibold text-lg text-foreground">2.00%</span>
               </div>
               <div className="flex flex-col items-start">
                 <span className="text-xs text-muted-foreground">Slope</span>
-                <span className="font-semibold text-lg">13.00%</span>
+                <span className="font-semibold text-lg text-foreground">13.00%</span>
               </div>
               <div className="flex flex-col items-start">
-                <span className="text-xs text-muted-foreground">Reserve Factor</span>
-                <span className="font-semibold text-lg">{reserveFactor}%</span>
+                <span className="text-xs text-muted-foreground">Reserve factor</span>
+                <span className="font-semibold text-lg text-foreground">{reserveFactor}%</span>
               </div>
             </div>
           </div>
-          <div className="p-4 bg-[#111b32] rounded">
-            <div className="mb-2 flex items-center text-base font-semibold text-white">
-              <svg className="h-5 w-5 mr-2 text-green-300" fill="none" viewBox="0 0 24 24"><rect width="24" height="24" fill="none"/><path d="M3 12v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7m-8-4v11" stroke="#33ff90" strokeWidth="2"/></svg>
-              Market Caps
+          <div className={`${panelClass} mb-0`}>
+            <div className="mb-2 flex items-center text-base font-semibold text-foreground">
+              <svg
+                className="h-5 w-5 mr-2 text-green-600 dark:text-green-400 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden
+              >
+                <path
+                  d="M3 12v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7m-8-4v11"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+              </svg>
+              Market caps
             </div>
             <div>
-              <div className="flex items-center text-sm mb-2">
-                <span className="text-blue-100/90 w-20">Supply Cap</span>
-                <div className="flex-1 mx-2 h-3 rounded-lg bg-gradient-to-r from-green-300 via-green-500/70 to-white/10 relative">
-                  <div className="absolute left-0 top-0 h-3 rounded-lg bg-green-400 transition-all" style={{width: `${Math.min(100, (totalSupply/supplyCap)*100)}%`}}></div>
+              <div className="flex flex-wrap items-center text-sm mb-2 gap-2">
+                <span className="text-muted-foreground w-20 shrink-0">Supply cap</span>
+                <div className="flex-1 min-w-[120px] mx-2 h-3 rounded-lg bg-muted relative overflow-hidden">
+                  <div
+                    className="absolute left-0 top-0 h-3 rounded-lg bg-green-500/80 transition-all"
+                    style={{
+                      width: `${Math.min(100, supplyCap > 0 ? (totalSupply / supplyCap) * 100 : 0)}%`,
+                    }}
+                  />
                 </div>
-                <span className="font-bold text-white w-32 text-right">${totalSupply.toLocaleString()} / ${supplyCap.toLocaleString()}</span>
+                <span className="font-bold text-foreground w-32 text-right shrink-0">
+                  ${totalSupply.toLocaleString()} / ${supplyCap.toLocaleString()}
+                </span>
               </div>
-              <div className="flex items-center text-sm">
-                <span className="text-blue-100/90 w-20">Borrow Cap</span>
-                <div className="flex-1 mx-2 h-3 rounded-lg bg-gradient-to-r from-orange-400 via-orange-700/60 to-white/10 relative">
-                  <div className="absolute left-0 top-0 h-3 rounded-lg bg-orange-400 transition-all" style={{width: `${Math.min(100, (totalBorrow/borrowCap)*100)}%`}}></div>
+              <div className="flex flex-wrap items-center text-sm gap-2">
+                <span className="text-muted-foreground w-20 shrink-0">Borrow cap</span>
+                <div className="flex-1 min-w-[120px] mx-2 h-3 rounded-lg bg-muted relative overflow-hidden">
+                  <div
+                    className="absolute left-0 top-0 h-3 rounded-lg bg-orange-500/80 transition-all"
+                    style={{
+                      width: `${Math.min(100, borrowCap > 0 ? (totalBorrow / borrowCap) * 100 : 0)}%`,
+                    }}
+                  />
                 </div>
-                <span className="font-bold text-white w-32 text-right">${totalBorrow.toLocaleString()} / ${borrowCap.toLocaleString()}</span>
+                <span className="font-bold text-foreground w-32 text-right shrink-0">
+                  ${totalBorrow.toLocaleString()} / ${borrowCap.toLocaleString()}
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/market-modal/CollateralRiskPanel.tsx
+++ b/src/components/market-modal/CollateralRiskPanel.tsx
@@ -3,49 +3,106 @@ import { MarketData } from './types';
 
 export const CollateralRiskPanel = ({ marketData }: { marketData: MarketData }) => {
   return (
-    <div className="bg-[#151e34] rounded-2xl p-6 mt-6 mb-4 border border-blue-100/5 shadow-md flex flex-col gap-4">
-      {/* Title */}
-      <div className="flex items-center gap-2 mb-2">
-        <svg className="w-5 h-5 text-blue-300" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M10.29 3.86a2.37 2.37 0 0 1 3.42 0l6.09 6.37c1.17 1.23.37 3.28-1.34 3.39l-1.4.09a2 2 0 0 0-1.84 2.1l.2 2.08c.13 1.3-1.18 2.28-2.35 1.7l-1.62-.81a2.1 2.1 0 0 0-1.87 0l-1.62.81c-1.17.58-2.48-.4-2.35-1.7l.2-2.08a2 2 0 0 0-1.84-2.1l-1.4-.09c-1.71-.11-2.51-2.16-1.34-3.39l6.09-6.37Z"/></svg>
-        <span className="font-semibold text-white text-lg">Collateral & Risk Parameters</span>
+    <div className="rounded-lg border-0 p-0 mt-0 mb-0 flex flex-col gap-4 min-w-0 w-full max-w-full overflow-x-hidden">
+      <div className="flex items-center gap-2 mb-0 min-w-0">
+        <svg
+          className="w-5 h-5 text-ocean-teal shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M10.29 3.86a2.37 2.37 0 0 1 3.42 0l6.09 6.37c1.17 1.23.37 3.28-1.34 3.39l-1.4.09a2 2 0 0 0-1.84 2.1l.2 2.08c.13 1.3-1.18 2.28-2.35 1.7l-1.62-.81a2.1 2.1 0 0 0-1.87 0l-1.62.81c-1.17.58-2.48-.4-2.35-1.7l.2-2.08a2 2 0 0 0-1.84-2.1l-1.4-.09c-1.71-.11-2.51-2.16-1.34-3.39l6.09-6.37Z"
+          />
+        </svg>
+        <span className="font-semibold text-foreground text-base sm:text-lg min-w-0 break-words">
+          Collateral & risk parameters
+        </span>
       </div>
 
-      {/* Parameters Grid */}
-      <div className="grid grid-cols-2 gap-4 mb-2">
-        {/* Max LTV */}
-        <div className="flex flex-col items-start rounded-xl bg-[#0d172b] p-4 shadow border border-blue-200/10">
-          <div className="flex items-center text-blue-200 mb-1">
-            <svg className="w-4 h-4 mr-1 text-blue-400" fill="none" viewBox="0 0 24 24"><path d="M17 16v2a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-2" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+      <div className="grid grid-cols-2 gap-2 sm:gap-3 mb-0 min-w-0 w-full">
+        <div className="min-w-0 flex flex-col items-start rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4 shadow-sm">
+          <div className="flex items-center text-muted-foreground mb-1">
+            <svg
+              className="w-4 h-4 mr-1 text-blue-500 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                d="M17 16v2a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-2"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
             <span className="text-xs font-medium">Max LTV</span>
           </div>
-          <div className="text-2xl font-bold text-white">{marketData.maxLTV}%</div>
+          <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">{marketData.maxLTV}%</div>
         </div>
-        {/* Liquidation Threshold */}
-        <div className="flex flex-col items-start rounded-xl bg-[#0d172b] p-4 shadow border border-blue-200/10">
-          <div className="flex items-center text-blue-200 mb-1">
-            <svg className="w-4 h-4 mr-1 text-green-400" fill="none" viewBox="0 0 24 24"><path d="M12 2v20m10-10H2" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-            <span className="text-xs font-medium">Liquidation Threshold</span>
+        <div className="min-w-0 flex flex-col items-start rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4 shadow-sm">
+          <div className="flex items-center text-muted-foreground mb-1 min-w-0">
+            <svg
+              className="w-4 h-4 mr-1 text-green-500 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                d="M12 2v20m10-10H2"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className="text-xs font-medium">Liquidation threshold</span>
           </div>
-          <div className="text-2xl font-bold text-white">{marketData.liquidationThreshold}%</div>
+          <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
+            {marketData.liquidationThreshold}%
+          </div>
         </div>
-        {/* Liquidation Bonus */}
-        <div className="flex flex-col items-start rounded-xl bg-[#0d172b] p-4 shadow border border-blue-200/10">
-          <div className="flex items-center text-blue-200 mb-1">
-            <svg className="w-4 h-4 mr-1 text-yellow-400" fill="none" viewBox="0 0 24 24"><path d="M12 5v14m-7-7h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-            <span className="text-xs font-medium">Liquidation Bonus</span>
+        <div className="min-w-0 flex flex-col items-start rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4 shadow-sm">
+          <div className="flex items-center text-muted-foreground mb-1">
+            <svg
+              className="w-4 h-4 mr-1 text-amber-500 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                d="M12 5v14m-7-7h14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className="text-xs font-medium">Liquidation bonus</span>
           </div>
-          <div className="text-2xl font-bold text-white">{marketData.liquidationBonus}%</div>
+          <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
+            {marketData.liquidationBonus}%
+          </div>
         </div>
-        {/* Reserve Factor */}
-        <div className="flex flex-col items-start rounded-xl bg-[#0d172b] p-4 shadow border border-blue-200/10">
-          <div className="flex items-center text-blue-200 mb-1">
-            <svg className="w-4 h-4 mr-1 text-purple-400" fill="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6" stroke="currentColor" strokeWidth="2"/></svg>
-            <span className="text-xs font-medium">Reserve Factor</span>
+        <div className="min-w-0 flex flex-col items-start rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4 shadow-sm">
+          <div className="flex items-center text-muted-foreground mb-1 min-w-0">
+            <svg
+              className="w-4 h-4 mr-1 text-purple-500 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <circle cx="12" cy="12" r="6" stroke="currentColor" strokeWidth="2" />
+            </svg>
+            <span className="text-xs font-medium">Reserve factor</span>
           </div>
-          <div className="text-2xl font-bold text-white">{marketData.reserveFactor}%</div>
+          <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
+            {marketData.reserveFactor}%
+          </div>
         </div>
       </div>
-
     </div>
   );
-}
+};

--- a/src/components/market-modal/EarningsCalculator.tsx
+++ b/src/components/market-modal/EarningsCalculator.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { MarketData, UserPosition } from './types';
+import { cn } from '@/lib/utils';
 
 const periods = [
   { label: '1 Month', value: '1M', months: 1 },
@@ -7,25 +9,26 @@ const periods = [
   { label: '1 Year', value: '1Y', months: 12 },
 ];
 
-// Compounding formula: principal * ((1 + apy/n)^(n*t) - 1)
 function calculateCompoundedEarnings(
   amount: number,
-  apy: number, // as percent
+  apy: number,
   months: number,
 ) {
-  const n = 12; // compounding monthly
+  const n = 12;
   const t = months / 12;
   const r = apy / 100;
-  // Avoid error for zero
   if (amount === 0 || apy === 0) return 0;
   return amount * (Math.pow(1 + r / n, n * t) - 1);
 }
 
-export const EarningsCalculator = ({ userPosition, marketData }: {
+export const EarningsCalculator = ({
+  userPosition: _userPosition,
+  marketData,
+}: {
   userPosition?: UserPosition;
   marketData: MarketData;
 }) => {
-  // Simulate amount, default $1000, min $100, max $100,000
+  void _userPosition;
   const [amount, setAmount] = useState(1000);
   const min = 100;
   const max = 100000;
@@ -37,13 +40,29 @@ export const EarningsCalculator = ({ userPosition, marketData }: {
   const borrowCost = calculateCompoundedEarnings(amount, borrowAPY, selectedPeriod.months);
 
   return (
-    <div className="bg-[#0f192e] p-6 rounded-2xl border border-blue-100/5 mt-4 mb-4 shadow-md min-w-[340px]">
-      <div className="font-semibold text-white flex items-center mb-2 text-lg">
-        <svg className="w-5 h-5 mr-2 text-blue-100" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect width="24" height="24" fill="none"/><path d="M8 12h8m-8 4h5m-2.5-12a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg> Earnings Calculator
+    <div className="p-0 rounded-lg border-0 mt-0 mb-0 min-w-0 w-full">
+      <div className="font-semibold text-foreground flex items-center gap-2 mb-2 text-lg">
+        <svg
+          className="w-5 h-5 text-ocean-teal shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            d="M8 12h8m-8 4h5m-2.5-12a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        Earnings calculator
       </div>
-      <div className="mb-2 mt-3 flex flex-row items-center justify-between text-sm font-medium text-blue-100/80">
+      <div className="mb-2 mt-3 flex flex-row items-center justify-between text-sm font-medium text-muted-foreground">
         <span>Amount</span>
-        <span className="text-white text-base font-semibold">${amount.toLocaleString()}</span>
+        <span className="text-foreground text-base font-semibold">
+          ${amount.toLocaleString()}
+        </span>
       </div>
       <input
         type="range"
@@ -51,43 +70,88 @@ export const EarningsCalculator = ({ userPosition, marketData }: {
         max={max}
         value={amount}
         step={100}
-        onChange={e => setAmount(Number(e.target.value))}
-        className="w-full mb-1 accent-cyan-400"
+        onChange={(e) => setAmount(Number(e.target.value))}
+        className="w-full mb-1 accent-ocean-teal"
       />
-      <div className="flex justify-between text-xs text-blue-300/60 mb-3">
+      <div className="flex justify-between text-xs text-muted-foreground mb-3">
         <span>${min.toLocaleString()}</span>
         <span>${max.toLocaleString()}</span>
       </div>
-      <div className="flex flex-row gap-2 mb-3 mt-1">
+      <div className="grid grid-cols-3 gap-2 mb-3 mt-1 min-w-0 w-full">
         {periods.map((p) => (
-          <button
+          <Button
             key={p.value}
-            className={`flex-1 py-1.5 rounded-lg font-bold text-sm transition-colors border-2 ${selectedPeriod.value === p.value ? 'bg-gradient-to-r from-cyan-400 to-teal-400 text-blue-900 border-cyan-400' : 'bg-[#12203a] text-blue-200 border-transparent hover:bg-blue-900/40'}`}
+            type="button"
+            variant={selectedPeriod.value === p.value ? 'default' : 'outline'}
+            size="sm"
+            className={cn(
+              'min-w-0 w-full px-1 sm:px-3 text-[11px] sm:text-sm',
+              selectedPeriod.value === p.value &&
+                'bg-ocean-teal hover:bg-ocean-teal/90 text-white border-ocean-teal'
+            )}
             onClick={() => setSelectedPeriod(p)}
           >
             {p.label}
-          </button>
+          </Button>
         ))}
       </div>
-      <div className="flex flex-row gap-3 w-full mt-1">
-        <div className="flex-1 rounded-xl border border-green-700/40 bg-gradient-to-bl from-green-950/50 to-[#14302e]/90 p-4 shadow text-left">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full min-w-0 mt-1">
+        <div className="min-w-0 w-full rounded-xl border border-green-600/30 bg-green-500/5 dark:bg-green-950/30 p-3 sm:p-4 shadow-sm text-left">
           <div className="flex items-center mb-0.5">
-            <svg className="h-4 w-4 mr-1 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7"/></svg>
-            <span className="font-semibold text-green-300 text-sm">If Supplying</span>
+            <svg
+              className="h-4 w-4 mr-1 text-green-600 dark:text-green-400 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <span className="font-semibold text-green-700 dark:text-green-400 text-sm">
+              If supplying
+            </span>
           </div>
-          <div className="mt-1 text-2xl font-extrabold text-green-400">+${supplyEarned.toFixed(2)}</div>
-          <div className="text-xs text-green-200/80 mt-0.5">at {supplyAPY.toFixed(2)}% APY</div>
+          <div className="mt-1 text-xl sm:text-2xl font-extrabold text-green-600 dark:text-green-400 break-all">
+            +${supplyEarned.toFixed(2)}
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5">
+            at {supplyAPY.toFixed(2)}% APY
+          </div>
         </div>
-        <div className="flex-1 rounded-xl border border-orange-700/30 bg-gradient-to-bl from-orange-950/40 to-[#33241a]/80 p-4 shadow text-left">
+        <div className="min-w-0 w-full rounded-xl border border-orange-600/30 bg-orange-500/5 dark:bg-orange-950/30 p-3 sm:p-4 shadow-sm text-left">
           <div className="flex items-center mb-0.5">
-            <svg className="h-4 w-4 mr-1 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a5 5 0 00-10 0v2a5 5 0 00-2 4v5a5 5 0 005 5h2a5 5 0 005-5v-5a5 5 0 00-2-4z"/></svg>
-            <span className="font-semibold text-orange-300 text-sm">If Borrowing</span>
+            <svg
+              className="h-4 w-4 mr-1 text-orange-600 dark:text-orange-400 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 9V7a5 5 0 00-10 0v2a5 5 0 00-2 4v5a5 5 0 005 5h2a5 5 0 005-5v-5a5 5 0 00-2-4z"
+              />
+            </svg>
+            <span className="font-semibold text-orange-700 dark:text-orange-400 text-sm">
+              If borrowing
+            </span>
           </div>
-          <div className="mt-1 text-2xl font-extrabold text-orange-400">-${borrowCost.toFixed(2)}</div>
-          <div className="text-xs text-orange-200/80 mt-0.5">at {borrowAPY.toFixed(2)}% APY</div>
+          <div className="mt-1 text-xl sm:text-2xl font-extrabold text-orange-600 dark:text-orange-400 break-all">
+            -${borrowCost.toFixed(2)}
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5">
+            at {borrowAPY.toFixed(2)}% APY
+          </div>
         </div>
       </div>
-      <div className="mt-4 text-center text-xs text-blue-200/70">
+      <div className="mt-4 text-center text-xs text-muted-foreground">
         Calculations assume compounding interest. Actual results may vary.
       </div>
     </div>

--- a/src/components/market-modal/HealthFactorSimulator.tsx
+++ b/src/components/market-modal/HealthFactorSimulator.tsx
@@ -1,54 +1,75 @@
 import React, { useState } from 'react';
 import { MarketData, UserPosition } from './types';
 
-export const HealthFactorSimulator = ({ userPosition, marketData }: {
+export const HealthFactorSimulator = ({
+  userPosition,
+  marketData: _marketData,
+}: {
   userPosition?: UserPosition;
   marketData: MarketData;
 }) => {
   const [borrowDelta, setBorrowDelta] = useState(0);
+  void _marketData;
 
   if (!userPosition) return null;
 
-  // Simulate new health factor: this is a placeholder calc.
   const simulatedHealthFactor = Math.max(
     0,
     userPosition.healthFactor - borrowDelta * 0.01
   );
 
-  const risk = simulatedHealthFactor >= 2
-    ? { text: 'Low Risk', color: 'text-green-400' }
-    : simulatedHealthFactor >= 1.1
-      ? { text: 'Warning', color: 'text-yellow-400' }
-      : { text: 'Danger', color: 'text-red-400' };
+  const risk =
+    simulatedHealthFactor >= 2
+      ? { text: 'Low risk', color: 'text-green-600 dark:text-green-400' }
+      : simulatedHealthFactor >= 1.1
+        ? { text: 'Warning', color: 'text-amber-600 dark:text-amber-400' }
+        : { text: 'Danger', color: 'text-red-600 dark:text-red-400' };
 
   return (
-    <div className="bg-[#131d35] p-4 rounded-2xl shadow border border-white/5 mb-2 mt-4">
-      <div className="font-semibold text-blue-200 flex items-center mb-3">
-        <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.418 0-8-2.239-8-5v-5c0-2.761 3.582-5 8-5s8 2.239 8 5v5m-4 2.5l2 2m0 0l2-2m-2 2V15" /></svg>
-        Health Factor Simulator
+    <div className="p-0 rounded-lg border-0 mb-0 mt-0 min-w-0 w-full max-w-full overflow-x-hidden">
+      <div className="font-semibold text-foreground flex items-center gap-2 mb-3">
+        <svg
+          className="w-5 h-5 text-ocean-teal shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.418 0-8-2.239-8-5v-5c0-2.761 3.582-5 8-5s8 2.239 8 5v5m-4 2.5l2 2m0 0l2-2m-2 2V15"
+          />
+        </svg>
+        Health factor simulator
       </div>
-      <div className="flex flex-row gap-4">
-        <div className="flex-1 flex flex-col items-center bg-gradient-to-br from-green-900/40 to-blue-800/10 rounded-xl p-4 mr-2">
-          <span className="text-xs text-blue-100/70 mb-2">Current HF</span>
-          <span className="text-2xl font-bold text-green-300">{userPosition.healthFactor.toFixed(2)}</span>
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-4 min-w-0 w-full">
+        <div className="min-w-0 flex flex-col items-center rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4">
+          <span className="text-xs text-muted-foreground mb-2">Current HF</span>
+          <span className="text-2xl font-bold text-green-600 dark:text-green-400">
+            {userPosition.healthFactor.toFixed(2)}
+          </span>
         </div>
-        <div className="flex-1 flex flex-col items-center bg-gradient-to-br from-blue-900/40 to-blue-800/10 rounded-xl p-4 ml-2">
-          <span className="text-xs text-blue-100/70 mb-2">Simulated HF</span>
-          <span className={`text-2xl font-bold ${risk.color}`}>{simulatedHealthFactor.toFixed(2)}</span>
+        <div className="flex-1 min-w-[140px] flex flex-col items-center rounded-xl border border-border bg-muted/30 dark:bg-muted/20 p-4">
+          <span className="text-xs text-muted-foreground mb-2">Simulated HF</span>
+          <span className={`text-2xl font-bold ${risk.color}`}>
+            {simulatedHealthFactor.toFixed(2)}
+          </span>
           <span className={`text-xs ${risk.color}`}>{risk.text}</span>
         </div>
       </div>
       <div className="mt-3">
-        <div className="font-medium text-blue-100/70 text-xs mb-1">Borrow Amount</div>
+        <div className="font-medium text-muted-foreground text-xs mb-1">Borrow amount</div>
         <input
           type="range"
           min={0}
           max={userPosition.borrowable}
           value={borrowDelta}
-          onChange={e => setBorrowDelta(Number(e.target.value))}
-          className="w-full mt-1 accent-yellow-400"
+          onChange={(e) => setBorrowDelta(Number(e.target.value))}
+          className="w-full mt-1 accent-ocean-teal"
         />
-        <div className="flex justify-between text-xs text-blue-200/80 mt-1">
+        <div className="flex justify-between text-xs text-muted-foreground mt-1">
           <span>${borrowDelta}</span>
           <span>Max: ${userPosition.borrowable}</span>
         </div>
@@ -56,4 +77,3 @@ export const HealthFactorSimulator = ({ userPosition, marketData }: {
     </div>
   );
 };
-

--- a/src/components/market-modal/MarketDetailStatsSection.tsx
+++ b/src/components/market-modal/MarketDetailStatsSection.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo } from "react";
+import { getMarketLabel } from "@/config";
+
+function formatUsdFromMicro(micro: number): string {
+  if (!Number.isFinite(micro)) return "—";
+  const usd = micro / 1_000_000;
+  return usd.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatNumber(n: number, maxFrac = 4): string {
+  if (!Number.isFinite(n)) return "—";
+  return n.toLocaleString("en-US", {
+    maximumFractionDigits: maxFrac,
+  });
+}
+
+export interface MarketDetailStatsSectionProps {
+  rawMarket: Record<string, unknown>;
+  networkId: string;
+}
+
+/**
+ * Read-only technical stats for the selected lending market (pool id, caps, risk params).
+ */
+export const MarketDetailStatsSection: React.FC<MarketDetailStatsSectionProps> = ({
+  rawMarket,
+  networkId,
+}) => {
+  const poolId = useMemo(() => {
+    const direct = rawMarket.poolId;
+    if (direct != null && String(direct) !== "") return String(direct);
+    const mi = rawMarket.marketInfo as { poolId?: string } | undefined;
+    return mi?.poolId != null ? String(mi.poolId) : "—";
+  }, [rawMarket]);
+
+  const marketLabel = useMemo(
+    () => getMarketLabel(networkId, poolId !== "—" ? poolId : undefined),
+    [networkId, poolId]
+  );
+
+  const collateralFactor = Number(rawMarket.collateralFactor ?? 0);
+  const liqThreshold = Number(rawMarket.liquidationThreshold ?? 0);
+  const liqPenalty = Number(rawMarket.liquidationPenalty ?? 0);
+  const reserveFactor = Number(rawMarket.reserveFactor ?? 0);
+  const utilization = Number(rawMarket.utilization ?? 0);
+
+  const totalSupplyUSD = Number(rawMarket.totalSupplyUSD ?? 0);
+  const totalBorrowUSD = Number(rawMarket.totalBorrowUSD ?? 0);
+  const totalSupply = Number(rawMarket.totalSupply ?? 0);
+  const totalBorrow = Number(rawMarket.totalBorrow ?? 0);
+  const supplyCap = Number(rawMarket.supplyCap ?? 0);
+  const borrowCap = Number(rawMarket.borrowCap ?? 0);
+  const asset = String(rawMarket.asset ?? "—");
+
+  const isLoading = rawMarket.isLoading === true;
+  const error = typeof rawMarket.error === "string" ? rawMarket.error : null;
+
+  const rows: { label: string; value: string; hint?: string }[] = [
+    { label: "Network", value: networkId.replace(/-/g, " ") },
+    { label: "Lending pool (app)", value: poolId },
+    ...(marketLabel
+      ? [{ label: "Market", value: `Pool ${marketLabel}` }]
+      : []),
+    {
+      label: "Total supplied",
+      value: formatUsdFromMicro(totalSupplyUSD),
+      hint: `${formatNumber(totalSupply)} ${asset}`,
+    },
+    {
+      label: "Total borrowed",
+      value: formatUsdFromMicro(totalBorrowUSD),
+      hint: `${formatNumber(totalBorrow)} ${asset}`,
+    },
+    {
+      label: "Utilization",
+      value: `${utilization.toFixed(1)}%`,
+    },
+    {
+      label: "Collateral factor",
+      value: `${collateralFactor.toFixed(0)}%`,
+    },
+    {
+      label: "Liquidation threshold",
+      value: `${liqThreshold.toFixed(0)}%`,
+    },
+    {
+      label: "Liquidation penalty",
+      value: `${liqPenalty.toFixed(0)}%`,
+    },
+    {
+      label: "Reserve factor",
+      value: `${reserveFactor.toFixed(0)}%`,
+    },
+    {
+      label: "Supply cap (units)",
+      value: supplyCap > 0 ? formatNumber(supplyCap) : "—",
+    },
+    {
+      label: "Borrow cap (units)",
+      value: borrowCap > 0 ? formatNumber(borrowCap) : "—",
+    },
+  ];
+
+  return (
+    <div className="rounded-lg border-0 bg-transparent p-0 min-w-0 w-full max-w-full overflow-x-hidden">
+      <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+        <span className="inline-block h-2 w-2 rounded-full bg-ocean-teal" />
+        Market details
+      </h3>
+      {isLoading && (
+        <p className="text-xs text-muted-foreground mb-2">Loading latest market data…</p>
+      )}
+      {error && (
+        <p className="text-xs text-amber-600 dark:text-amber-400 mb-2">{error}</p>
+      )}
+      <dl className="space-y-2.5">
+        {rows.map(({ label, value, hint }) => (
+          <div
+            key={label}
+            className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-0.5 border-b border-border pb-2 last:border-0 last:pb-0"
+          >
+            <dt className="text-xs text-muted-foreground shrink-0">{label}</dt>
+            <dd className="text-sm font-medium text-foreground text-right sm:text-right min-w-0 break-all">
+              {value}
+              {hint && (
+                <span className="block text-[11px] font-normal text-muted-foreground mt-0.5">
+                  {hint}
+                </span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};

--- a/src/components/market-modal/MarketHeader.tsx
+++ b/src/components/market-modal/MarketHeader.tsx
@@ -1,41 +1,138 @@
 import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { MarketPoolBadge } from '@/components/markets/MarketPoolBadge';
+import { formatUsdPerTokenDisplay } from '@/lib/utils';
 import { MarketData } from './types';
 
-// Placeholder for sparkline. If you want historical prices, use a chart lib or SVG.
-const MiniSparkline = () => (
-  <svg width="60" height="18" fill="none" viewBox="0 0 60 18">
-    <polyline points="0,11 10,12 20,7 30,14 40,5 50,10 60,8" stroke="#05D484" strokeWidth="2" fill="none" />
-  </svg>
-);
+const SPARK_W = 60;
+const SPARK_H = 18;
 
-export const MarketHeader = ({ marketData, chainId }: { marketData: MarketData; chainId?: 'voi' | 'algorand' }) => {
+const sparklineColorClass = (change24h: number) =>
+  change24h >= 0
+    ? 'text-green-600 dark:text-green-400'
+    : 'text-red-600 dark:text-red-400';
+
+/** Renders last N points of USD price over 24h; flat line if insufficient data. */
+function PriceSparkline({
+  points,
+  change24h,
+}: {
+  points: { time: number; price: number }[];
+  change24h: number;
+}) {
+  const strokeClass = sparklineColorClass(change24h);
+
+  if (points.length < 2) {
+    return (
+      <svg
+        width={SPARK_W}
+        height={SPARK_H}
+        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+        fill="none"
+        className={`${strokeClass} shrink-0`}
+        aria-hidden
+      >
+        <line
+          x1="0"
+          y1={SPARK_H / 2}
+          x2={String(SPARK_W)}
+          y2={SPARK_H / 2}
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+      </svg>
+    );
+  }
+
+  const prices = points.map((p) => p.price);
+  const minP = Math.min(...prices);
+  const maxP = Math.max(...prices);
+  const range = maxP - minP;
+  const pad = range < 1e-12 ? Math.max(minP * 1e-6, 1e-8) : 0;
+  const lo = minP - pad;
+  const hi = maxP + pad;
+  const denom = hi - lo || 1;
+  const padding = 2;
+
+  const coords = points.map((p, i) => {
+    const x = (i / (points.length - 1)) * SPARK_W;
+    const norm = (p.price - lo) / denom;
+    const y = SPARK_H - padding - norm * (SPARK_H - 2 * padding);
+    return `${x},${y}`;
+  });
+
   return (
-    <div className="flex flex-row items-center justify-between px-6 pt-6 pb-2">
-      <div className="flex items-center gap-5">
-        <img src={marketData.icon} alt={marketData.name} className="w-16 h-16 rounded-full shadow-lg bg-white p-2 border-2 border-blue-400" />
-        <div>
-          <div className="flex items-center">
-            <span className="text-2xl md:text-3xl font-extrabold text-white uppercase">
+    <svg
+      width={SPARK_W}
+      height={SPARK_H}
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      fill="none"
+      className={`${strokeClass} shrink-0`}
+      aria-hidden
+    >
+      <polyline
+        points={coords.join(' ')}
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export const MarketHeader = ({
+  marketData,
+  chainId,
+  marketLabel,
+}: {
+  marketData: MarketData;
+  chainId?: 'voi' | 'algorand';
+  marketLabel?: string | null;
+}) => {
+  return (
+    <div className="flex flex-col gap-3 min-w-0 w-full sm:flex-row sm:items-center sm:justify-between sm:gap-4 px-0 pt-0 pb-1 sm:pb-2">
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="relative shrink-0">
+          <img
+            src={marketData.icon}
+            alt={marketData.name}
+            className="w-14 h-14 sm:w-16 sm:h-16 rounded-full shadow-md bg-background p-1 border-2 border-border object-contain"
+          />
+          <MarketPoolBadge label={marketLabel} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xl sm:text-2xl md:text-3xl font-extrabold text-foreground uppercase truncate max-w-full">
               {marketData.symbol}
             </span>
             {chainId && (
-              <span className="ml-2 bg-blue-900 text-blue-200 px-2 py-0.5 rounded-full text-xs font-semibold">
-                {chainId.toUpperCase()}
-              </span>
+              <Badge variant="secondary" className="text-xs font-semibold capitalize shrink-0">
+                {chainId}
+              </Badge>
             )}
           </div>
-          <div className="text-base text-blue-200/80 font-normal">
+          <div className="text-sm sm:text-base text-muted-foreground font-normal break-words">
             {marketData.name}
           </div>
         </div>
       </div>
-      <div className="text-right min-w-[110px] flex flex-col items-end justify-center gap-0.5">
-        <div className="text-2xl font-bold text-white">
-          ${marketData.price?.toFixed(2)}
+      <div className="flex flex-row items-center justify-between gap-3 min-w-0 w-full sm:w-auto sm:max-w-[min(100%,11rem)] sm:flex-col sm:items-end sm:justify-center sm:gap-0.5 sm:text-right shrink-0">
+        <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums break-all">
+          ${formatUsdPerTokenDisplay(Number(marketData.price ?? 0))}
         </div>
-        <div className={`text-sm font-medium flex items-center gap-1 ${marketData.priceChange24h >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-          {marketData.priceChange24h >= 0 ? '+' : ''}{marketData.priceChange24h?.toFixed(2)}%
-          <span className="inline-block align-middle"><MiniSparkline /></span>
+        <div
+          className={`text-sm font-medium flex items-center gap-1 shrink-0 tabular-nums ${
+            marketData.priceChange24h >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}
+        >
+          {marketData.priceChange24h >= 0 ? '+' : ''}
+          {marketData.priceChange24h?.toFixed(2)}%
+          <span className="inline-block align-middle shrink-0" title="24h vs USDC (Mimir)">
+            <PriceSparkline
+              points={marketData.priceHistory ?? []}
+              change24h={marketData.priceChange24h ?? 0}
+            />
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/market-modal/MarketModalFooter.tsx
+++ b/src/components/market-modal/MarketModalFooter.tsx
@@ -2,19 +2,18 @@ import React from 'react';
 
 export const MarketModalFooter = ({ asset }: { asset: string }) => {
   return (
-    <div className="p-4 mt-2 flex flex-col gap-2 justify-center text-center text-xs text-blue-200/60 rounded-b-2xl border-t border-white/10">
+    <div className="px-1 sm:px-2 py-4 mt-2 flex flex-col gap-2 justify-center text-center text-xs text-muted-foreground rounded-b-xl border-t border-border min-w-0 w-full max-w-full">
       <a
         href={`https://explorer.yourprotocol.org/asset/${asset}`}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-primary underline font-semibold"
+        className="text-ocean-teal hover:underline font-semibold"
       >
         View asset on explorer
       </a>
-      <div className="mt-1 mb-1 text-xs font-medium">
+      <div className="mt-1 mb-1 text-xs font-medium break-words hyphens-auto">
         Powered by DorkFi. Data & analytics may be delayed or inaccurate. Not financial advice.
       </div>
     </div>
   );
 };
-

--- a/src/components/market-modal/MarketOverview.tsx
+++ b/src/components/market-modal/MarketOverview.tsx
@@ -1,42 +1,76 @@
 import React from 'react';
 import { MarketData } from './types';
 
-const OverviewItem = ({ title, value, subtitle, color }: {
-  title: string, value: string, color?: string, subtitle?: string
+const OverviewItem = ({
+  title,
+  value,
+  subtitle,
+  color,
+}: {
+  title: string;
+  value: string;
+  color?: string;
+  subtitle?: string;
 }) => (
-  <div className="flex flex-col items-start bg-[#101c38] rounded-2xl px-4 py-4 min-w-[140px] flex-1 shadow border border-white/5">
-    <span className="text-xs text-blue-100/80 mb-1">{title}</span>
-    <span className={`font-extrabold text-xl md:text-2xl ${color || 'text-white'} mb-0`}>{value}</span>
-    {subtitle && <span className="text-[11px] text-blue-300/70 mt-0.5">{subtitle}</span>}
+  <div className="flex flex-col items-start rounded-xl px-3 py-3 sm:px-4 sm:py-4 min-w-0 w-full flex-1 shadow-sm border border-border bg-muted/40 dark:bg-muted/25">
+    <span className="text-xs text-muted-foreground mb-1">{title}</span>
+    <span className={`font-extrabold text-lg sm:text-xl md:text-2xl break-all ${color || 'text-foreground'} mb-0`}>
+      {value}
+    </span>
+    {subtitle && (
+      <span className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</span>
+    )}
   </div>
 );
 
 const UtilizationBar = ({ percent }: { percent: number }) => (
   <div className="w-full mt-4 mb-1 flex flex-col gap-1">
-    <div className="flex flex-row justify-between items-center text-xs text-blue-200/80">
-      <span>0%</span>
-      <span className="text-yellow-400 font-semibold">Optimal: 80%</span>
-      <span>100%</span>
+    <div className="flex flex-row flex-wrap justify-between items-center gap-x-2 gap-y-0.5 text-[10px] sm:text-xs text-muted-foreground">
+      <span className="shrink-0">0%</span>
+      <span className="text-whale-gold font-semibold text-center min-w-0">Optimal: 80%</span>
+      <span className="shrink-0">100%</span>
     </div>
-    <div className="w-full h-3 rounded-full bg-gradient-to-r from-yellow-400 via-yellow-600/80 to-blue-700/60 relative flex">
-      <div style={{ width: `${percent}%` }} className="h-3 rounded-full bg-yellow-400 absolute left-0 top-0 transition-all" />
-      <div style={{ left: '80%' }} className="absolute top-0 h-3 w-[2px] bg-white/50" />
+    <div className="w-full h-3 rounded-full bg-muted relative flex overflow-hidden">
+      <div
+        style={{ width: `${Math.min(100, percent)}%` }}
+        className="h-3 rounded-full bg-whale-gold/90 absolute left-0 top-0 transition-all"
+      />
+      <div
+        style={{ left: '80%' }}
+        className="absolute top-0 h-3 w-0.5 bg-foreground/30"
+      />
     </div>
-    <div className="mt-1 text-right text-yellow-400 text-lg font-bold">{percent?.toFixed(1)}%</div>
+    <div className="mt-1 text-right text-whale-gold text-lg font-bold">
+      {percent?.toFixed(1)}%
+    </div>
   </div>
 );
 
 export const MarketOverview = ({ marketData }: { marketData: MarketData }) => {
   return (
-    <div className="flex flex-wrap gap-4 px-2 mb-2">
-      <OverviewItem title="Available Liquidity" value={`$${marketData.availableLiquidity.toLocaleString()}`} color="text-blue-200" subtitle={`${(marketData.availableLiquidity / (marketData.totalSupply || 1) * 100).toFixed(1)}% of supply`} />
-      <OverviewItem title="Total Supplied" value={`$${marketData.totalSupply.toLocaleString()}`} color="text-green-400" subtitle={`${marketData.supplyAPY.toFixed(2)}% APY`} />
-      <OverviewItem title="Total Borrowed" value={`$${marketData.totalBorrow.toLocaleString()}`} color="text-orange-400" subtitle={`${marketData.borrowAPY.toFixed(2)}% APY`} />
-    <div className="flex-1 min-w-[240px]">
-      <span className="block text-xs text-blue-100/80 mb-1">Utilization Rate</span>
-      <UtilizationBar percent={marketData.utilization ?? 0} />
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 px-0 mb-0 min-w-0 w-full">
+      <OverviewItem
+        title="Available liquidity"
+        value={`$${marketData.availableLiquidity.toLocaleString()}`}
+        color="text-blue-600 dark:text-blue-400"
+        subtitle={`${((marketData.availableLiquidity / (marketData.totalSupply || 1)) * 100).toFixed(1)}% of supply`}
+      />
+      <OverviewItem
+        title="Total supplied"
+        value={`$${marketData.totalSupply.toLocaleString()}`}
+        color="text-green-600 dark:text-green-400"
+        subtitle={`${marketData.supplyAPY.toFixed(2)}% APY`}
+      />
+      <OverviewItem
+        title="Total borrowed"
+        value={`$${marketData.totalBorrow.toLocaleString()}`}
+        color="text-orange-600 dark:text-orange-400"
+        subtitle={`${marketData.borrowAPY.toFixed(2)}% APY`}
+      />
+      <div className="min-w-0 w-full sm:col-span-2">
+        <span className="block text-xs text-muted-foreground mb-1">Utilization rate</span>
+        <UtilizationBar percent={marketData.utilization ?? 0} />
+      </div>
     </div>
-  </div>
   );
 };
-

--- a/src/components/market-modal/PremiumMarketModal.tsx
+++ b/src/components/market-modal/PremiumMarketModal.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
+import React, { useMemo } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { getMarketLabel } from '@/config';
+import { useMimirTokenPrice24h } from '@/hooks/useMimirTokenPrice24h';
 import { MarketData, UserPosition } from './types';
 import { MarketHeader } from './MarketHeader';
 import { UserPositionBar } from './UserPositionBar';
@@ -11,12 +12,28 @@ import { EarningsCalculator } from './EarningsCalculator';
 import { CollateralRiskPanel } from './CollateralRiskPanel';
 import { MarketModalFooter } from './MarketModalFooter';
 import { UtilizationRatePanel } from './UtilizationRatePanel';
+import { MarketDetailStatsSection } from './MarketDetailStatsSection';
+
+const SECTION =
+  'rounded-lg border border-border bg-muted/30 dark:bg-muted/20 p-3 sm:p-4 min-w-0 w-full max-w-full overflow-x-hidden';
+
+function poolIdFromRawMarket(raw: Record<string, unknown> | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  const direct = raw.poolId;
+  if (direct != null && String(direct) !== '') return String(direct);
+  const mi = raw.marketInfo as { poolId?: string } | undefined;
+  if (mi?.poolId != null && String(mi.poolId) !== '') return String(mi.poolId);
+  return undefined;
+}
 
 export interface PremiumMarketModalProps {
   isOpen: boolean;
   onClose: () => void;
   asset: string;
   chainId?: 'voi' | 'algorand';
+  /** Original on-demand market row (pool id, caps, risk params). */
+  rawMarket?: Record<string, unknown> | null;
+  networkId?: string | null;
   marketData: MarketData;
   userPosition?: UserPosition;
   onDeposit?: () => void;
@@ -30,6 +47,8 @@ export const PremiumMarketModal = ({
   onClose,
   asset,
   chainId = 'voi',
+  rawMarket,
+  networkId,
   marketData,
   userPosition,
   onDeposit,
@@ -37,28 +56,50 @@ export const PremiumMarketModal = ({
   onBorrow,
   onRepay,
 }: PremiumMarketModalProps) => {
+  const marketLabel = useMemo(() => {
+    const poolId = poolIdFromRawMarket(rawMarket ?? null);
+    if (!networkId || !poolId) return null;
+    return getMarketLabel(networkId, poolId);
+  }, [rawMarket, networkId]);
+
+  const {
+    priceChange24h: mimirChange24h,
+    priceHistory: mimirHistory,
+  } = useMimirTokenPrice24h(marketData.symbol, isOpen);
+
+  const headerMarketData = useMemo((): MarketData => {
+    const mergedHistory =
+      mimirHistory.length > 0 ? mimirHistory : (marketData.priceHistory ?? []);
+    return {
+      ...marketData,
+      priceChange24h: mimirChange24h,
+      priceHistory: mergedHistory,
+    };
+  }, [marketData, mimirChange24h, mimirHistory]);
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl w-full px-0 py-0 bg-gradient-to-br from-[#111e2f] via-[#101729] to-[#111624] shadow-2xl border border-blue-50/10 rounded-2xl">
+      <DialogContent className="max-w-2xl w-full min-w-0 min-h-0 max-h-[min(90dvh,90vh)] flex flex-col overflow-hidden px-0 py-0 bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl card-hover hover:shadow-lg hover:border-ocean-teal/40 transition-all">
         <DialogTitle className="sr-only">{marketData.symbol} Market Details</DialogTitle>
-        <ScrollArea className="max-h-[90vh] overflow-y-auto rounded-2xl">
-          <div className="flex flex-col gap-4 px-4">
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain rounded-xl">
+          <div className="flex flex-col gap-3 sm:gap-4 px-3 pb-4 pt-10 pr-11 sm:px-4 sm:pt-4 sm:pr-10 min-w-0 w-full max-w-full box-border">
 
-            <MarketHeader marketData={marketData} chainId={chainId} />
+            <MarketHeader
+              marketData={headerMarketData}
+              chainId={chainId}
+              marketLabel={marketLabel}
+            />
             <UserPositionBar userPosition={userPosition} />
 
-            {/* Market Overview */}
-            <section className="bg-[#111b32] rounded-lg p-4 mb-0">
+            <section className={SECTION}>
               <MarketOverview marketData={marketData} />
             </section>
 
-            {/* Utilization */}
-            <section className="bg-[#111b32] rounded-lg p-4 mt-0 mb-0">
+            <section className={SECTION}>
               <UtilizationRatePanel utilization={marketData.utilization ?? 0} />
             </section>
 
-            {/* Primary Actions */}
-            <section className="bg-[#111b32] rounded-lg p-4 mt-0 mb-0">
+            <section className={SECTION}>
               <PrimaryActionButtons
                 onDeposit={onDeposit}
                 onWithdraw={onWithdraw}
@@ -70,25 +111,31 @@ export const PremiumMarketModal = ({
               />
             </section>
 
-            {/* Simulators */}
-            <section className="bg-[#111b32] rounded-lg p-4 mt-0 mb-0">
+            <section className={SECTION}>
               <HealthFactorSimulator userPosition={userPosition} marketData={marketData} />
             </section>
 
-            <section className="bg-[#111b32] rounded-lg p-4 mt-0 mb-0">
+            <section className={SECTION}>
               <EarningsCalculator userPosition={userPosition} marketData={marketData} />
             </section>
 
-            {/* Collateral & Risk */}
-            <section className="bg-[#111b32] rounded-lg p-4 mt-0 mb-0">
-              <CollateralRiskPanel userPosition={userPosition} marketData={marketData} />
+            <section className={SECTION}>
+              <CollateralRiskPanel marketData={marketData} />
             </section>
 
-            {/* Footer */}
+            {rawMarket && networkId && (
+              <section className={SECTION}>
+                <MarketDetailStatsSection
+                  rawMarket={rawMarket}
+                  networkId={networkId}
+                />
+              </section>
+            )}
+
             <MarketModalFooter asset={asset} />
 
           </div>
-        </ScrollArea>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/market-modal/PremiumMarketModal.tsx
+++ b/src/components/market-modal/PremiumMarketModal.tsx
@@ -79,7 +79,7 @@ export const PremiumMarketModal = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl w-full min-w-0 min-h-0 max-h-[min(90dvh,90vh)] flex flex-col overflow-hidden px-0 py-0 bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl card-hover hover:shadow-lg hover:border-ocean-teal/40 transition-all">
+      <DialogContent className="max-w-2xl w-full min-w-0 min-h-0 max-h-[min(90dvh,90vh)] flex flex-col overflow-hidden px-0 py-0 dorkfi-dark-bg-modal rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl card-hover hover:shadow-lg hover:border-ocean-teal/40 transition-all">
         <DialogTitle className="sr-only">{marketData.symbol} Market Details</DialogTitle>
         <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain rounded-xl">
           <div className="flex flex-col gap-3 sm:gap-4 px-3 pb-4 pt-10 pr-11 sm:px-4 sm:pt-4 sm:pr-10 min-w-0 w-full max-w-full box-border">

--- a/src/components/market-modal/PrimaryActionButtons.tsx
+++ b/src/components/market-modal/PrimaryActionButtons.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import DorkFiButton from '@/components/ui/DorkFiButton';
 import { MarketData, UserPosition } from './types';
 
 export const PrimaryActionButtons = ({
@@ -7,7 +8,7 @@ export const PrimaryActionButtons = ({
   onBorrow,
   onRepay,
   asset,
-  userPosition,
+  userPosition: _userPosition,
   marketData,
 }: {
   onDeposit?: () => void;
@@ -18,41 +19,60 @@ export const PrimaryActionButtons = ({
   userPosition?: UserPosition;
   marketData: MarketData;
 }) => {
-  const [selected, setSelected] = useState<'deposit' | 'borrow' | 'withdraw'>('deposit');
+  void _userPosition;
+  void asset;
+
   return (
-    <div className="flex flex-col gap-2 bg-[#131d35] px-0 py-0 rounded-2xl mt-2 shadow border-none">
-      <div className="flex flex-row gap-3 mb-2">
-        {/* Deposit Button (filled teal) */}
-        <button
-          className={`flex-1 font-bold rounded-lg py-3 px-2 flex items-center justify-center text-base transition focus:outline-none focus:ring-2 focus:ring-teal-300 shadow-none
-            ${selected === 'deposit' ? 'bg-[#16d8a8] text-white' : 'bg-[#153b34] text-white/80'}
-            hover:bg-[#11c6a1]`}
-          onClick={() => { setSelected('deposit'); onDeposit?.(); }}
+    <div className="flex flex-col gap-3 min-w-0 w-full">
+      <div className="flex flex-col gap-2 min-w-0 w-full sm:flex-row sm:flex-wrap sm:gap-2">
+        <DorkFiButton
+          type="button"
+          variant="primary"
+          className="w-full min-w-0 sm:flex-1 sm:min-w-0"
+          onClick={() => onDeposit?.()}
         >
           Deposit
-        </button>
-        {/* Borrow Button (yellow outline) */}
-        <button
-          className={`flex-1 font-bold rounded-lg py-3 px-2 flex items-center justify-center text-base transition focus:outline-none focus:ring-2 focus:ring-yellow-300 shadow-none border-2
-            ${selected === 'borrow' ? 'border-yellow-400 text-yellow-400 bg-[#222b12]/50' : 'border-yellow-400 text-yellow-400 bg-transparent'}
-            hover:bg-yellow-900/10`}
-          onClick={() => { setSelected('borrow'); onBorrow?.(); }}
+        </DorkFiButton>
+        <DorkFiButton
+          type="button"
+          variant="borrow-outline"
+          className="w-full min-w-0 sm:flex-1 sm:min-w-0"
+          onClick={() => onBorrow?.()}
         >
           Borrow
-        </button>
-        {/* Withdraw Button (outline dark) */}
-        <button
-          className={`flex-1 font-bold rounded-lg py-3 px-2 flex items-center justify-center text-base transition focus:outline-none focus:ring-2 focus:ring-blue-300 shadow-none border-2
-            ${selected === 'withdraw' ? 'border-blue-400 text-white bg-[#12203a]/70' : 'border-blue-600 text-white bg-transparent'}
-            hover:bg-blue-900/20`}
-          onClick={() => { setSelected('withdraw'); onWithdraw?.(); }}
+        </DorkFiButton>
+        <DorkFiButton
+          type="button"
+          variant="withdraw"
+          className="w-full min-w-0 sm:flex-1 sm:min-w-0"
+          onClick={() => onWithdraw?.()}
         >
           Withdraw
-        </button>
+        </DorkFiButton>
       </div>
-      <div className="flex flex-row justify-between text-xs text-blue-200/90 mt-1">
-        <span>Supply APY: <span className="text-green-400 font-semibold">{marketData.supplyAPY.toFixed(2)}%</span></span>
-        <span>Borrow APY: <span className="text-yellow-400 font-semibold">{marketData.borrowAPY.toFixed(2)}%</span></span>
+      {onRepay && (
+        <DorkFiButton
+          type="button"
+          variant="secondary"
+          className="w-full"
+          onClick={() => onRepay()}
+        >
+          Repay
+        </DorkFiButton>
+      )}
+      <div className="flex flex-row flex-wrap justify-between gap-2 text-xs text-muted-foreground pt-1">
+        <span>
+          Supply APY:{' '}
+          <span className="text-green-600 dark:text-green-400 font-semibold">
+            {marketData.supplyAPY.toFixed(2)}%
+          </span>
+        </span>
+        <span>
+          Borrow APY:{' '}
+          <span className="text-amber-600 dark:text-amber-400 font-semibold">
+            {marketData.borrowAPY.toFixed(2)}%
+          </span>
+        </span>
       </div>
     </div>
   );

--- a/src/components/market-modal/UserPositionBar.tsx
+++ b/src/components/market-modal/UserPositionBar.tsx
@@ -1,10 +1,18 @@
 import React, { useState } from 'react';
 import { UserPosition } from './types';
 
-const StatCard = ({ label, value, color }: { label: string, value: string, color: string }) => (
-  <div className="flex-1 mx-1 min-w-[100px] bg-[#18233A] rounded-2xl px-0 py-4 shadow border border-white/5 flex flex-col items-center">
-    <div className="uppercase text-xs tracking-wide mb-1 text-blue-100/70">{label}</div>
-    <div className={`font-bold text-xl md:text-2xl ${color}`}>{value}</div>
+const StatCard = ({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color: string;
+}) => (
+  <div className="min-w-0 rounded-xl px-1 py-3 sm:py-4 shadow-sm border border-border bg-muted/40 dark:bg-muted/25 flex flex-col items-center">
+    <div className="uppercase text-xs tracking-wide mb-1 text-muted-foreground">{label}</div>
+    <div className={`font-bold text-base sm:text-xl md:text-2xl text-center break-all px-0.5 ${color}`}>{value}</div>
   </div>
 );
 
@@ -12,31 +20,54 @@ export const UserPositionBar = ({ userPosition }: { userPosition?: UserPosition 
   const [open, setOpen] = useState(true);
   if (!userPosition) return null;
   return (
-    <div className="px-0 mt-[-20px] mb-4">
-      {/* Dropdown bar */}
+    <div className="px-0 mb-2 min-w-0 w-full max-w-full overflow-x-hidden">
       <button
-        className="w-full flex items-center justify-between px-5 py-4 rounded-t-2xl bg-[#101729] border-b border-blue-50/10 hover:bg-[#162346] transition-colors group focus:outline-none"
-        onClick={() => setOpen(o => !o)}
+        type="button"
+        className="w-full flex items-center justify-between px-4 py-3 rounded-t-xl border border-b-0 border-border bg-muted/30 dark:bg-muted/20 hover:bg-muted/50 transition-colors group focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={() => setOpen((o) => !o)}
       >
-        <span className="flex items-center font-semibold text-base text-white">
-          <svg className="h-5 w-5 text-blue-300 mr-2" fill="none" viewBox="0 0 24 24"><rect width="24" height="24" fill="none"/><path d="M4 12h16" stroke="#60a5fa" strokeWidth="2" strokeLinecap="round"/></svg> Your Position
+        <span className="flex items-center font-semibold text-base text-foreground">
+          <svg
+            className="h-5 w-5 text-ocean-teal mr-2 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <path
+              d="M4 12h16"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          Your position
         </span>
         <svg
-          className={`w-6 h-6 ml-2 text-blue-100 transition-transform duration-300 ${open ? '' : '-rotate-90'}`}
+          className={`w-5 h-5 ml-2 text-muted-foreground transition-transform duration-300 shrink-0 ${open ? '' : '-rotate-90'}`}
           fill="none"
           viewBox="0 0 24 24"
+          aria-hidden
         >
-          <polyline points="6 9 12 15 18 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          <polyline
+            points="6 9 12 15 18 9"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
-      {/* Stat cards dropdown */}
       {open && (
-        <div className="bg-gradient-to-br from-[#0c1528] to-[#101c38] shadow-lg rounded-b-2xl border border-gray-800/80 flex flex-row gap-0 px-4 py-0 items-center w-full">
-          <StatCard label="Supplied" value={`$${userPosition.supplied}`} color="text-green-400" />
-          <StatCard label="Borrowed" value={`$${userPosition.borrowed}`} color="text-orange-400" />
-          <StatCard label="Withdrawable" value={`$${userPosition.withdrawable}`} color="text-cyan-300" />
-          <StatCard label="Borrowable" value={`$${userPosition.borrowable}`} color="text-blue-400" />
-          <StatCard label="Health Factor" value={userPosition.healthFactor.toFixed(2)} color="text-green-300" />
+        <div className="rounded-b-xl border border-t-0 border-border bg-muted/20 dark:bg-muted/15 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 px-2 py-3 items-stretch w-full min-w-0">
+          <StatCard label="Supplied" value={`$${userPosition.supplied}`} color="text-green-600 dark:text-green-400" />
+          <StatCard label="Borrowed" value={`$${userPosition.borrowed}`} color="text-orange-600 dark:text-orange-400" />
+          <StatCard label="Withdrawable" value={`$${userPosition.withdrawable}`} color="text-cyan-600 dark:text-cyan-400" />
+          <StatCard label="Borrowable" value={`$${userPosition.borrowable}`} color="text-blue-600 dark:text-blue-400" />
+          <StatCard
+            label="Health factor"
+            value={userPosition.healthFactor.toFixed(2)}
+            color="text-emerald-600 dark:text-emerald-400"
+          />
         </div>
       )}
     </div>

--- a/src/components/market-modal/UtilizationRatePanel.tsx
+++ b/src/components/market-modal/UtilizationRatePanel.tsx
@@ -1,28 +1,27 @@
 import React from 'react';
 
 interface UtilizationRatePanelProps {
-  utilization: number; // percent, e.g. 40 for 40%
+  utilization: number;
 }
 
 export const UtilizationRatePanel: React.FC<UtilizationRatePanelProps> = ({ utilization }) => (
-  <div className="p-4 bg-[#111b32] rounded-lg mb-4">
+  <div className="p-0 rounded-lg mb-0 min-w-0 w-full max-w-full overflow-x-hidden">
     <div className="flex justify-between items-center mb-1">
-      <span className="font-semibold text-white">Utilization Rate</span>
-      <span className="font-bold text-green-400 text-lg">
+      <span className="font-semibold text-foreground">Utilization rate</span>
+      <span className="font-bold text-ocean-teal text-lg">
         {utilization?.toFixed(1) ?? 0}%
       </span>
     </div>
-    <div className="relative h-3 w-full rounded-full bg-[#222c3f] mb-2 overflow-hidden">
+    <div className="relative h-3 w-full rounded-full bg-muted mb-2 overflow-hidden">
       <div
-        className="absolute left-0 top-0 h-3 rounded-full bg-green-400 transition-all"
-        style={{ width: `${utilization ?? 0}%` }}
-      ></div>
+        className="absolute left-0 top-0 h-3 rounded-full bg-ocean-teal/90 transition-all"
+        style={{ width: `${Math.min(100, utilization ?? 0)}%` }}
+      />
     </div>
-    <div className="flex flex-row justify-between items-center text-xs">
-      <span className="text-white/70">0%</span>
-      <span className="text-yellow-400 font-semibold">Optimal: 80%</span>
-      <span className="text-white/70">100%</span>
+    <div className="flex flex-row flex-wrap justify-between items-center gap-x-2 gap-y-0.5 text-[10px] sm:text-xs text-muted-foreground">
+      <span className="shrink-0">0%</span>
+      <span className="text-whale-gold font-semibold text-center min-w-0">Optimal: 80%</span>
+      <span className="shrink-0">100%</span>
     </div>
   </div>
 );
-

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -11,7 +11,7 @@ import { useNetwork } from "@/contexts/NetworkContext";
 import { useWallet } from "@txnlab/use-wallet-react";
 import STokenCard from "./STokenCard";
 import { ArrowRightLeft } from "lucide-react";
-import { getTokenConfig, getAllTokensWithDisplayInfo } from "@/config";
+import { getTokenConfig, getAllTokensWithDisplayInfo, getMarketLabel } from "@/config";
 import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
@@ -120,35 +120,19 @@ const MarketCardView = ({
     checkMigrationBalances();
   }, [markets, activeAccount?.address, currentNetwork]);
 
-  // Deduplicate markets by asset symbol and poolId
-  // For mobile, we show only one market per asset (preferring sToken if available)
+  // One card per asset+pool so A and B markets both appear on mobile
   const deduplicatedMarkets = useMemo(() => {
     const marketMap = new Map<string, OnDemandMarketData>();
-    
     markets.forEach((market) => {
-      const key = market.asset;
-      const existingMarket = marketMap.get(key);
-      
-      // If no existing market, add this one
-      if (!existingMarket) {
+      const poolId = market.marketInfo?.poolId || market.poolId || "default";
+      const key = `${market.asset}-${poolId}`;
+      const existing = marketMap.get(key);
+      if (!existing) {
         marketMap.set(key, market);
-      } else {
-        // Prefer sToken markets, otherwise keep the first one
-        // Also check by poolId to avoid true duplicates
-        const existingPoolId = existingMarket.marketInfo?.poolId || existingMarket.poolId;
-        const currentPoolId = market.marketInfo?.poolId || market.poolId;
-        
-        // If poolIds are different, prefer sToken
-        if (existingPoolId !== currentPoolId) {
-          if (market.isSToken && !existingMarket.isSToken) {
-            marketMap.set(key, market);
-          }
-          // If both are sTokens or both are not, keep the first one
-        }
-        // If poolIds match, it's a duplicate, keep existing
+      } else if (market.isSToken && !existing.isSToken) {
+        marketMap.set(key, market);
       }
     });
-    
     return Array.from(marketMap.values());
   }, [markets]);
 
@@ -162,6 +146,10 @@ const MarketCardView = ({
   return (
     <div className="space-y-4">
       {deduplicatedMarkets.map((market) => {
+        const poolIdForLabel =
+          market.marketInfo?.poolId || market.poolId || undefined;
+        const marketLabel = getMarketLabel(currentNetwork, poolIdForLabel);
+
         // Render special card for s-tokens
         if (market.isSToken) {
           // Use poolId in key to ensure uniqueness even if multiple markets exist
@@ -170,6 +158,7 @@ const MarketCardView = ({
             <STokenCard
               key={marketKey}
               market={market}
+              marketLabel={marketLabel}
               onRowClick={onRowClick}
               onInfoClick={onInfoClick}
               onDepositClick={onDepositClick}
@@ -191,7 +180,22 @@ const MarketCardView = ({
             {/* Header with logo, asset info, and info button */}
             <div className="flex flex-col items-center text-center md:flex-col-reverse md:items-start md:text-left md:justify-normal">
               <div className="flex items-center gap-3 flex-1">
-                <img src={market.icon} alt={market.asset} className="w-10 h-10 md:w-8 md:h-8 rounded-full object-contain flex-shrink-0" />
+                <div className="relative flex-shrink-0">
+                  <img src={market.icon} alt={market.asset} className="w-10 h-10 md:w-8 md:h-8 rounded-full object-contain flex-shrink-0" />
+                  {marketLabel && (
+                    <div
+                      className={`absolute -top-1 -right-1 w-5 h-5 rounded-full ${
+                        marketLabel === "A"
+                          ? "bg-blue-500 dark:bg-blue-600"
+                          : "bg-purple-500 dark:bg-purple-600"
+                      } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+                    >
+                      <span className="text-xs font-bold text-white">
+                        {marketLabel}
+                      </span>
+                    </div>
+                  )}
+                </div>
                 <div className="flex flex-col items-center justify-center gap-1 text-center flex-1">
                   <div className="font-semibold text-lg leading-tight">{market.asset}</div>
                   <Badge variant="outline" className="text-xs px-2 py-0.5 h-4 flex items-center justify-center whitespace-nowrap">

--- a/src/components/markets/MarketPoolBadge.tsx
+++ b/src/components/markets/MarketPoolBadge.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+interface MarketPoolBadgeProps {
+  label: string | null | undefined;
+  className?: string;
+}
+
+/**
+ * A/B lending pool indicator (matches markets table + portfolio badges).
+ */
+export function MarketPoolBadge({ label, className }: MarketPoolBadgeProps) {
+  if (!label) return null;
+  return (
+    <div
+      className={cn(
+        "absolute -top-1 -right-1 w-5 h-5 rounded-full border-2 border-white dark:border-slate-800 flex items-center justify-center z-10",
+        label === "A"
+          ? "bg-blue-500 dark:bg-blue-600"
+          : "bg-purple-500 dark:bg-purple-600",
+        className
+      )}
+    >
+      <span className="text-xs font-bold text-white leading-none">{label}</span>
+    </div>
+  );
+}

--- a/src/components/markets/STokenCard.tsx
+++ b/src/components/markets/STokenCard.tsx
@@ -9,6 +9,8 @@ import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 
 interface STokenCardProps {
   market: OnDemandMarketData;
+  /** A/B pool badge from parent (mobile card view). */
+  marketLabel?: string | null;
   onRowClick: (market: OnDemandMarketData) => void;
   onInfoClick: (e: React.MouseEvent, market: OnDemandMarketData) => void;
   onDepositClick: (asset: string) => void;
@@ -17,7 +19,8 @@ interface STokenCardProps {
 }
 
 const STokenCard = ({ 
-  market, 
+  market,
+  marketLabel,
   onRowClick, 
   onInfoClick, 
   onDepositClick, 
@@ -34,7 +37,20 @@ const STokenCard = ({
       {/* Header with logo, asset info, and info button */}
       <div className="flex flex-col items-center text-center md:flex-col-reverse md:items-start md:text-left md:justify-normal">
         <div className="flex items-center gap-3 flex-1">
-          <img src={market.icon} alt={market.asset} className="w-10 h-10 md:w-8 md:h-8 rounded-full object-contain flex-shrink-0" />
+          <div className="relative flex-shrink-0">
+            <img src={market.icon} alt={market.asset} className="w-10 h-10 md:w-8 md:h-8 rounded-full object-contain flex-shrink-0" />
+            {marketLabel && (
+              <div
+                className={`absolute -top-1 -right-1 w-5 h-5 rounded-full ${
+                  marketLabel === "A"
+                    ? "bg-blue-500 dark:bg-blue-600"
+                    : "bg-purple-500 dark:bg-purple-600"
+                } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+              >
+                <span className="text-xs font-bold text-white">{marketLabel}</span>
+              </div>
+            )}
+          </div>
           <div className="flex flex-col items-center justify-center gap-1 text-center flex-1">
             <div className="font-semibold text-lg leading-tight">{market.asset}</div>
             <Badge variant="outline" className="text-xs px-2 py-0.5 h-4 flex items-center justify-center whitespace-nowrap">

--- a/src/components/portfolio/AccruedInterestMobileCard.tsx
+++ b/src/components/portfolio/AccruedInterestMobileCard.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import { useNetwork } from "@/contexts/NetworkContext";
-import { getTokenConfig } from "@/config";
+import { getTokenConfig, getMarketLabel } from "@/config";
 
 interface AccruedInterestMobileCardProps {
   asset: string;
@@ -42,6 +42,8 @@ const AccruedInterestMobileCard = ({
     : tokenConfigRaw;
   const displayDecimals = Math.min((tokenConfig as { decimals?: number } | undefined)?.decimals ?? 6, 8);
 
+  const marketLabel = getMarketLabel(network || currentNetwork, poolId);
+
   const isNetPositive = netInterest > 0;
   const hasDeposits = (earnedInterest || 0) > 0;
   const hasBorrows = (owedInterest || 0) > 0;
@@ -56,11 +58,26 @@ const AccruedInterestMobileCard = ({
         {/* Header: Asset Icon + Name + Actions */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <img
-              src={icon}
-              alt={asset}
-              className="w-10 h-10 rounded-full flex-shrink-0"
-            />
+            <div className="relative flex-shrink-0">
+              <img
+                src={icon}
+                alt={asset}
+                className="w-10 h-10 rounded-full flex-shrink-0"
+              />
+              {marketLabel && (
+                <div
+                  className={`absolute -top-0.5 -right-0.5 w-5 h-5 rounded-full ${
+                    marketLabel === "A"
+                      ? "bg-blue-500 dark:bg-blue-600"
+                      : "bg-purple-500 dark:bg-purple-600"
+                  } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+                >
+                  <span className="text-[10px] font-bold text-white leading-none">
+                    {marketLabel}
+                  </span>
+                </div>
+              )}
+            </div>
             <div>
               <div className="font-semibold text-base text-slate-800 dark:text-white">
                 {asset}

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -3,7 +3,7 @@ import { Plus, Minus, RefreshCw, Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import { useNetwork } from "@/contexts/NetworkContext";
-import { getTokenConfig } from "@/config";
+import { getTokenConfig, getMarketLabel } from "@/config";
 
 interface PortfolioTableMobileCardProps {
   asset: string;
@@ -61,6 +61,11 @@ const PortfolioTableMobileCard = ({
     : tokenConfigRaw;
   const displayDecimals = Math.min((tokenConfig as { decimals?: number } | undefined)?.decimals ?? 6, 8);
 
+  const marketLabel = getMarketLabel(
+    network || currentNetwork,
+    poolId
+  );
+
   const isDeposit = type === "deposit";
   const valueColor = isDeposit ? "text-green-400" : "text-red-400";
   const apyColor = isDeposit ? "text-green-400" : "text-red-400";
@@ -74,11 +79,26 @@ const PortfolioTableMobileCard = ({
         {/* Header: Asset Icon above Ticker + Actions */}
         <div className="flex items-center justify-between">
           <div className="flex flex-col items-center gap-1">
-            <img
-              src={icon}
-              alt={asset}
-              className="w-12 h-12 rounded-full flex-shrink-0"
-            />
+            <div className="relative flex-shrink-0">
+              <img
+                src={icon}
+                alt={asset}
+                className="w-12 h-12 rounded-full flex-shrink-0"
+              />
+              {marketLabel && (
+                <div
+                  className={`absolute -top-0.5 -right-0.5 w-5 h-5 rounded-full ${
+                    marketLabel === "A"
+                      ? "bg-blue-500 dark:bg-blue-600"
+                      : "bg-purple-500 dark:bg-purple-600"
+                  } border-2 border-white dark:border-slate-800 flex items-center justify-center z-10`}
+                >
+                  <span className="text-[10px] font-bold text-white leading-none">
+                    {marketLabel}
+                  </span>
+                </div>
+              )}
+            </div>
             <div className="text-center">
               <div className="font-semibold text-base text-slate-800 dark:text-white">
                 {asset}

--- a/src/hooks/useMimirTokenPrice24h.ts
+++ b/src/hooks/useMimirTokenPrice24h.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from "react";
+import { MimirApiService } from "@/services/mimirApi";
+import type { PriceDataPoint } from "@/types/mimirTypes";
+
+/** Lending assets quoted vs themselves / USD stable — no meaningful Mimir pair. */
+const STABLE_ASSET_SYMBOLS = new Set(
+  ["USDC", "USDT", "DAI", "aUSDC", "XUSD"].map((s) => s.toUpperCase())
+);
+
+function parseTs(t: string): number {
+  const n = Date.parse(t);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function computeChange24h(sorted: PriceDataPoint[]): number {
+  if (sorted.length < 2) return 0;
+  const first = sorted[0]!.price;
+  const last = sorted[sorted.length - 1]!.price;
+  if (!(first > 0) || !Number.isFinite(last)) return 0;
+  return ((last - first) / first) * 100;
+}
+
+export interface TokenPrice24hPoint {
+  time: number;
+  price: number;
+}
+
+export interface UseMimirTokenPrice24hResult {
+  priceChange24h: number;
+  priceHistory: TokenPrice24hPoint[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * 24h USD-ish price series from Mimir (token vs USDC) for sparkline + % change.
+ * Fetches only when `enabled` (e.g. modal open).
+ */
+export function useMimirTokenPrice24h(
+  symbol: string,
+  enabled: boolean
+): UseMimirTokenPrice24hResult {
+  const [priceChange24h, setPriceChange24h] = useState(0);
+  const [priceHistory, setPriceHistory] = useState<TokenPrice24hPoint[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch24h = useCallback(async () => {
+    if (!enabled || !symbol?.trim()) {
+      setPriceChange24h(0);
+      setPriceHistory([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const upper = symbol.trim().toUpperCase();
+    if (STABLE_ASSET_SYMBOLS.has(upper)) {
+      setPriceChange24h(0);
+      setPriceHistory([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const points = await MimirApiService.getPriceHistory(
+        symbol.trim(),
+        "USDC",
+        "1h",
+        "24h"
+      );
+      const sorted = [...points].sort(
+        (a, b) => parseTs(a.timestamp) - parseTs(b.timestamp)
+      );
+      const history: TokenPrice24hPoint[] = sorted.map((p) => ({
+        time: parseTs(p.timestamp),
+        price: p.price,
+      }));
+      setPriceChange24h(computeChange24h(sorted));
+      setPriceHistory(history);
+    } catch (e) {
+      setPriceChange24h(0);
+      setPriceHistory([]);
+      setError(e instanceof Error ? e.message : "Failed to load 24h price");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [symbol, enabled]);
+
+  useEffect(() => {
+    void fetch24h();
+  }, [fetch24h]);
+
+  return { priceChange24h, priceHistory, isLoading, error };
+}

--- a/src/hooks/useUserAssets.ts
+++ b/src/hooks/useUserAssets.ts
@@ -9,6 +9,8 @@ import { getAllTokensWithDisplayInfo } from '@/config';
 
 export interface UserAsset {
   symbol: string;
+  /** Lending pool app id when position is pool-specific (for A/B market labels). */
+  poolId?: string;
   contractId: string;
   depositBalance: number;
   borrowBalance: number;
@@ -98,6 +100,7 @@ export const useUserAssets = (userAddress: string) => {
           if (depositBalance > 0 || borrowBalance > 0) {
             assets.push({
               symbol: token.symbol,
+              poolId: token.poolId,
               contractId: token.underlyingContractId,
               depositBalance,
               borrowBalance,

--- a/src/index.css
+++ b/src/index.css
@@ -182,6 +182,19 @@
     background-position: center;
     background-repeat: no-repeat;
   }
+
+  /* Modal-safe site background (no pseudo-element overlay layering). */
+  .dorkfi-dark-bg-modal {
+    background-image: linear-gradient(
+        to bottom,
+        hsl(var(--deep-sea-navy) / 0.7),
+        hsl(var(--deep-sea-navy) / 0.7)
+      ),
+      url('/lovable-uploads/dorkfi_bg_03.png');
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
   
   .light-mode-beach-bg {
     background-image: url('/lovable-uploads/beach_banner.png');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,35 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Strip trailing zeros after decimal while keeping a non-empty fractional part when present. */
+function stripTrailingZerosDecimal(s: string): string {
+  if (!s.includes(".")) return s
+  return s.replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.$/, "")
+}
+
+/**
+ * Format USD price per whole token for UI: 2 decimals when ≥ $0.01; extra decimals
+ * when the value would otherwise show as $0.00 (e.g. VOI).
+ */
+export function formatUsdPerTokenDisplay(price: number): string {
+  if (price == null || !Number.isFinite(price)) return "0.00"
+  if (price === 0) return "0.00"
+
+  const abs = Math.abs(price)
+  if (abs >= 0.01) {
+    return price.toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  }
+
+  for (let d = 3; d <= 10; d++) {
+    const s = price.toFixed(d)
+    if (parseFloat(s) !== 0) {
+      return stripTrailingZerosDecimal(s)
+    }
+  }
+
+  return stripTrailingZerosDecimal(price.toExponential(4))
+}


### PR DESCRIPTION
## Summary
- improve market modal UX and responsiveness to remove horizontal overflow on mobile
- make price display and 24h movement more accurate: adaptive small-price formatting, 24h change wiring, and trend sparkline color by direction
- add market detail enrichments and shared A/B market labeling components across modal/cards

## Test plan
- [x] run `npx tsc --noEmit`
- [x] verify market detail modal opens from Markets table rows
- [x] verify 24h change and sparkline render in header and sparkline color matches positive/negative change
- [x] verify very small prices (e.g. VOI) display with additional decimals instead of `$0.00`
- [x] verify no horizontal scroll on iPhone width in market modal sections
- [x] verify Earnings calculator cards are 50/50 width on desktop/tablet


Made with [Cursor](https://cursor.com)