### PR TITLE
fix: APY market tooltips (portal + single-asset display)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.602",
+  "version": "0.1.603",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/APYDisplay.tsx
+++ b/src/components/APYDisplay.tsx
@@ -63,7 +63,7 @@ export const APYDisplay: React.FC<APYDisplayProps> = ({
       ? "h-3 w-3 text-black/55"
       : "h-3 w-3 text-gray-400 hover:text-gray-600";
 
-  if (!showTooltip || (!apyCalculation && bonus <= 0 && intrinsic <= 0)) {
+  if (!showTooltip) {
     return (
       <span className={`font-medium ${colorClass} ${className}`}>
         {formattedAPY}
@@ -128,11 +128,9 @@ export const APYDisplay: React.FC<APYDisplayProps> = ({
         </div>
       </div>
 
-      {apyCalculation ? (
-        <div className="text-xs text-gray-400 mt-2">
-          APY = (1 + daily_supply_rate)^365 - 1
-        </div>
-      ) : null}
+      <div className="text-xs text-gray-400 mt-2">
+        APY = (1 + daily_supply_rate)^365 - 1
+      </div>
     </div>
   );
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -13,17 +13,19 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    collisionPadding={8}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-xl animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      "max-w-[calc(100vw-2rem)] sm:max-w-sm md:max-w-md whitespace-normal break-words text-left leading-snug",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={8}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-xl animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "max-w-[calc(100vw-2rem)] sm:max-w-sm md:max-w-md whitespace-normal break-words text-left leading-snug",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
## Summary
Addresses [dorkfi-app#285](https://github.com/DorkFi/dorkfi-app/issues/285) (deposit APY tooltip missing or clipped in market view).

## Changes
- **Portal tooltip content** — Radix `TooltipContent` is wrapped in `TooltipPrimitive.Portal` so tooltips render under `document.body` and are not clipped by table/scroll containers (`overflow-*`).
- **APYDisplay** — Remove the guard that skipped the interactive tooltip when `apyCalculation` was missing and there were no intrinsic/bonus add-ons (single-asset / ALGO-only cases could hit this). Always show the formula footnote.

## Test plan
- [ ] Markets table: hover deposit APY (single-asset pool and multi-asset).
- [ ] Confirm tooltip is fully visible (not cut off at top).
- [ ] Spot-check other tooltips (headers, portfolio) still behave.

## Notes
- Pre-commit bumped `package.json` version per repo hook.

Made with [Cursor](https://cursor.com)