### PR TITLE
fix(ui): keep LocaleNumberInput stable while focused

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.610",
+  "version": "0.1.611",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -364,10 +364,13 @@ const SupplyBorrowModal = ({
     }
   }, [isOpen, mode]);
 
-  const handleAmountChange = (newAmount: string, newFiatValue: number) => {
-    setAmount(newAmount);
-    setFiatValue(newFiatValue);
-  };
+  const handleAmountChange = useCallback(
+    (newAmount: string, newFiatValue: number) => {
+      setAmount(newAmount);
+      setFiatValue(newFiatValue);
+    },
+    []
+  );
 
   const handleSubmit = async () => {
     if (!activeAccount?.address) {

--- a/src/components/ui/LocaleNumberInput.tsx
+++ b/src/components/ui/LocaleNumberInput.tsx
@@ -51,14 +51,16 @@ export const LocaleNumberInput = React.forwardRef<
       [formatNumber, formatOptions]
     );
 
-    // Sync display from parent whenever value changes (e.g. MAX/quick-amount buttons).
-    // Parent value only changes on blur (onChange) or button clicks, never while user is typing,
-    // so this won't overwrite in-progress input.
+    // Sync display from parent when value / formatter changes (e.g. MAX, locale switch).
+    // While focused, skip sync: parent `value` often stays stale until blur (LocaleNumberInput
+    // only calls onChange on blur), and `formatForDisplay` identity can change on re-renders —
+    // without this guard, display resets every render and the field appears "unable to accept input".
     React.useEffect(() => {
+      if (isFocused) return;
       const formatted = formatForDisplay(value === "" ? "" : value);
       setDisplayValue(formatted);
       setLastValidValue(value);
-    }, [value, formatForDisplay]);
+    }, [value, formatForDisplay, isFocused]);
 
     const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
       setIsFocused(true);


### PR DESCRIPTION
LocaleNumberInput: skip syncing display from parent while focused so re-renders do not clear in-progress typing.

SupplyBorrowModal: memoize handleAmountChange with useCallback.
Made-with: Cursor