### PR TITLE
feat: rewards bonus APR, React Query, markets modal fetch fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "0.1.582",
+  "version": "0.1.597",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "0.1.582",
+      "version": "0.1.597",
       "dependencies": {
         "@agoralabs-sh/avm-web-provider": "^1.7.0",
         "@algorandfoundation/algokit-utils": "^9.1.2",

--- a/src/components/APYDisplay.tsx
+++ b/src/components/APYDisplay.tsx
@@ -63,7 +63,10 @@ export const APYDisplay: React.FC<APYDisplayProps> = ({
       ? "h-3 w-3 text-black/55"
       : "h-3 w-3 text-gray-400 hover:text-gray-600";
 
-  if (!showTooltip) {
+  if (
+    !showTooltip ||
+    (!apyCalculation && bonus <= 0 && intrinsic <= 0)
+  ) {
     return (
       <span className={`font-medium ${colorClass} ${className}`}>
         {formattedAPY}
@@ -115,7 +118,7 @@ export const APYDisplay: React.FC<APYDisplayProps> = ({
 
         {bonus > 0 ? (
           <div className="flex justify-between">
-            <span className="text-gray-300">Bonus rewards:</span>
+            <span className="text-gray-300">Bonus rewards (target / supply):</span>
             <span className="text-emerald-300 font-mono">+{formatAPY(bonus)}</span>
           </div>
         ) : null}
@@ -128,9 +131,11 @@ export const APYDisplay: React.FC<APYDisplayProps> = ({
         </div>
       </div>
 
-      <div className="text-xs text-gray-400 mt-2">
-        APY = (1 + daily_supply_rate)^365 - 1
-      </div>
+      {apyCalculation ? (
+        <div className="text-xs text-gray-400 mt-2">
+          APY = (1 + daily_supply_rate)^365 - 1
+        </div>
+      ) : null}
     </div>
   );
 

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -2561,7 +2561,9 @@ const MarketsTable = () => {
     detailModal.marketData,
     activeAccount?.address,
     currentNetwork,
-    markets,
+    // Not `markets`: that list is rebuilt on every row/rewards update and caused a full
+    // Promise.all per tick while the modal stayed open. `detailModal.marketData` is enough;
+    // the sync effect updates it when the selected row’s `lastFetched` advances.
   ]);
 
   return (

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -125,6 +125,7 @@ const Portfolio = () => {
   const navigate = useNavigate();
   const { activeAccount, signTransactions, activeWallet } = useWallet();
   const { currentNetwork } = useNetwork();
+  const rewardsAprByBaseUrl = useRewardsAprBonusMap(getEnabledNetworks());
   const { formatNumber, formatCurrency, formatPercent } = useNumberI18n();
 
   const rewardsAprNetworks = useMemo(
@@ -1539,9 +1540,16 @@ const Portfolio = () => {
         asset: deposit.asset,
         icon: deposit.icon,
         value: deposit.value,
-        apy: deposit.apy,
+        apy:
+          deposit.apy +
+          getRewardsBonusSupplyAprPercent(
+            (deposit as ItemWithNetwork).network ?? currentNetwork,
+            deposit.asset,
+            deposit.poolId,
+            rewardsAprByBaseUrl
+          ),
       }));
-  }, [deposits]);
+  }, [deposits, rewardsAprByBaseUrl, currentNetwork]);
 
   const modalBorrows = useMemo(() => {
     return borrows
@@ -5439,6 +5447,15 @@ const Portfolio = () => {
                         return (
                           <>
                             {displayDeposits.map((deposit) => {
+                              const rewardsBonusApr = getRewardsBonusSupplyAprPercent(
+                                (deposit as ItemWithNetwork).network ??
+                                  currentNetwork,
+                                deposit.asset,
+                                deposit.poolId,
+                                rewardsAprByBaseUrl
+                              );
+                              const depositApyWithRewards =
+                                deposit.apy + rewardsBonusApr;
                               const market = marketData.find(
                                 (m) =>
                                   m.symbol === deposit.asset &&

--- a/src/config/__tests__/rewardsPublicBaseUrl.test.ts
+++ b/src/config/__tests__/rewardsPublicBaseUrl.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_REWARDS_PROVIDER_HOST,
+  getRewardsProgramPublicBaseUrl,
+  getRewardsPublicProviderHost,
+  normalizeRewardsPublicBaseUrl,
+  REWARDS_PROGRAM_PUBLIC_BASE_URL_REGISTRY,
+  resolveRewardsRegistryEntryToOrigin,
+} from "../index";
+
+describe("normalizeRewardsPublicBaseUrl", () => {
+  it("trims and strips trailing slashes", () => {
+    expect(normalizeRewardsPublicBaseUrl("  https://x.example.com/  ")).toBe(
+      "https://x.example.com"
+    );
+    expect(normalizeRewardsPublicBaseUrl("https://x.example.com///")).toBe(
+      "https://x.example.com"
+    );
+  });
+});
+
+describe("getRewardsPublicProviderHost", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults to rewards.nautilus.sh", () => {
+    expect(DEFAULT_REWARDS_PROVIDER_HOST).toBe("rewards.nautilus.sh");
+    expect(getRewardsPublicProviderHost()).toBe("rewards.nautilus.sh");
+  });
+
+  it("respects VITE_REWARDS_PROVIDER_HOST", () => {
+    vi.stubEnv("VITE_REWARDS_PROVIDER_HOST", "rewards.example.com");
+    expect(getRewardsPublicProviderHost()).toBe("rewards.example.com");
+  });
+
+  it("strips scheme from a full URL value", () => {
+    vi.stubEnv("VITE_REWARDS_PROVIDER_HOST", "https://staging.rewards.example.com/");
+    expect(getRewardsPublicProviderHost()).toBe("staging.rewards.example.com");
+  });
+});
+
+describe("resolveRewardsRegistryEntryToOrigin", () => {
+  it("builds https origin from instance id and provider host override", () => {
+    expect(
+      resolveRewardsRegistryEntryToOrigin("fa00f0044fc97455", "rewards.example.com")
+    ).toBe("https://fa00f0044fc97455.rewards.example.com");
+  });
+
+  it("accepts a full URL as registry value", () => {
+    expect(
+      resolveRewardsRegistryEntryToOrigin("https://legacy.example.com/app/")
+    ).toBe("https://legacy.example.com/app");
+  });
+});
+
+describe("getRewardsProgramPublicBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the registered origin for a known network/pool/contract triple", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "algorand-mainnet",
+        "47139781",
+        "47138068"
+      )
+    ).toBe("https://fa00f0044fc97455.rewards.nautilus.sh");
+  });
+
+  it("normalizes network id case for registry lookup", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "ALGORAND-MAINNET",
+        "47139781",
+        "47138068"
+      )
+    ).toBe("https://fa00f0044fc97455.rewards.nautilus.sh");
+  });
+
+  it("uses VITE_REWARDS_PROVIDER_HOST when resolving instance id", () => {
+    vi.stubEnv("VITE_REWARDS_PROVIDER_HOST", "rewards.example.com");
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "algorand-mainnet",
+        "47139781",
+        "47138068"
+      )
+    ).toBe("https://fa00f0044fc97455.rewards.example.com");
+  });
+
+  it("returns null for an unknown triple", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "algorand-mainnet",
+        "47139781",
+        "99999999"
+      )
+    ).toBe(null);
+  });
+
+  it("returns null when any key part is missing", () => {
+    expect(getRewardsProgramPublicBaseUrl(null, "1", "2")).toBe(null);
+    expect(getRewardsProgramPublicBaseUrl("voi-mainnet", undefined, "2")).toBe(
+      null
+    );
+    expect(getRewardsProgramPublicBaseUrl("voi-mainnet", "1", null)).toBe(null);
+  });
+
+  it("uses token rewardsPublicBaseUrl override when defined (wins over registry)", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "algorand-mainnet",
+        "47139781",
+        "47138068",
+        { rewardsPublicBaseUrl: "https://override.example.com/path/" }
+      )
+    ).toBe("https://override.example.com/path");
+    expect(
+      REWARDS_PROGRAM_PUBLIC_BASE_URL_REGISTRY["algorand-mainnet:47139781:47138068"]
+    ).toBe("fa00f0044fc97455");
+  });
+
+  it("uses token rewardsInstanceId over registry (same triple)", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl(
+        "algorand-mainnet",
+        "47139781",
+        "47138068",
+        { rewardsInstanceId: "tokenrow-instance-id" }
+      )
+    ).toBe("https://tokenrow-instance-id.rewards.nautilus.sh");
+  });
+
+  it("prefers rewardsPublicBaseUrl over rewardsInstanceId when both are set", () => {
+    expect(
+      getRewardsProgramPublicBaseUrl("algorand-mainnet", "47139781", "47138068", {
+        rewardsPublicBaseUrl: "https://full-url.wins/",
+        rewardsInstanceId: "ignored-instance",
+      })
+    ).toBe("https://full-url.wins");
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -78,12 +78,13 @@ export interface TokenConfig {
   hasRewards?: boolean;
   /**
    * Optional deployment instance id for this row (`https://{id}.{provider host}`). Used when
-   * `rewardsPublicBaseUrl` is unset; overrides the global registry for the same `(networkId, poolId, contractId)`.
+   * {@link rewardsPublicBaseUrl} is unset; wins over the global registry for the same
+   * `(networkId, poolId, contractId)`.
    */
   rewardsInstanceId?: string;
   /**
    * Optional full HTTPS origin for the rewards app (highest-priority override). When set, ignores
-   * registry and `VITE_REWARDS_PROVIDER_HOST` for the origin host.
+   * {@link rewardsInstanceId}, registry, and `VITE_REWARDS_PROVIDER_HOST` for the origin host.
    */
   rewardsPublicBaseUrl?: string;
   /** ISO 8601 timestamp when this token row was added to config (optional metadata). */
@@ -854,6 +855,7 @@ const prodTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
       symbol: "WAD",
       logoPath: "/lovable-uploads/WAD_fixed.png",
       tokenStandard: "arc200",
+      hasRewards: true,
     },
   ],
 };
@@ -2159,6 +2161,8 @@ export function resolveRewardsRegistryEntryToOrigin(
 export const REWARDS_PROGRAM_PUBLIC_BASE_URL_REGISTRY: Record<string, string> = {
   // ALGO @ A market — matches rewards API `dorkfi` cohort (algorand-mainnet / pool / contract)
   "algorand-mainnet:3333688282:3207744109": "fa00f0044fc97455",
+  // Algorand mainnet — B market WAD (`hasRewards` row for WAD @ pool 47139781)
+  "algorand-mainnet:47139781:47138068": "fa00f0044fc97455",
 };
 
 /** Fields used when resolving rewards URLs from a token row (see {@link getRewardsProgramPublicBaseUrl}). */
@@ -2168,9 +2172,12 @@ export type TokenRewardsUrlFields = Pick<
 >;
 
 /**
- * `(networkId, poolId, contractId)` → public rewards app origin, or `null`.
+ * Single resolver: `(networkId, poolId, contractId)` → public rewards app origin, or `null` if none.
  *
- * Priority: `token.rewardsPublicBaseUrl` → `token.rewardsInstanceId` → registry + provider host.
+ * **Priority (highest first):**
+ * 1. `token.rewardsPublicBaseUrl` — full origin; ignores registry and provider host.
+ * 2. `token.rewardsInstanceId` — `{instance}.{VITE_REWARDS_PROVIDER_HOST or default}`; ignores registry.
+ * 3. {@link REWARDS_PROGRAM_PUBLIC_BASE_URL_REGISTRY} for `(networkId, poolId, contractId)` + provider host.
  */
 export const getRewardsProgramPublicBaseUrl = (
   networkId: NetworkId | string | null | undefined,

--- a/src/hooks/useRewardsAprBonusMap.ts
+++ b/src/hooks/useRewardsAprBonusMap.ts
@@ -11,7 +11,8 @@ import { fetchRewardAprStats } from "@/services/rewardAprStatsService";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Fetches and caches `targetAprAdjustedToSupplyPercent` per rewards deployment origin (24h).
+ * Fetches and caches `targetAprAdjustedToSupplyPercent` per rewards deployment origin
+ * (24h). React Query dedupes with Markets table when the same origins are used.
  */
 export function useRewardsAprBonusMap(networkIds: NetworkId[]) {
   const baseUrls = useMemo(() => {


### PR DESCRIPTION
## Summary
- Wraps the app in `QueryClientProvider` (TanStack Query) with conservative defaults.
- Adds rewards program URL resolution (config + registry), `useRewardsAprBonusMap`, and `rewardAprStatsService`; merges bonus supply APR into APY in markets, portfolio, and APY display.
- **MarketsTable:** removes `markets` from the detail-modal user-position `useEffect` deps to stop repeated `Promise.all` (RPC/API load) when other table rows refresh while `PremiumMarketModal` is open.

## Tracking
- Closes https://github.com/DorkFi/dorkfi-app/issues/291 when merged to `next`.
- Related Pad tasks: http://localhost:7777/dorkfi-app/tasks

## Notes
This branch also includes the prior commit `feat: add AlgoVoi wallet support` from the previous branch base; review the full commit list on the PR.

Made with [Cursor](https://cursor.com)