### PR TITLE
Premium market modal: chain refresh and borrow curve params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.603",
+  "version": "0.1.604",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -117,6 +117,21 @@ function normalizeMarketData(md: Record<string, unknown>) {
 
   const utilization = Number(md.utilization ?? 0);
 
+  const parseRateFraction = (v: unknown): number | undefined => {
+    if (typeof v === "number" && Number.isFinite(v)) {
+      return v > 1 ? v / 10000 : v;
+    }
+    if (typeof v === "string" && v.trim() !== "") {
+      const n = Number.parseFloat(v.replace(/,/g, ""));
+      if (Number.isFinite(n)) return n > 1 ? n / 10000 : n;
+    }
+    return undefined;
+  };
+  const borrowRateFrac =
+    parseRateFraction(mi?.borrowRate) ?? parseRateFraction(md.borrowRate);
+  const slopeFrac =
+    parseRateFraction(mi?.slope) ?? parseRateFraction(md.slope);
+
   const baseSupplyApy = Number(md.supplyAPY ?? 0);
   const rewardsBonus =
     typeof md.rewardsBonusSupplyAprPercent === "number" &&
@@ -143,6 +158,8 @@ function normalizeMarketData(md: Record<string, unknown>) {
     utilization,
     supplyAPY: baseSupplyApy + rewardsBonus + intrinsicBonus,
     borrowAPY: Number(md.borrowAPY ?? 0),
+    ...(borrowRateFrac !== undefined ? { borrowRate: borrowRateFrac } : {}),
+    ...(slopeFrac !== undefined ? { slope: slopeFrac } : {}),
     maxLTV: Number(md.maxLTV ?? md.collateralFactor ?? 0),
     liquidationThreshold: Number(md.liquidationThreshold ?? 0),
     liquidationBonus: Number(
@@ -165,6 +182,31 @@ function poolIdFromMarketRow(market: Record<string, unknown>): string | undefine
   const mi = market.marketInfo as { poolId?: string } | undefined;
   if (mi?.poolId != null && String(mi.poolId) !== "") return String(mi.poolId);
   return undefined;
+}
+
+/** Matches `useOnDemandMarketData` cache keys (`symbol` or `symbol-poolId`). */
+function marketKeyForOnDemandLoad(asset: string, poolId?: string): string {
+  return poolId != null && poolId !== ""
+    ? `${asset.toLowerCase()}-${String(poolId)}`
+    : asset.toLowerCase();
+}
+
+/** Find the current row on the markets page (same asset + pool); used to merge fresh chain data into the detail modal. */
+function findMarketRowOnPage(
+  pageMarkets: Record<string, unknown>[],
+  asset: string,
+  poolId?: string
+): Record<string, unknown> | null {
+  if (poolId != null && poolId !== "") {
+    const found = pageMarkets.find(
+      (m) =>
+        String(m.asset) === asset &&
+        String((m.poolId as string | undefined) ?? "") === String(poolId)
+    );
+    return found ?? null;
+  }
+  const found = pageMarkets.find((m) => String(m.asset) === asset);
+  return found ?? null;
 }
 
 function networkIdToChainId(
@@ -1050,6 +1092,8 @@ const MarketsTable = () => {
       poolId,
       marketData: market,
     });
+    // Fresh on-chain read for modal (fetchMarketInfo(..., "contract") via useOnDemandMarketData).
+    void loadMarketDataWithBypass(marketKeyForOnDemandLoad(asset, poolId));
   };
 
   const handleRowClick = (market: Record<string, unknown>) => {
@@ -1069,6 +1113,33 @@ const MarketsTable = () => {
       marketData: null,
     });
   };
+
+  // When the detail modal is open, replace the snapshot row with the refreshed row from
+  // `loadMarketDataWithBypass` (chain-sourced marketInfo) once it lands in `markets`.
+  // Compare `lastFetched` so we do not churn on unrelated `markets` remaps (e.g. rewards APR).
+  useEffect(() => {
+    if (!detailModal.isOpen || !detailModal.asset) return;
+    const fresh = findMarketRowOnPage(
+      markets as Record<string, unknown>[],
+      detailModal.asset,
+      detailModal.poolId
+    );
+    if (!fresh) return;
+    setDetailModal((prev) => {
+      if (!prev.isOpen || !prev.marketData) return prev;
+      if (fresh === prev.marketData) return prev;
+      const prevLast = (prev.marketData as { lastFetched?: number }).lastFetched;
+      const freshLast = (fresh as { lastFetched?: number }).lastFetched;
+      if (
+        prevLast !== undefined &&
+        freshLast !== undefined &&
+        freshLast <= prevLast
+      ) {
+        return prev;
+      }
+      return { ...prev, marketData: fresh };
+    });
+  }, [markets, detailModal.isOpen, detailModal.asset, detailModal.poolId]);
 
   // Load all markets when component mounts
   useEffect(() => {

--- a/src/components/market-modal/MarketOverview.tsx
+++ b/src/components/market-modal/MarketOverview.tsx
@@ -46,6 +46,12 @@ const UtilizationBar = ({ percent }: { percent: number }) => (
   </div>
 );
 
+function formatCurveRateFraction(v: number | undefined): string {
+  if (v === undefined || !Number.isFinite(v)) return "—";
+  const pct = v > 1 ? v : v * 100;
+  return `${pct.toFixed(2)}%`;
+}
+
 export const MarketOverview = ({ marketData }: { marketData: MarketData }) => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 px-0 mb-0 min-w-0 w-full">
@@ -67,6 +73,18 @@ export const MarketOverview = ({ marketData }: { marketData: MarketData }) => {
         color="text-orange-600 dark:text-orange-400"
         subtitle={`${marketData.borrowAPY.toFixed(2)}% APY`}
       />
+      <div className="min-w-0 w-full sm:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <OverviewItem
+          title="Borrow rate (base)"
+          value={formatCurveRateFraction(marketData.borrowRate)}
+          subtitle="Curve intercept at 0% utilization"
+        />
+        <OverviewItem
+          title="Slope"
+          value={formatCurveRateFraction(marketData.slope)}
+          subtitle="Per 100% utilization"
+        />
+      </div>
       <div className="min-w-0 w-full sm:col-span-2">
         <span className="block text-xs text-muted-foreground mb-1">Utilization rate</span>
         <UtilizationBar percent={marketData.utilization ?? 0} />

--- a/src/components/market-modal/types.ts
+++ b/src/components/market-modal/types.ts
@@ -13,6 +13,10 @@ export interface MarketData {
   utilization: number;
   supplyAPY: number;
   borrowAPY: number;
+  /** Base borrow rate from the interest curve (fraction 0–1, e.g. 0.02 = 2%). */
+  borrowRate?: number;
+  /** Utilization slope on the borrow curve (fraction 0–1). */
+  slope?: number;
   maxLTV: number;
   liquidationThreshold: number;
   liquidationBonus: number;


### PR DESCRIPTION
## Summary
- **Market overview:** Show **borrow rate (base)** and **slope** in `PremiumMarketModal` (`MarketOverview`), backed by optional `MarketData.borrowRate` / `slope`.
- **Normalization:** `normalizeMarketData` reads curve params from `marketInfo` or top-level row fields, accepting fraction or bps-style values.
- **Fresh chain data:** On market detail open, call `loadMarketDataWithBypass` so `fetchMarketInfo(..., "contract")` runs. A `useEffect` merges the updated row when `markets` reflects a newer `lastFetched`, avoiding stale snapshots and unnecessary updates on reward-only remaps.

## Notes
- Pre-commit bumped `package.json` version (0.1.604).

## Testing
- `npx tsc --noEmit`

Made with [Cursor](https://cursor.com)