### PR TITLE
feat: add AlgoVoi wallet support

### DIFF
--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -57,6 +57,13 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
           isInstalled: true,
         },
         {
+          id: "algovoi",
+          name: "AlgoVoi",
+          icon: wallets.find((w) => w.id === "algovoi")?.metadata.icon || "",
+          description: "Connect with AlgoVoi wallet (Algorand/VOI)",
+          isInstalled: true,
+        },
+        {
           id: "lute",
           name: "Lute",
           icon: wallets.find((w) => w.id === "lute")?.metadata.icon || "🔗",
@@ -174,6 +181,15 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
         if (provider.id === "biatec" && availableWalletIds.includes("biatec")) {
           return true;
         }
+        // Show AlgoVoi if registered in WalletManager OR if the extension is detected directly
+        // (window.algorand detection bridges the gap before TxnLab/use-wallet#434 lands)
+        if (
+          provider.id === "algovoi" &&
+          (availableWalletIds.includes("algovoi") ||
+            (typeof window !== "undefined" && (window as any).algorand?.isAlgoVoi === true))
+        ) {
+          return true;
+        }
         // Show other wallets if they're available or not installed
         return (
           availableWalletIds.includes(provider.id) || !provider.isInstalled
@@ -250,6 +266,24 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
 
       // For AVM networks, find the wallet from the wallets array
       if (isAVM) {
+        // Handle AlgoVoi: use window.algorand directly until TxnLab/use-wallet#434 lands
+        if (providerId === "algovoi") {
+          const algoVoiProvider = (window as any).algorand;
+          if (!algoVoiProvider?.isAlgoVoi) {
+            throw new Error("AlgoVoi extension not detected. Please install it and reload.");
+          }
+          const registeredWallet = wallets.find((w) => w.id === "algovoi");
+          if (registeredWallet) {
+            await registeredWallet.connect();
+          } else {
+            // Fallback: trigger ARC-27 enable directly
+            const accounts = await algoVoiProvider.enable({ genesisHash: undefined });
+            if (!accounts?.accounts?.length) throw new Error("No accounts returned");
+          }
+          if (abortController.signal.aborted) return;
+          if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
+          toast({ title: "AlgoVoi Connected", description: "Successfully connected to AlgoVoi" });
+        } else
         // Handle Vera Wallet specifically (uses WalletConnect)
         if (providerId === "vera") {
           const walletConnectWallet = wallets.find(

--- a/src/contexts/NetworkContext.tsx
+++ b/src/contexts/NetworkContext.tsx
@@ -122,6 +122,9 @@ export const NetworkProvider: React.FC<NetworkProviderProps> = ({
       // This allows switching to any network without disconnecting the wallet
       return [
         WalletId.KIBISIS,
+        // AlgoVoi: ARC-27 browser extension wallet (Algorand + Voi)
+        // Replace 'algovoi' with WalletId.ALGOVOI once TxnLab/use-wallet#434 lands
+        'algovoi' as any,
         {
           id: WalletId.LUTE,
           options: { siteName: "DorkFi" },
@@ -178,7 +181,7 @@ export const NetworkProvider: React.FC<NetworkProviderProps> = ({
     const walletNameLower = (walletName || "").toLowerCase();
 
     // Universal wallets support all AVM networks
-    if (walletIdLower === "lute" || walletIdLower === "kibisis") {
+    if (walletIdLower === "lute" || walletIdLower === "kibisis" || walletIdLower === "algovoi") {
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Adds **AlgoVoi** to the wallet selection modal for all AVM networks (Algorand + Voi)
- Registers `'algovoi'` in `WalletManager` (NetworkContext) alongside existing AVM wallets
- Marks AlgoVoi as a **universal wallet** — supports both Algorand Mainnet and Voi Mainnet
- Connection handler detects the extension directly via `window.algorand.isAlgoVoi` as a fallback, so it works today without waiting for the npm package

## How it works

AlgoVoi is a browser extension wallet that injects an ARC-27 compliant `window.algorand` provider. The connect flow:

1. If `WalletId.ALGOVOI` is registered in use-wallet (after [TxnLab/use-wallet#434](https://github.com/TxnLab/use-wallet/pull/434) lands) → uses the standard use-wallet path
2. Until then → falls back to calling `window.algorand.enable()` directly via ARC-27

This means **the button works immediately** for users who have AlgoVoi installed, and the integration upgrades automatically once the use-wallet package ships the named provider.

## Files changed

- `src/contexts/NetworkContext.tsx` — register `'algovoi'` in `getWalletsForNetwork()`, add to universal wallet list in `isNetworkSupportedByWallet()`
- `src/components/WalletModal.tsx` — add AlgoVoi entry to `baseWallets`, availability check via `window.algorand.isAlgoVoi`, dedicated connection handler

## Links

- AlgoVoi extension: https://github.com/chopmob-cloud/AlgoVoi
- use-wallet PR: https://github.com/TxnLab/use-wallet/pull/434

## Test plan

- [ ] Install AlgoVoi Chrome extension
- [ ] Open DorkFi on Voi Mainnet → Connect Wallet → AlgoVoi appears in the list
- [ ] Click Connect → AlgoVoi popup opens → approve → wallet connects
- [ ] Switch to Algorand Mainnet → AlgoVoi still available
- [ ] Without AlgoVoi installed → button does not appear
