### PR TITLE
Portfolio: pagination, data freshness, and shared price-change sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.651",
+  "version": "0.1.652",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.652",
+  "version": "0.1.653",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.654",
+  "version": "0.1.655",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.653",
+  "version": "0.1.654",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.655",
+  "version": "0.1.656",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -633,7 +633,28 @@ const MarketsTable = () => {
       },
       symbol: "VOI",
       decimals: 6,
-    }
+    },
+    {
+      id: 13,
+      name: "Phase 2 Incentive",
+      description: "DorkFi Phase 2 Incentive (Biweekly)",
+      reward: 1897436,
+      icon: "/lovable-uploads/VOI.png",
+      airdropAccount:
+        "PWSTH6HCRSBDVGSWWIVPIVZCFR7QGKD2F4SQ7JREFJQWSC4DFT2EAUFUDA",
+      tokenStandard: "network",
+      networks: {
+        "algorand-mainnet": {
+          contractId: "3210709899",
+          assetId: "2320775407",
+        },
+        "voi-mainnet": {
+          contractId: "41877720",
+        },
+      },
+      symbol: "VOI",
+      decimals: 6,
+    },
   ];
 
   const {

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+  type RefObject,
+} from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useWallet } from "@txnlab/use-wallet-react";
 import { useNetwork } from "@/contexts/NetworkContext";
@@ -23,11 +30,10 @@ import {
   fetchUserDepositBalance,
   enhanceAVMMarketInfo,
   fetchMarketInfo,
-  collectPositionMarketKeys,
-  postRefreshMarketDataSnapshot,
   repayOnBehalf,
   liquidateCrossMarket,
   fetchUserDataFromChain,
+  postRefreshMarketDataSnapshot,
 } from "@/services/lendingService";
 import {
   estimateFolksDepositMintedFAssetAmount,
@@ -199,6 +205,93 @@ const SHOW_ACCRUED_INTEREST_SECTION = false;
 
 /** Liquidation Price column in Borrowed Assets (desktop + mobile card). */
 const SHOW_LIQUIDATION_PRICE_IN_BORROWED = false;
+
+/** Supplied / borrowed asset lists: rows per page. */
+const ASSET_LIST_PAGE_SIZE = 10;
+
+function sliceAssetListPage<T>(
+  items: T[],
+  currentPage: number,
+  pageSize: number
+): T[] {
+  if (items.length === 0) return [];
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+  const lastPage = pageCount - 1;
+  const page = Math.min(currentPage, lastPage);
+  const start = page * pageSize;
+  return items.slice(start, start + pageSize);
+}
+
+function PortfolioAssetListPagination({
+  currentPage,
+  onPageChange,
+  totalItems,
+  pageSize,
+  scrollToRef,
+}: {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  totalItems: number;
+  pageSize: number;
+  scrollToRef: RefObject<HTMLDivElement | null> | null;
+}) {
+  if (totalItems <= pageSize) return null;
+  const pageCount = Math.ceil(totalItems / pageSize);
+  const lastPage = pageCount - 1;
+  const current = Math.min(currentPage, lastPage);
+  const from = current * pageSize + 1;
+  const to = Math.min((current + 1) * pageSize, totalItems);
+
+  const go = (page: number) => {
+    onPageChange(Math.max(0, Math.min(page, lastPage)));
+    if (scrollToRef?.current) {
+      setTimeout(() => {
+        scrollToRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }, 0);
+    }
+  };
+
+  return (
+    <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between w-full min-w-0">
+      <p
+        className="text-sm text-muted-foreground text-center sm:text-left"
+        aria-live="polite"
+      >
+        Showing {from}–{to} of {totalItems}
+      </p>
+      <div className="flex items-center justify-center gap-2 w-full sm:w-auto min-w-0">
+        <DorkFiButton
+          type="button"
+          variant="secondary"
+          onClick={() => go(current - 1)}
+          disabled={current === 0}
+          className="min-w-0 flex-1 sm:flex-initial"
+        >
+          <span className="sm:hidden">Prev</span>
+          <span className="hidden sm:inline">Previous</span>
+        </DorkFiButton>
+        <span
+          className="text-sm text-muted-foreground tabular-nums shrink-0 min-w-[4.5rem] text-center"
+          aria-label={`Page ${current + 1} of ${pageCount}`}
+        >
+          {current + 1} / {pageCount}
+        </span>
+        <DorkFiButton
+          type="button"
+          variant="secondary"
+          onClick={() => go(current + 1)}
+          disabled={current >= lastPage}
+          className="min-w-0 flex-1 sm:flex-initial"
+        >
+          Next
+        </DorkFiButton>
+      </div>
+    </div>
+  );
+}
 
 const Portfolio = () => {
   const { address: routeAddress } = useParams<{ address: string }>();
@@ -374,16 +467,14 @@ const Portfolio = () => {
   }>({ column: "apy", direction: "desc" });
   const [suppliedAssetsSearchTerm, setSuppliedAssetsSearchTerm] =
     useState<string>("");
-  const [showAllSuppliedAssets, setShowAllSuppliedAssets] =
-    useState<boolean>(false);
+  const [suppliedAssetsPage, setSuppliedAssetsPage] = useState(0);
   const suppliedAssetsTableRef = useRef<HTMLDivElement>(null);
   const [borrowedAssetsSearchTerm, setBorrowedAssetsSearchTerm] =
     useState<string>("");
   const [portfolioPositionsTab, setPortfolioPositionsTab] = useState<
     "supplied" | "borrowed"
   >("supplied");
-  const [showAllBorrowedAssets, setShowAllBorrowedAssets] =
-    useState<boolean>(false);
+  const [borrowedAssetsPage, setBorrowedAssetsPage] = useState(0);
   const borrowedAssetsTableRef = useRef<HTMLDivElement>(null);
   const [borrowedAssetsSort, setBorrowedAssetsSort] = useState<{
     column: string | null;
@@ -437,6 +528,65 @@ const Portfolio = () => {
       marketData,
       formatPriceFromContract,
     });
+
+  // POST `/market-data/...` when a supply/borrow position modal opens (fresh API snapshot for that market).
+  useEffect(() => {
+    const pick = depositModal.isOpen
+      ? depositModal
+      : withdrawModal.isOpen
+        ? withdrawModal
+        : borrowModal.isOpen
+          ? borrowModal
+          : repayModal.isOpen
+            ? repayModal
+            : null;
+    if (!pick?.isOpen || !pick.asset) {
+      return;
+    }
+    const networkId = (pick.network || currentNetwork) as NetworkId;
+    const poolId = pick.poolId;
+    if (!poolId) {
+      return;
+    }
+    const configSymbol = pick.configSymbol;
+    const marketId = pick.marketId;
+
+    const tokens = getAllTokensWithDisplayInfo(networkId);
+    const token = resolveSupplyBorrowToken(
+      tokens,
+      pick.asset,
+      poolId,
+      configSymbol,
+      marketId
+    );
+    const appId = token?.poolId != null ? String(token.poolId) : poolId;
+    const uMid = token?.underlyingContractId
+      ? String(token.underlyingContractId)
+      : marketId != null && String(marketId) !== ""
+        ? String(marketId)
+        : "";
+    if (!uMid) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        await postRefreshMarketDataSnapshot(networkId, appId, uMid);
+      } catch (e) {
+        console.warn(
+          "[Portfolio] postRefreshMarketDataSnapshot on modal open failed",
+          { networkId, appId, marketId: uMid },
+          e
+        );
+      }
+    })();
+  }, [
+    depositModal,
+    withdrawModal,
+    borrowModal,
+    repayModal,
+    currentNetwork,
+  ]);
 
   // Function to fetch ntoken balance for a specific token
   const fetchNTokenBalance = async (
@@ -3586,43 +3736,10 @@ const Portfolio = () => {
       try {
         const enabledNetworks = getEnabledNetworks();
 
-        // POST /market-data/... for user-position markets first (backend refreshes chain snapshot)
-        const computed = user?.computed as
-          | Record<string, unknown>
-          | undefined;
-        const positionKeys = [
-          ...collectPositionMarketKeys(
-            Array.isArray(computed?.deposits)
-              ? (computed.deposits as Record<string, unknown>[])
-              : undefined
-          ),
-          ...collectPositionMarketKeys(
-            Array.isArray(computed?.borrows)
-              ? (computed.borrows as Record<string, unknown>[])
-              : undefined
-          ),
-        ];
-        const seenPost = new Set<string>();
-        for (const { networkId, poolId, marketId } of positionKeys) {
-          const k = `${networkId}|${poolId}|${marketId}`;
-          if (seenPost.has(k)) continue;
-          seenPost.add(k);
-          try {
-            await postRefreshMarketDataSnapshot(
-              networkId,
-              poolId,
-              marketId
-            );
-          } catch (e) {
-            console.error(
-              "[Portfolio] postRefreshMarketDataSnapshot failed",
-              { networkId, poolId, marketId },
-              e
-            );
-          }
-        }
+        // Market POST `/market-data/...` for visible table rows is handled in
+        // `usePortfolioVisibleChainLive` (intersection) before user-data fetch.
 
-        // Single display path: GET-backed fetchAllMarkets after POSTs
+        // GET-backed `fetchAllMarkets` for portfolio display
         const allMarketData: unknown[] = [];
         for (const networkId of enabledNetworks) {
           try {
@@ -3799,14 +3916,14 @@ const Portfolio = () => {
   //   fetchData();
   // }, [activeAccount?.address, currentNetwork]);
 
-  // Reset showAllSuppliedAssets when filters change
+  // Reset supplied list page when filters change
   useEffect(() => {
-    setShowAllSuppliedAssets(false);
+    setSuppliedAssetsPage(0);
   }, [suppliedAssetsSearchTerm, suppliedAssetsNetworkFilter]);
 
-  // Reset showAllBorrowedAssets when filters change
+  // Reset borrowed list page when filters change
   useEffect(() => {
-    setShowAllBorrowedAssets(false);
+    setBorrowedAssetsPage(0);
   }, [borrowedAssetsSearchTerm, borrowedAssetsNetworkFilter]);
 
   // Section filter modals are mobile-only; close when viewport shows inline filters
@@ -6088,10 +6205,11 @@ const Portfolio = () => {
                               : -comparison;
                           });
 
-                        const displayDeposits = showAllSuppliedAssets
-                          ? filteredAndSorted
-                          : filteredAndSorted.slice(0, 5);
-                        const hasMore = filteredAndSorted.length > 5;
+                        const displayDeposits = sliceAssetListPage(
+                          filteredAndSorted,
+                          suppliedAssetsPage,
+                          ASSET_LIST_PAGE_SIZE
+                        );
 
                         if (displayDeposits.length === 0) {
                           return (
@@ -6232,21 +6350,13 @@ const Portfolio = () => {
                                 </div>
                               );
                             })}
-                            {hasMore && (
-                              <DorkFiButton
-                                variant="secondary"
-                                onClick={() =>
-                                  setShowAllSuppliedAssets(
-                                    !showAllSuppliedAssets
-                                  )
-                                }
-                                className="w-full min-w-0"
-                              >
-                                {showAllSuppliedAssets
-                                  ? "Show Less"
-                                  : "Show More"}
-                              </DorkFiButton>
-                            )}
+                            <PortfolioAssetListPagination
+                              currentPage={suppliedAssetsPage}
+                              onPageChange={setSuppliedAssetsPage}
+                              totalItems={filteredAndSorted.length}
+                              pageSize={ASSET_LIST_PAGE_SIZE}
+                              scrollToRef={suppliedAssetsTableRef}
+                            />
                           </>
                         );
                       })()}
@@ -6704,10 +6814,11 @@ const Portfolio = () => {
                                   : -comparison;
                               });
 
-                            const displayDeposits = showAllSuppliedAssets
-                              ? filteredAndSorted
-                              : filteredAndSorted.slice(0, 5);
-                            const hasMore = filteredAndSorted.length > 5;
+                            const displayDeposits = sliceAssetListPage(
+                              filteredAndSorted,
+                              suppliedAssetsPage,
+                              ASSET_LIST_PAGE_SIZE
+                            );
 
                             return displayDeposits.map((depositRaw, index) => {
                               const deposit = mergeDeposit(
@@ -7098,36 +7209,15 @@ const Portfolio = () => {
                             : -comparison;
                         });
 
-                      const hasMore = filteredAndSorted.length > 5;
-
-                      return hasMore ? (
-                        <div className="mt-4 text-center">
-                          <DorkFiButton
-                            variant="secondary"
-                            onClick={() => {
-                              const wasExpanded = showAllSuppliedAssets;
-                              setShowAllSuppliedAssets(!showAllSuppliedAssets);
-                              // Scroll to top when collapsing
-                              if (
-                                wasExpanded &&
-                                suppliedAssetsTableRef.current
-                              ) {
-                                setTimeout(() => {
-                                  suppliedAssetsTableRef.current?.scrollIntoView(
-                                    {
-                                      behavior: "smooth",
-                                      block: "start",
-                                    }
-                                  );
-                                }, 0);
-                              }
-                            }}
-                            className="w-full min-w-0"
-                          >
-                            {showAllSuppliedAssets ? "Show Less" : "Show More"}
-                          </DorkFiButton>
-                        </div>
-                      ) : null;
+                      return (
+                        <PortfolioAssetListPagination
+                          currentPage={suppliedAssetsPage}
+                          onPageChange={setSuppliedAssetsPage}
+                          totalItems={filteredAndSorted.length}
+                          pageSize={ASSET_LIST_PAGE_SIZE}
+                          scrollToRef={suppliedAssetsTableRef}
+                        />
+                      );
                     })()}
                 </DorkFiCard>
               )}
@@ -7956,10 +8046,11 @@ const Portfolio = () => {
                               : -comparison;
                           });
 
-                        const displayBorrows = showAllBorrowedAssets
-                          ? filteredAndSorted
-                          : filteredAndSorted.slice(0, 5);
-                        const hasMore = filteredAndSorted.length > 5;
+                        const displayBorrows = sliceAssetListPage(
+                          filteredAndSorted,
+                          borrowedAssetsPage,
+                          ASSET_LIST_PAGE_SIZE
+                        );
 
                         if (displayBorrows.length === 0) {
                           return (
@@ -8106,21 +8197,13 @@ const Portfolio = () => {
                                 </div>
                               );
                             })}
-                            {hasMore && (
-                              <DorkFiButton
-                                variant="secondary"
-                                onClick={() =>
-                                  setShowAllBorrowedAssets(
-                                    !showAllBorrowedAssets
-                                  )
-                                }
-                                className="w-full min-w-0"
-                              >
-                                {showAllBorrowedAssets
-                                  ? "Show Less"
-                                  : "Show More"}
-                              </DorkFiButton>
-                            )}
+                            <PortfolioAssetListPagination
+                              currentPage={borrowedAssetsPage}
+                              onPageChange={setBorrowedAssetsPage}
+                              totalItems={filteredAndSorted.length}
+                              pageSize={ASSET_LIST_PAGE_SIZE}
+                              scrollToRef={borrowedAssetsTableRef}
+                            />
                           </>
                         );
                       })()}
@@ -8477,9 +8560,11 @@ const Portfolio = () => {
                                   : -comparison;
                               });
 
-                            const displayBorrows = showAllBorrowedAssets
-                              ? filteredAndSorted
-                              : filteredAndSorted.slice(0, 5);
+                            const displayBorrows = sliceAssetListPage(
+                              filteredAndSorted,
+                              borrowedAssetsPage,
+                              ASSET_LIST_PAGE_SIZE
+                            );
 
                             return displayBorrows.map((borrowRaw, index) => {
                               const borrow = mergeBorrow(
@@ -8895,36 +8980,15 @@ const Portfolio = () => {
                             : -comparison;
                         });
 
-                      const hasMore = filteredAndSorted.length > 5;
-
-                      return hasMore ? (
-                        <div className="mt-4 text-center">
-                          <DorkFiButton
-                            variant="secondary"
-                            onClick={() => {
-                              const wasExpanded = showAllBorrowedAssets;
-                              setShowAllBorrowedAssets(!showAllBorrowedAssets);
-                              // Scroll to top when collapsing
-                              if (
-                                wasExpanded &&
-                                borrowedAssetsTableRef.current
-                              ) {
-                                setTimeout(() => {
-                                  borrowedAssetsTableRef.current?.scrollIntoView(
-                                    {
-                                      behavior: "smooth",
-                                      block: "start",
-                                    }
-                                  );
-                                }, 0);
-                              }
-                            }}
-                            className="w-full min-w-0"
-                          >
-                            {showAllBorrowedAssets ? "Show Less" : "Show More"}
-                          </DorkFiButton>
-                        </div>
-                      ) : null;
+                      return (
+                        <PortfolioAssetListPagination
+                          currentPage={borrowedAssetsPage}
+                          onPageChange={setBorrowedAssetsPage}
+                          totalItems={filteredAndSorted.length}
+                          pageSize={ASSET_LIST_PAGE_SIZE}
+                          scrollToRef={borrowedAssetsTableRef}
+                        />
+                      );
                     })()}
                 </DorkFiCard>
               )}

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1489,36 +1489,6 @@ const Portfolio = () => {
       : userGlobalData?.totalBorrowValue ||
       borrows.reduce((sum, borrow) => sum + borrow.value, 0);
 
-  /** Per pool collateral USD for LTV in Borrowed Assets (contract global user; deposit sum fallback). */
-  const collateralUsdByPoolId = useMemo(() => {
-    const map: Record<string, number> = {};
-    if (user?.globalUserData && Array.isArray(user.globalUserData)) {
-      for (const item of user.globalUserData) {
-        const rec = item as Record<string, unknown>;
-        const appId = String(rec.appId ?? rec.poolId ?? "");
-        if (!appId) continue;
-        try {
-          const v = Number(
-            BigInt(String(rec.totalCollateralValue ?? 0)) / BigInt(1e12)
-          );
-          if (!Number.isNaN(v)) map[appId] = v;
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-    const depositSumByPool: Record<string, number> = {};
-    for (const d of deposits) {
-      if (d.poolId == null || d.poolId === "") continue;
-      const pid = String(d.poolId);
-      depositSumByPool[pid] = (depositSumByPool[pid] ?? 0) + d.value;
-    }
-    for (const [pid, sum] of Object.entries(depositSumByPool)) {
-      if (map[pid] === undefined) map[pid] = sum;
-    }
-    return map;
-  }, [user?.globalUserData, deposits]);
-
   // Calculate weighted liquidation threshold based on borrowed assets only
   // This is more accurate because liquidation risk only applies to markets with active debt
   const calculateWeightedLiquidationThreshold = () => {
@@ -8108,19 +8078,6 @@ const Portfolio = () => {
                                     ? liquidationThresholdNum / 10000
                                     : liquidationThresholdNum;
 
-                              // Calculate LTV Usage (per pool collateral, not portfolio aggregate)
-                              const poolCollateralUsd =
-                                borrow.poolId != null && borrow.poolId !== ""
-                                  ? collateralUsdByPoolId[String(borrow.poolId)] ??
-                                    0
-                                  : totalCollateral;
-                              const ltvUsage =
-                                poolCollateralUsd > 0
-                                  ? (borrow.value / poolCollateralUsd) * 100
-                                  : borrow.value > 0
-                                    ? 100
-                                    : 0;
-
                               const liquidationPrice =
                                 SHOW_LIQUIDATION_PRICE_IN_BORROWED
                                   ? (() => {
@@ -8163,7 +8120,6 @@ const Portfolio = () => {
                                   accruedInterestValue={
                                     (borrow as ItemWithNetwork).accruedInterestValue
                                   }
-                                  ltvUsage={ltvUsage}
                                   liquidationPrice={liquidationPrice}
                                   network={(borrow as ItemWithNetwork).network}
                                   poolId={borrow.poolId}
@@ -8385,27 +8341,6 @@ const Portfolio = () => {
                                 )}
                               </button>
                             </TableHead>
-                            <TableHead className="text-right">
-                              <div className="flex items-center justify-end gap-1">
-                                LTV Usage
-                                <UITooltip>
-                                  <TooltipTrigger asChild>
-                                    <Info className="w-4 h-4 text-muted-foreground cursor-help" />
-                                  </TooltipTrigger>
-                                  <TooltipContent className="max-w-xs">
-                                    <p className="text-sm">
-                                      Your borrow&apos;s value in USD, compared
-                                      to this lending pool&apos;s total
-                                      collateral (from on-chain data).
-                                    </p>
-                                    <p className="text-xs text-muted-foreground mt-2">
-                                      If this row isn&apos;t linked to a pool, we
-                                      use your portfolio-wide collateral instead.
-                                    </p>
-                                  </TooltipContent>
-                                </UITooltip>
-                              </div>
-                            </TableHead>
                             {SHOW_LIQUIDATION_PRICE_IN_BORROWED && (
                               <TableHead className="text-right">
                                 <div className="flex items-center justify-end gap-1">
@@ -8595,19 +8530,6 @@ const Portfolio = () => {
                                 borrow.poolId
                               );
 
-                              // Calculate LTV Usage (per pool collateral, not portfolio aggregate)
-                              const poolCollateralUsd =
-                                borrow.poolId != null && borrow.poolId !== ""
-                                  ? collateralUsdByPoolId[String(borrow.poolId)] ??
-                                    0
-                                  : totalCollateral;
-                              const ltvUsage =
-                                poolCollateralUsd > 0
-                                  ? (borrow.value / poolCollateralUsd) * 100
-                                  : borrow.value > 0
-                                    ? 100
-                                    : 0;
-
                               const liquidationPrice =
                                 SHOW_LIQUIDATION_PRICE_IN_BORROWED
                                   ? (() => {
@@ -8681,14 +8603,6 @@ const Portfolio = () => {
                                   }
                                 }
                               }
-
-                              // Color code LTV usage
-                              const getLTVColor = (ltv: number) => {
-                                if (ltv >= 80) return "bg-red-500";
-                                if (ltv >= 60) return "bg-orange-500";
-                                if (ltv >= 40) return "bg-yellow-500";
-                                return "bg-green-500";
-                              };
 
                               const borrowDesktopChainKey =
                                 portfolioPositionChainKey(
@@ -8787,26 +8701,6 @@ const Portfolio = () => {
                                       </span>
                                     )}
                                   </TableCell>
-                                  <TableCell className="text-right">
-                                    <div className="flex items-center justify-end gap-2">
-                                      <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2 max-w-[100px]">
-                                        <div
-                                          className={`h-2 rounded-full ${getLTVColor(
-                                            ltvUsage
-                                          )}`}
-                                          style={{
-                                            width: `${Math.min(
-                                              ltvUsage,
-                                              100
-                                            )}%`,
-                                          }}
-                                        />
-                                      </div>
-                                      <span className="text-sm font-medium min-w-[50px] tabular-nums text-right">
-                                        {formatPercent(ltvUsage / 100, { maximumFractionDigits: 1 })}
-                                      </span>
-                                    </div>
-                                  </TableCell>
                                   {SHOW_LIQUIDATION_PRICE_IN_BORROWED &&
                                     liquidationPrice !== undefined && (
                                       <TableCell className="text-right tabular-nums">
@@ -8881,7 +8775,9 @@ const Portfolio = () => {
                           {borrows.length === 0 && (
                             <TableRow>
                               <TableCell
-                                colSpan={9}
+                                colSpan={
+                                  SHOW_LIQUIDATION_PRICE_IN_BORROWED ? 9 : 8
+                                }
                                 className="text-center text-muted-foreground py-8"
                               >
                                 No borrowed assets

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -15,6 +15,7 @@ import { getCurrentNetworkConfig } from "@/config";
 import { APP_SPEC as LendingPoolAppSpec } from "@/clients/DorkFiLendingPoolClient";
 import { abi, CONTRACT } from "ulujs";
 import { updateTransactionMetadata } from "@/utils/transactionUtils";
+import { signAndSendSyncUserMarketsForPriceChangeTx } from "@/utils/syncUserMarketsForPriceChange";
 import {
   fetchUserGlobalData,
   fetchAllMarkets,
@@ -2559,181 +2560,20 @@ const Portfolio = () => {
       }
 
       try {
-        // Find which network this poolId belongs to
-        const enabledNetworks = getEnabledNetworks();
-        let marketNetworkId: NetworkId | null = null;
-
-        for (const networkId of enabledNetworks) {
-          const networkConfig = getNetworkConfig(networkId);
-          const lendingPools = networkConfig?.contracts?.lendingPools || [];
-          if (lendingPools.includes(poolId)) {
-            marketNetworkId = networkId;
-            break;
-          }
-        }
-
-        if (!marketNetworkId) {
-          console.error(
-            `[Portfolio] Could not find network for poolId ${poolId}`
-          );
-          return;
-        }
-
-        // Use the market's network config, not the active network
-        const networkConfig = getNetworkConfig(marketNetworkId);
-        const algorandNetwork =
-          getAlgorandNetworkFromNetworkId(marketNetworkId);
-        if (!algorandNetwork) {
-          console.error(
-            `[Portfolio] Network ${marketNetworkId} is not Algorand-compatible`
-          );
-          return;
-        }
-        const clients = algorandService.initializeClients(algorandNetwork);
-
-        // If marketId is provided, sync only that specific market
-        // Otherwise, sync all markets for the provided poolId
-        let marketsToSync: Array<{ poolId: string; marketId: string }> = [];
-
-        if (marketId) {
-          // Sync only the specific market
-          marketsToSync = [{ poolId, marketId }];
-        } else {
-          // Get all markets for this poolId from the market's network
-          const tokens = getAllTokensWithDisplayInfo(marketNetworkId);
-          const matchingTokens = tokens.filter((t) => t.poolId === poolId);
-
-          for (const token of matchingTokens) {
-            if (token.underlyingContractId) {
-              marketsToSync.push({
-                poolId,
-                marketId: token.underlyingContractId,
-              });
-            }
-          }
-        }
-
-        if (marketsToSync.length === 0) {
-          console.log("[Portfolio] No markets to sync");
-          return;
-        }
-
-        console.log(
-          "[Portfolio] Syncing markets:",
-          marketsToSync,
-          "on network:",
-          marketNetworkId
+        await signAndSendSyncUserMarketsForPriceChangeTx(
+          userAddress,
+          poolId,
+          marketId,
+          activeAccount.address,
+          signTransactions
         );
-
-        // Create contract instance for this specific poolId
-        const ci = new CONTRACT(
-          Number(poolId),
-          clients.algod,
-          clients.indexer,
-          abi.custom,
-          {
-            addr: activeAccount.address,
-            sk: new Uint8Array(),
-          }
-        );
-
-        const builder = {
-          lending: new CONTRACT(
-            Number(poolId),
-            clients.algod,
-            clients.indexer,
-            { ...LendingPoolAppSpec.contract, events: [] },
-            {
-              addr: activeAccount.address,
-              sk: new Uint8Array(),
-            },
-            true,
-            false,
-            true
-          ),
-        };
-
-        // Build sync transactions for each market
-        const buildN = [];
-        for (const { marketId: syncMarketId } of marketsToSync) {
-          console.log("[Portfolio] Syncing market:", {
-            poolId,
-            marketId: syncMarketId,
-            userAddress,
-          });
-          try {
-            const txnO = (
-              await builder.lending.sync_user_market_for_price_change(
-                userAddress,
-                Number(syncMarketId)
-              )
-            ).obj;
-            buildN.push({
-              ...txnO,
-              note: new TextEncoder().encode(
-                `lending sync_market ${syncMarketId}`
-              ),
-              payment: 1e5,
-            });
-          } catch (error) {
-            console.warn(
-              `[Portfolio] Failed to sync market ${syncMarketId} in pool ${poolId}:`,
-              error
-            );
-          }
-        }
-
-        if (buildN.length === 0) {
-          console.log(`[Portfolio] No sync transactions for pool ${poolId}`);
-          return;
-        }
-
-        ci.setFee(10000);
-        ci.setEnableGroupResourceSharing(true);
-        ci.setExtraTxns(buildN);
-        // Set beacon ID for algorand-mainnet (using market's network, not active network)
-        if (marketNetworkId === "algorand-mainnet") {
-          ci.setBeaconId(3209233839);
-        }
-        const customR = await ci.custom();
-
-        console.log(
-          `[Portfolio] Sync transactions for pool ${poolId}:`,
-          customR
-        );
-
-        // Use clients for the market's network
-        const algorandClients =
-          await algorandService.initializeClientsForTransactions(
-            algorandNetwork
-          );
-
-        const stxns = await signTransactions(
-          customR.txns.map((txn: string) =>
-            Uint8Array.from(atob(txn), (c) => c.charCodeAt(0))
-          )
-        );
-
-        const res = await algorandClients.algod.sendRawTransaction(stxns).do();
-        await algosdk.waitForConfirmation(algorandClients.algod, res.txid, 4);
-
-        // Update transaction metadata (using market's network, not active network)
-        await updateTransactionMetadata(res.txid, marketNetworkId);
-
         console.log("[Portfolio] Markets synced successfully");
       } catch (error) {
         console.error("[Portfolio] Error syncing markets:", error);
         throw error;
       }
     },
-     
-    [
-      signTransactions,
-      activeAccount?.address,
-      currentNetwork,
-      deposits,
-      borrows,
-    ]
+    [signTransactions, activeAccount?.address]
   );
 
   // Function to refresh positions data

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -173,6 +173,16 @@ interface ItemWithNetwork {
   accruedInterest?: number;
   interest?: number;
   accruedInterestValue?: number;
+  tokenPrice?: number;
+}
+
+/** For sorting Accrued Interest columns: prefer stored USD, else token amount × price. */
+function accruedInterestUsdForSort(
+  item: ItemWithNetwork
+): number {
+  const v = item.accruedInterestValue;
+  if (v != null && Number.isFinite(v)) return v;
+  return (item.accruedInterest ?? 0) * (item.tokenPrice || 1);
 }
 
 /** Folks f-asset rows show underlying balance; if their market row has no usable price, use native ALGO same pool. */
@@ -6022,11 +6032,13 @@ const Portfolio = () => {
                                 comparison = a.apy - b.apy;
                                 break;
                               case "accruedInterest": {
-                                const accruedInterestA =
-                                  (a as ItemWithNetwork).accruedInterest || 0;
-                                const accruedInterestB =
-                                  (b as ItemWithNetwork).accruedInterest || 0;
-                                comparison = accruedInterestA - accruedInterestB;
+                                comparison =
+                                  accruedInterestUsdForSort(
+                                    a as ItemWithNetwork
+                                  ) -
+                                  accruedInterestUsdForSort(
+                                    b as ItemWithNetwork
+                                  );
                                 break;
                               }
                               case "collateralFactor": {
@@ -6619,12 +6631,13 @@ const Portfolio = () => {
                                     comparison = a.apy - b.apy;
                                     break;
                                   case "accruedInterest": {
-                                    const accruedInterestA =
-                                      (a as ItemWithNetwork).accruedInterest || 0;
-                                    const accruedInterestB =
-                                      (b as ItemWithNetwork).accruedInterest || 0;
                                     comparison =
-                                      accruedInterestA - accruedInterestB;
+                                      accruedInterestUsdForSort(
+                                        a as ItemWithNetwork
+                                      ) -
+                                      accruedInterestUsdForSort(
+                                        b as ItemWithNetwork
+                                      );
                                     break;
                                   }
                                   case "collateralFactor": {
@@ -7163,11 +7176,13 @@ const Portfolio = () => {
                               comparison = a.apy - b.apy;
                               break;
                             case "accruedInterest":
-                              const accruedInterestA =
-                                (a as ItemWithNetwork).accruedInterest || 0;
-                              const accruedInterestB =
-                                (b as ItemWithNetwork).accruedInterest || 0;
-                              comparison = accruedInterestA - accruedInterestB;
+                              comparison =
+                                accruedInterestUsdForSort(
+                                  a as ItemWithNetwork
+                                ) -
+                                accruedInterestUsdForSort(
+                                  b as ItemWithNetwork
+                                );
                               break;
                             default:
                               comparison = a.apy - b.apy;
@@ -8480,12 +8495,13 @@ const Portfolio = () => {
                                     comparison = a.apy - b.apy;
                                     break;
                                   case "accruedInterest":
-                                    const accruedInterestA =
-                                      (a as ItemWithNetwork).accruedInterest || 0;
-                                    const accruedInterestB =
-                                      (b as ItemWithNetwork).accruedInterest || 0;
                                     comparison =
-                                      accruedInterestA - accruedInterestB;
+                                      accruedInterestUsdForSort(
+                                        a as ItemWithNetwork
+                                      ) -
+                                      accruedInterestUsdForSort(
+                                        b as ItemWithNetwork
+                                      );
                                     break;
                                   default:
                                     comparison = a.apy - b.apy;
@@ -8867,11 +8883,13 @@ const Portfolio = () => {
                               comparison = a.apy - b.apy;
                               break;
                             case "accruedInterest":
-                              const accruedInterestA =
-                                (a as ItemWithNetwork).accruedInterest || 0;
-                              const accruedInterestB =
-                                (b as ItemWithNetwork).accruedInterest || 0;
-                              comparison = accruedInterestA - accruedInterestB;
+                              comparison =
+                                accruedInterestUsdForSort(
+                                  a as ItemWithNetwork
+                                ) -
+                                accruedInterestUsdForSort(
+                                  b as ItemWithNetwork
+                                );
                               break;
                             default:
                               comparison = a.apy - b.apy;
@@ -8985,7 +9003,8 @@ const Portfolio = () => {
                             switch (accruedInterestSort.column) {
                               case "interest":
                                 comparison =
-                                  (a.netInterest || 0) - (b.netInterest || 0);
+                                  (a.netInterestValue || 0) -
+                                  (b.netInterestValue || 0);
                                 break;
                               case "value":
                                 comparison =
@@ -9271,8 +9290,8 @@ const Portfolio = () => {
                                     break;
                                   case "interest":
                                     comparison =
-                                      (a.netInterest || 0) -
-                                      (b.netInterest || 0);
+                                      (a.netInterestValue || 0) -
+                                      (b.netInterestValue || 0);
                                     break;
                                   case "value":
                                   default:
@@ -9517,7 +9536,8 @@ const Portfolio = () => {
                               break;
                             case "interest":
                               comparison =
-                                (a.netInterest || 0) - (b.netInterest || 0);
+                                (a.netInterestValue || 0) -
+                                (b.netInterestValue || 0);
                               break;
                             case "value":
                             default:

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -479,7 +479,7 @@ const Portfolio = () => {
   const [borrowedAssetsSort, setBorrowedAssetsSort] = useState<{
     column: string | null;
     direction: "asc" | "desc";
-  }>({ column: "apy", direction: "asc" });
+  }>({ column: "apy", direction: "desc" });
   const [accruedInterestSearchTerm, setAccruedInterestSearchTerm] =
     useState<string>("");
   const [showAllAccruedInterest, setShowAllAccruedInterest] =
@@ -6964,7 +6964,7 @@ const Portfolio = () => {
                                   <TableCell>
                                     {formatNumber(deposit.balance, {
                                       minimumFractionDigits: 2,
-                                      maximumFractionDigits: 2,
+                                      maximumFractionDigits: 6,
                                     })}
                                   </TableCell>
                                   <TableCell>
@@ -8287,7 +8287,7 @@ const Portfolio = () => {
                                   } else {
                                     setBorrowedAssetsSort({
                                       column: "apy",
-                                      direction: "asc",
+                                      direction: "desc",
                                     });
                                   }
                                 }}
@@ -8373,7 +8373,9 @@ const Portfolio = () => {
                                 </div>
                               </TableHead>
                             )}
-                            <TableHead>Actions</TableHead>
+                            <TableHead className="whitespace-nowrap w-[1%]">
+                              Actions
+                            </TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -8666,15 +8668,20 @@ const Portfolio = () => {
                                     {borrowMarketLabel || "-"}
                                   </TableCell>
                                   <TableCell>
-                                    {formatNumber(borrow.balance, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}
+                                    {formatNumber(borrow.balance, {
+                                      minimumFractionDigits: 2,
+                                      maximumFractionDigits: 6,
+                                    })}
                                   </TableCell>
                                   <TableCell>
                                     {formatCurrency(borrow.value, "USD", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
-                                    <span className="text-red-600 dark:text-red-400">
-                                      {formatPercent(borrow.apy / 100, { maximumFractionDigits: 2 })}
-                                    </span>
+                                    <div className="flex flex-col gap-0.5 items-end">
+                                      <span className="text-red-600 dark:text-red-400">
+                                        {formatPercent(borrow.apy / 100, { maximumFractionDigits: 2 })}
+                                      </span>
+                                    </div>
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
                                     {borrow.accruedInterest > 0 ? (
@@ -8712,8 +8719,8 @@ const Portfolio = () => {
                                         </span>
                                       </TableCell>
                                     )}
-                                  <TableCell>
-                                    <div className="flex items-center gap-2 flex-wrap">
+                                  <TableCell className="whitespace-nowrap w-[1%]">
+                                    <div className="flex items-center gap-2">
                                       {!isViewOnly && (
                                         <>
                                           {!market?.isPaused && (
@@ -8738,7 +8745,7 @@ const Portfolio = () => {
                                                   : "Borrow more of this asset against your collateral"
                                               }
                                               aria-label="Borrow"
-                                              className="min-w-[92px] h-8 px-2 gap-1"
+                                              className="min-w-[92px] h-8 shrink-0 px-2 gap-1"
                                             >
                                               <span className="text-base leading-none">+</span>
                                               <span className="hidden lg:inline text-xs">Borrow</span>
@@ -8759,7 +8766,7 @@ const Portfolio = () => {
                                             }}
                                             title="Repay this debt to improve health factor"
                                             aria-label="Repay"
-                                            className="min-w-[92px] h-8 px-2 gap-1"
+                                            className="min-w-[92px] h-8 shrink-0 px-2 gap-1"
                                           >
                                             <span className="text-base leading-none">−</span>
                                             <span className="hidden lg:inline text-xs">Repay</span>

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -23,6 +23,7 @@ import {
   withdraw,
   repay,
   repayAll,
+  postRefreshMarketDataSnapshot,
   fetchUserWalletBalance,
   fetchMarketInfoFromContract,
   getMaxWithdrawableForMarket,
@@ -1935,27 +1936,39 @@ const PortfolioModals = ({
         onRefreshWalletBalance(repayModal.asset, networkToUse);
       }
 
-      Promise.all([
-        dorkfiAPIService.fetchFreshUserData(
-          activeAccount.address,
-          networkToUse,
-          parseInt(token.poolId),
-          parseInt(token.underlyingContractId)
-        ),
-        dorkfiAPIService.fetchFreshUserHealth(
-          networkToUse,
-          parseInt(token.poolId),
-          activeAccount.address
-        ),
-      ])
-        .then(() => {
-          setTimeout(() => {
-            onRefreshMarket();
-          }, 1000);
-        })
-        .catch((error) => {
-          console.error("Error calling fetchFreshUserData after repay:", error);
-        });
+      // Wait for chain/indexer + API to catch up, then market + user; another beat before full portfolio fetch
+      // (so Borrowed + marketData reflect the repay; does not block returning txid below)
+      const REPAY_SETTLE_BEFORE_API_MS = 2_000;
+      const REPAY_WAIT_AFTER_API_BEFORE_USER_FETCH_MS = 2_500;
+      setTimeout(() => {
+        void Promise.all([
+          postRefreshMarketDataSnapshot(
+            networkToUse as NetworkId,
+            String(token.poolId),
+            String(token.underlyingContractId)
+          ),
+          dorkfiAPIService.fetchFreshUserData(
+            activeAccount.address,
+            networkToUse,
+            parseInt(token.poolId, 10),
+            parseInt(token.underlyingContractId, 10)
+          ),
+          dorkfiAPIService.fetchFreshUserHealth(
+            networkToUse,
+            parseInt(token.poolId, 10),
+            activeAccount.address
+          ),
+        ])
+          .then(() => {
+            setTimeout(() => {
+              onRefreshMarket();
+            }, REPAY_WAIT_AFTER_API_BEFORE_USER_FETCH_MS);
+          })
+          .catch((error) => {
+            console.error("Error calling fetchFreshUserData after repay:", error);
+            setTimeout(() => onRefreshMarket(), REPAY_WAIT_AFTER_API_BEFORE_USER_FETCH_MS);
+          });
+      }, REPAY_SETTLE_BEFORE_API_MS);
 
       // Return the transaction ID so RepayModal can use it
       return res.txid;

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -27,6 +27,7 @@ import {
   fetchMarketInfoFromContract,
   getMaxWithdrawableForMarket,
   fetchUserGlobalDataForPool,
+  fetchBorrowPositionChainDebug,
 } from "@/services/lendingService";
 import {
   estimateFolksDepositMintedFAssetAmount,
@@ -273,6 +274,15 @@ const PortfolioModals = ({
     | null
     | undefined
   >(undefined);
+
+  /**
+   * On-chain total debt + accrued (get_user + sync_market via fetchBorrowPositionChainDebug),
+   * same as admin borrow debug. When null, RepayModal falls back to portfolio API row.
+   */
+  const [repayChainOwed, setRepayChainOwed] = useState<{
+    totalDebt: number;
+    accruedInterest: number;
+  } | null>(null);
 
   const [userDepositIndexCache, setUserDepositIndexCache] = useState<
     Record<string, string>
@@ -1619,6 +1629,76 @@ const PortfolioModals = ({
     currentNetwork,
   ]);
 
+  useEffect(() => {
+    if (!repayModal.isOpen || !repayModal.asset || !activeAccount?.address) {
+      setRepayChainOwed(null);
+      return;
+    }
+    const networkToUse = (repayModal.network || currentNetwork) as NetworkId;
+    if (!isAlgorandCompatibleNetwork(networkToUse)) {
+      setRepayChainOwed(null);
+      return;
+    }
+    const tokensRep = getAllTokensWithDisplayInfo(networkToUse);
+    const repayTokenRow = resolveSupplyBorrowToken(
+      tokensRep,
+      repayModal.asset ?? "",
+      repayModal.poolId,
+      repayModal.configSymbol,
+      repayModal.marketId
+    );
+    const poolIdStr =
+      repayModal.poolId != null && String(repayModal.poolId).trim() !== ""
+        ? String(repayModal.poolId)
+        : repayTokenRow.poolId != null
+          ? String(repayTokenRow.poolId)
+          : "";
+    const marketIdStr =
+      repayModal.marketId != null && String(repayModal.marketId).trim() !== ""
+        ? String(repayModal.marketId)
+        : repayTokenRow.underlyingContractId != null
+          ? String(repayTokenRow.underlyingContractId)
+          : "";
+    if (!poolIdStr || !marketIdStr) {
+      setRepayChainOwed(null);
+      return;
+    }
+    let cancelled = false;
+    setRepayChainOwed(null);
+    fetchBorrowPositionChainDebug(
+      activeAccount.address,
+      poolIdStr,
+      marketIdStr,
+      networkToUse
+    )
+      .then((r) => {
+        if (cancelled) return;
+        if (r.ok) {
+          setRepayChainOwed({
+            totalDebt: r.data.totalDebtFromSyncMarket,
+            accruedInterest: r.data.accruedInterestFromSyncMarket,
+          });
+        } else {
+          setRepayChainOwed(null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRepayChainOwed(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    repayModal.isOpen,
+    repayModal.asset,
+    repayModal.poolId,
+    repayModal.marketId,
+    repayModal.configSymbol,
+    repayModal.network,
+    activeAccount?.address,
+    currentNetwork,
+  ]);
+
   const handleRepaySubmit = async (
     amount: string,
     opts?: { isRepayAll?: boolean; repayAdapterId?: string }
@@ -2518,8 +2598,12 @@ const PortfolioModals = ({
               network={
                 repayModal.network || (borrow as any)?.network || currentNetwork
               }
-              currentBorrow={borrow?.balance || 0}
-              accruedInterest={borrow?.interest || 0}
+              currentBorrow={
+                repayChainOwed?.totalDebt ?? borrow?.balance ?? 0
+              }
+              accruedInterest={
+                repayChainOwed?.accruedInterest ?? borrow?.interest ?? 0
+              }
               walletBalance={
                 repayModal.network
                   ? walletBalances[

--- a/src/components/RepayModal.tsx
+++ b/src/components/RepayModal.tsx
@@ -614,6 +614,52 @@ const RepayModal = ({
 
   const maxRepayAmount = Math.min(maxDebtInInputUnits, effectiveWalletBalance);
 
+  /**
+   * Repay amount in **input field units** that covers accrued interest (capped by wallet + total debt).
+   * Hidden for xALGO consensus ALGO route (non-linear mint) until we have a dedicated conversion.
+   */
+  const interestOnlyInInputUnits = useMemo(() => {
+    if (!(accruedInterest > 0) || !(currentBorrow > 0)) return null;
+    const interestMarketHuman = Math.min(accruedInterest, currentBorrow);
+
+    let rawInInputUnits: number;
+    if (repayWalletBasis === "underlying") {
+      if (isXalgoConsensusRepayAlgoRoute) return null;
+      if (
+        folksMintRatioStatus !== "ready" ||
+        folksMintedFAssetPerOneUnderlying == null ||
+        folksMintedFAssetPerOneUnderlying <= BigInt(0)
+      ) {
+        return null;
+      }
+      rawInInputUnits = folksFAssetHumanToUnderlyingHuman(
+        interestMarketHuman,
+        folksMintedFAssetPerOneUnderlying,
+        repayTokenDecimals
+      );
+    } else {
+      rawInInputUnits = interestMarketHuman;
+    }
+
+    const capped = Math.min(
+      rawInInputUnits,
+      maxDebtInInputUnits,
+      effectiveWalletBalance
+    );
+    if (!Number.isFinite(capped) || capped <= 0) return null;
+    return capped;
+  }, [
+    accruedInterest,
+    currentBorrow,
+    repayWalletBasis,
+    isXalgoConsensusRepayAlgoRoute,
+    folksMintRatioStatus,
+    folksMintedFAssetPerOneUnderlying,
+    repayTokenDecimals,
+    maxDebtInInputUnits,
+    effectiveWalletBalance,
+  ]);
+
   const numAmountMarketTokenHuman = useMemo((): number | null => {
     const amountInputStr =
       amount === "" ? "0" : typeof amount === "number" ? String(amount) : "0";
@@ -672,6 +718,15 @@ const RepayModal = ({
     setAmount(roundedMax);
     const roundedDebtCap = Math.round(maxDebtInInputUnits * 1000000) / 1000000;
     setIsRepayAll(roundedMax === roundedDebtCap);
+  };
+
+  const handleInterestOnlyClick = () => {
+    if (interestOnlyInInputUnits == null || !(interestOnlyInInputUnits > 0)) {
+      return;
+    }
+    const rounded = Math.round(interestOnlyInInputUnits * 1e6) / 1e6;
+    setAmount(rounded);
+    setIsRepayAll(false);
   };
 
   const handleConfirmRepay = async () => {
@@ -1104,6 +1159,29 @@ const RepayModal = ({
                                     )
                                   </span>
                                 </p>
+                                {interestOnlyInInputUnits != null &&
+                                  interestOnlyInInputUnits > 0 && (
+                                    <div className="mt-2">
+                                      <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleInterestOnlyClick}
+                                        className="h-8 w-full sm:w-auto border-amber-400/70 bg-white/90 text-amber-900 hover:bg-amber-100 dark:border-amber-600/50 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:bg-amber-900/60"
+                                      >
+                                        Repay this interest (~
+                                        {interestOnlyInInputUnits.toLocaleString(
+                                          undefined,
+                                          { maximumFractionDigits: 6 }
+                                        )}{" "}
+                                        {walletUnitSymbol})
+                                      </Button>
+                                      <p className="text-[11px] text-amber-700/85 dark:text-amber-400/90 mt-1.5">
+                                        Sets the amount field (capped by wallet).
+                                        Use MAX to repay principal + all interest.
+                                      </p>
+                                    </div>
+                                  )}
                                 <p className="text-xs text-amber-600 dark:text-amber-500 mt-1">
                                   Included in total owed above. You&apos;ll see a
                                   full breakdown on the next step before signing.

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -21,7 +21,6 @@ interface PortfolioTableMobileCardProps {
   rewardBonusAprPercent?: number;
   accruedInterest?: number;
   accruedInterestValue?: number;
-  ltvUsage?: number;
   liquidationPrice?: number;
   network?: string;
   poolId?: string;
@@ -47,7 +46,6 @@ const PortfolioTableMobileCard = ({
   rewardBonusAprPercent,
   accruedInterest,
   accruedInterestValue,
-  ltvUsage,
   liquidationPrice,
   network,
   poolId,
@@ -219,75 +217,29 @@ const PortfolioTableMobileCard = ({
           </div>
         )}
 
-        {/* Additional Info Grid (borrow positions only) */}
-        {!isDeposit && (
-        <div className="grid grid-cols-2 gap-3 pt-2 border-t border-border">
-              {ltvUsage !== undefined && (
-                <div>
-                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
-                    LTV Usage
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="w-3 h-3 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        <p className="text-sm">
-                          Your borrow&apos;s value in USD, compared to this
-                          lending pool&apos;s total collateral (from on-chain
-                          data).
-                        </p>
-                        <p className="text-xs text-muted-foreground mt-2">
-                          If this row isn&apos;t linked to a pool, we use your
-                          portfolio-wide collateral instead.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2 max-w-[60px]">
-                      <div
-                        className={`h-2 rounded-full ${
-                          ltvUsage >= 80
-                            ? "bg-red-500"
-                            : ltvUsage >= 60
-                            ? "bg-orange-500"
-                            : ltvUsage >= 40
-                            ? "bg-yellow-500"
-                            : "bg-green-500"
-                        }`}
-                        style={{
-                          width: `${Math.min(ltvUsage, 100)}%`,
-                        }}
-                      />
-                    </div>
-                    <span className="text-sm font-semibold">
-                      {ltvUsage.toFixed(1)}%
-                    </span>
-                  </div>
-                </div>
-              )}
-              {liquidationPrice !== undefined && (
-                <div>
-                  <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
-                    Liquidation Price
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="w-3 h-3 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        <p>Estimated price at which liquidation could occur</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <div className="text-sm font-semibold">
-                    ${liquidationPrice.toLocaleString("en-US", {
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 4,
-                    })}
-                  </div>
-                </div>
-              )}
-        </div>
+        {/* Liquidation price (borrow, when enabled) */}
+        {!isDeposit && liquidationPrice !== undefined && (
+          <div className="pt-2 border-t border-border">
+            <div>
+              <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
+                Liquidation Price
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="w-3 h-3 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    <p>Estimated price at which liquidation could occur</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <div className="text-sm font-semibold">
+                ${liquidationPrice.toLocaleString("en-US", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 4,
+                })}
+              </div>
+            </div>
+          </div>
         )}
 
         {/* Action Buttons */}

--- a/src/hooks/usePortfolioVisibleChainLive.ts
+++ b/src/hooks/usePortfolioVisibleChainLive.ts
@@ -270,7 +270,8 @@ type FetchMode = "api" | "chain";
 
 /**
  * After API-backed portfolio load, track visible rows:
- * - **api** — `POST /user-data/user/...` (indexer), with direct reads as fallback
+ * - **api** — for each visible group, `POST /market-data/...` then
+ *   `POST /user-data/user/...` (indexer), with direct reads as fallback
  * - **chain** — direct contract reads only (interval polling)
  */
 export function usePortfolioVisibleChainLive(opts: {
@@ -467,6 +468,32 @@ export function usePortfolioVisibleChainLive(opts: {
     }
 
     for (const group of groups.values()) {
+      // POST `/market-data/...` so the API refreshes its chain snapshot for this
+      // visible position before we load fresh user data (indexer) for the same group.
+      try {
+        const marketPostRes = await dorkfiAPIService.fetchFreshMarketData(
+          group.network,
+          group.appId,
+          group.marketId
+        );
+        if (marketPostRes?.success && marketPostRes.data && group.market) {
+          const d = marketPostRes.data;
+          if (d.price != null) {
+            group.market = { ...group.market, price: String(d.price) };
+          }
+        }
+      } catch (e) {
+        console.warn(
+          "[usePortfolioVisibleChainLive] fetchFreshMarketData (POST) failed",
+          {
+            network: group.network,
+            appId: group.appId,
+            marketId: group.marketId,
+          },
+          e
+        );
+      }
+
       const tokenPrice = group.market?.price
         ? formatPriceFromContract(
             group.market.price as string | number,

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -102,6 +102,7 @@ import {
   GovernanceConfig,
   isCurrentNetworkAVM,
   getAlgorandNetworkFromNetworkId,
+  isAlgorandCompatibleNetwork,
   type TokenStandard,
 } from "@/config";
 import { useNetwork } from "@/contexts/NetworkContext";
@@ -171,6 +172,7 @@ import {
   refreshAllLendingBackendSnapshots,
   type RefreshAllSnapshotsResult,
 } from "@/utils/refreshAllLendingBackendSnapshots";
+import { signAndSendSyncUserMarketsForPriceChangeTx } from "@/utils/syncUserMarketsForPriceChange";
 import { ARC200Service } from "@/services/arc200Service";
 import { TokenContractModal } from "@/components/ui/TokenContractModal";
 import {
@@ -439,6 +441,84 @@ export default function AdminDashboard() {
   const [borrowDebugLoading, setBorrowDebugLoading] = useState(false);
   const [borrowDebugApiLoading, setBorrowDebugApiLoading] = useState(false);
   const [borrowDebugQuickPick, setBorrowDebugQuickPick] = useState("__manual__");
+
+  /** Tools: on-chain sync_user_market_for_price_change (after oracle / price updates) */
+  const [pcSyncNetwork, setPcSyncNetwork] = useState<NetworkId>(
+    () => currentNetwork as NetworkId
+  );
+  const [pcSyncUserAddress, setPcSyncUserAddress] = useState("");
+  const [pcSyncPoolId, setPcSyncPoolId] = useState("");
+  const [pcSyncMarketId, setPcSyncMarketId] = useState("");
+  const [pcSyncLoading, setPcSyncLoading] = useState(false);
+  const [pcSyncLastResult, setPcSyncLastResult] = useState<string | null>(null);
+  const [pcSyncError, setPcSyncError] = useState<string | null>(null);
+  const [pcSyncQuickPick, setPcSyncQuickPick] = useState("__manual__");
+
+  const pcSyncTokenOptions = useMemo(() => {
+    return getAllTokensWithDisplayInfo(pcSyncNetwork).filter(
+      (t) => t.underlyingContractId && t.poolId
+    );
+  }, [pcSyncNetwork]);
+
+  useEffect(() => {
+    if (activeAccount?.address && !pcSyncUserAddress) {
+      setPcSyncUserAddress(activeAccount.address);
+    }
+  }, [activeAccount?.address, pcSyncUserAddress]);
+
+  useEffect(() => {
+    setPcSyncQuickPick("__manual__");
+  }, [pcSyncNetwork]);
+
+  const handleSyncUserForPriceChange = useCallback(async () => {
+    const u = pcSyncUserAddress.trim();
+    const p = pcSyncPoolId.trim();
+    const m = pcSyncMarketId.trim();
+    if (!activeAccount?.address) {
+      toast.error("Connect a wallet to sign.");
+      return;
+    }
+    if (!u || !p) {
+      toast.error("User address and pool (lending app) ID are required.");
+      return;
+    }
+    if (!signTransactions) {
+      toast.error("Wallet does not support signing transaction groups.");
+      return;
+    }
+    if (!isAlgorandCompatibleNetwork(pcSyncNetwork)) {
+      toast.error("This tool only supports Algorand-compatible networks.");
+      return;
+    }
+    setPcSyncLoading(true);
+    setPcSyncError(null);
+    setPcSyncLastResult(null);
+    try {
+      const r = await signAndSendSyncUserMarketsForPriceChangeTx(
+        u,
+        p,
+        m || undefined,
+        activeAccount.address,
+        signTransactions
+      );
+      const line = `Synced ${r.marketsSynced} market(s) in pool ${r.poolId} · tx ${r.txid} · ${r.networkId}`;
+      setPcSyncLastResult(line);
+      toast.success("sync_user_market_for_price_change confirmed.");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setPcSyncError(msg);
+      toast.error(msg);
+    } finally {
+      setPcSyncLoading(false);
+    }
+  }, [
+    activeAccount?.address,
+    pcSyncUserAddress,
+    pcSyncPoolId,
+    pcSyncMarketId,
+    pcSyncNetwork,
+    signTransactions,
+  ]);
 
   useEffect(() => {
     if (activeAccount?.address && !borrowDebugAddress) {
@@ -11749,11 +11829,12 @@ export default function AdminDashboard() {
                   Borrow position debugger (authoritative)
                 </CardTitle>
                 <CardDescription>
-                  Reads <code className="text-xs">get_user</code> and{" "}
-                  <code className="text-xs">sync_market</code> for market indices
-                  (accrued interest / debt uses the same index path as{" "}
-                  <code className="text-xs">fetchUserBorrowBalance</code>). Use this to
-                  compare against indexer/API rows after{" "}
+                  Reads <code className="text-xs">get_user</code>,{" "}
+                  <code className="text-xs">sync_market</code>, and{" "}
+                  <code className="text-xs">get_market</code> (indices and last update; debt
+                  math uses <code className="text-xs">sync_market</code>, same as{" "}
+                  <code className="text-xs">fetchUserBorrowBalance</code>). Compare
+                  against indexer/API rows after{" "}
                   <code className="text-xs">fetchFreshUserData</code>.
                 </CardDescription>
               </CardHeader>
@@ -11900,20 +11981,83 @@ export default function AdminDashboard() {
                       <span className="break-all">{borrowDebugChain.scaledBorrows}</span>
                       <span className="text-muted-foreground">user borrowIndex</span>
                       <span className="break-all">{borrowDebugChain.userBorrowIndex}</span>
-                      <span className="text-muted-foreground">market borrowIndex</span>
+                      <span className="text-muted-foreground">
+                        sync_market · borrowIndex
+                      </span>
                       <span className="break-all">{borrowDebugChain.marketBorrowIndex}</span>
-                      <span className="text-muted-foreground">total debt (underlying)</span>
+                      <span className="text-muted-foreground">
+                        sync_market · depositIndex
+                      </span>
+                      <span className="break-all">
+                        {borrowDebugChain.marketDepositIndex}
+                      </span>
+                      <span className="text-muted-foreground">sync_market · last update</span>
+                      <span className="break-all">
+                        {borrowDebugChain.syncMarketChainLastUpdateIso || "—"}
+                      </span>
+                      <span className="text-muted-foreground">
+                        get_market · borrowIndex
+                      </span>
+                      <span className="break-all">
+                        {borrowDebugChain.getMarketBorrowIndex}
+                      </span>
+                      <span className="text-muted-foreground">
+                        get_market · depositIndex
+                      </span>
+                      <span className="break-all">
+                        {borrowDebugChain.getMarketDepositIndex}
+                      </span>
+                      <span className="text-muted-foreground">get_market · last update</span>
+                      <span className="break-all">
+                        {borrowDebugChain.getMarketChainLastUpdateIso || "—"}
+                      </span>
+                      <span className="text-muted-foreground">
+                        get vs sync (indices match)
+                      </span>
+                      <span
+                        className={
+                          borrowDebugChain.getSyncMarketIndexMatch
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-amber-700 dark:text-amber-300"
+                        }
+                      >
+                        {borrowDebugChain.getSyncMarketIndexMatch ? "yes" : "no (diverged)"}
+                      </span>
+                      <span className="text-muted-foreground">
+                        total_debt (sync_market I_mkt)
+                      </span>
                       <span>
-                        {borrowDebugChain.totalDebtUnderlying.toLocaleString(undefined, {
-                          maximumFractionDigits: 8,
-                        })}{" "}
+                        {borrowDebugChain.totalDebtFromSyncMarket.toLocaleString(
+                          undefined,
+                          { maximumFractionDigits: 8 }
+                        )}{" "}
                         {borrowDebugChain.tokenSymbol}
                       </span>
                       <span className="text-muted-foreground">
-                        accrued (index delta)
+                        total_debt (get_market I_mkt)
                       </span>
                       <span>
-                        {borrowDebugChain.accruedInterestUnderlying.toLocaleString(
+                        {borrowDebugChain.totalDebtFromGetMarket.toLocaleString(
+                          undefined,
+                          { maximumFractionDigits: 8 }
+                        )}{" "}
+                        {borrowDebugChain.tokenSymbol}
+                      </span>
+                      <span className="text-muted-foreground">
+                        accrued (index delta, sync I_mkt)
+                      </span>
+                      <span>
+                        {borrowDebugChain.accruedInterestFromSyncMarket.toLocaleString(
+                          undefined,
+                          { maximumFractionDigits: 8 }
+                        )}{" "}
+                        {borrowDebugChain.tokenSymbol}
+                      </span>
+                      <span className="text-muted-foreground">
+                        accrued (index delta, get I_mkt)
+                      </span>
+                      <span>
+                        {borrowDebugChain.accruedInterestFromGetMarket.toLocaleString(
                           undefined,
                           { maximumFractionDigits: 8 }
                         )}{" "}
@@ -11994,6 +12138,140 @@ export default function AdminDashboard() {
                       read.
                     </p>
                   </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-teal-500/25 bg-teal-500/[0.03]">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <RefreshCcw className="h-5 w-5 text-teal-600 dark:text-teal-400" />
+                  Sync user for price change
+                </CardTitle>
+                <CardDescription>
+                  Submits the lending app{" "}
+                  <code className="text-xs">sync_user_market_for_price_change</code> for a
+                  user and pool (and optionally one market). Use after oracle / asset
+                  price updates so a user’s stored <code className="text-xs">lastPrice</code>{" "}
+                  and health reflect the new price. If market ID is left empty, all
+                  markets configured for that pool in token config are synced. Same
+                  build path as{" "}
+                  <span className="text-muted-foreground">Portfolio (view-only)</span>.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+                  <div className="space-y-2">
+                    <Label>Network (config lookup)</Label>
+                    <Select
+                      value={pcSyncNetwork}
+                      onValueChange={(v) => setPcSyncNetwork(v as NetworkId)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Network" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {getEnabledNetworks().map((nid) => (
+                          <SelectItem key={nid} value={nid}>
+                            {nid}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2 md:col-span-2">
+                    <Label>User to sync (Algorand address)</Label>
+                    <Input
+                      className="font-mono text-xs"
+                      placeholder="Account whose user row is updated"
+                      value={pcSyncUserAddress}
+                      onChange={(e) => setPcSyncUserAddress(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Quick fill (token)</Label>
+                    <Select
+                      value={pcSyncQuickPick}
+                      onValueChange={(v) => {
+                        setPcSyncQuickPick(v);
+                        if (v === "__manual__") return;
+                        const t = pcSyncTokenOptions.find(
+                          (x) =>
+                            `${x.symbol}|${x.poolId}|${x.underlyingContractId}` ===
+                            v
+                        );
+                        if (t?.poolId && t.underlyingContractId) {
+                          setPcSyncPoolId(String(t.poolId));
+                          setPcSyncMarketId(String(t.underlyingContractId));
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Pick market" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__manual__">— manual —</SelectItem>
+                        {pcSyncTokenOptions.map((t) => (
+                          <SelectItem
+                            key={`pcsync-${t.symbol}-${t.poolId}-${t.underlyingContractId}`}
+                            value={`${t.symbol}|${t.poolId}|${t.underlyingContractId}`}
+                          >
+                            {t.symbol} · pool {t.poolId} · mkt {t.underlyingContractId}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <div className="space-y-2">
+                    <Label>Pool (lending app ID)</Label>
+                    <Input
+                      className="font-mono text-xs"
+                      value={pcSyncPoolId}
+                      onChange={(e) => setPcSyncPoolId(e.target.value)}
+                      placeholder="e.g. 3345940978"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Market (optional — underlying ASA / app id)</Label>
+                    <Input
+                      className="font-mono text-xs"
+                      value={pcSyncMarketId}
+                      onChange={(e) => setPcSyncMarketId(e.target.value)}
+                      placeholder="Empty = sync all markets in pool (from config)"
+                    />
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={() => void handleSyncUserForPriceChange()}
+                    disabled={pcSyncLoading || !activeAccount?.address}
+                  >
+                    {pcSyncLoading ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        Signing…
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCcw className="h-4 w-4 mr-2" />
+                        Sign &amp; send sync
+                      </>
+                    )}
+                  </Button>
+                </div>
+                {pcSyncError && (
+                  <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                    {pcSyncError}
+                  </div>
+                )}
+                {pcSyncLastResult && (
+                  <p className="text-xs font-mono text-muted-foreground break-all">
+                    {pcSyncLastResult}
+                  </p>
                 )}
               </CardContent>
             </Card>

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1037,7 +1037,7 @@ export const fetchAllMarkets = async (
             `Fetching market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
           );
 
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId); // uses API by default
+          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId, "contract", "sync_market"); // uses API by default
 
           if (marketInfo) {
             console.log(
@@ -1747,19 +1747,31 @@ export type BorrowPositionChainDebug = {
   scaledDeposits: string;
   userBorrowIndex: string;
   userDepositIndex: string;
+  /** From `sync_market` (accrue path; used for debt math). */
   marketBorrowIndex: string;
   marketDepositIndex: string;
+  /** From `get_market` (storage read; may differ from `sync_market` on indices until accrual). */
+  getMarketBorrowIndex: string;
+  getMarketDepositIndex: string;
+  getMarketChainLastUpdateIso: string;
+  syncMarketChainLastUpdateIso: string;
+  /** `true` when get_market and sync_market return the same deposit/borrow indices. */
+  getSyncMarketIndexMatch: boolean;
   userLastUpdateTime: string;
-  totalDebtUnderlying: number;
-  accruedInterestUnderlying: number;
+  /** `scaledBorrows × I_market ÷ SCALE` with `I_market` from `sync_market`. */
+  totalDebtFromSyncMarket: number;
+  /** Same formula with `I_market` from `get_market` (storage; may differ from sync). */
+  totalDebtFromGetMarket: number;
+  accruedInterestFromSyncMarket: number;
+  accruedInterestFromGetMarket: number;
   actualBorrowsRaw: string;
   interestRaw: string;
 };
 
 /**
  * Read `get_user` + market state from contracts and compute total debt / index-delta interest.
- * Uses `sync_market` for current indices so accrued-interest / debt math matches on-chain accrual
- * (same as {@link fetchUserBorrowBalance}).
+ * Fetches both `sync_market` and `get_market` for comparison; **debt math** uses
+ * `sync_market` indices (same as {@link fetchUserBorrowBalance}).
  * Use this as the source of truth when comparing Portfolio/API display issues.
  */
 export async function fetchBorrowPositionChainDebug(
@@ -1819,7 +1831,7 @@ export async function fetchBorrowPositionChainDebug(
       };
     }
 
-    const [marketInfo, borrowAmountR] = await Promise.all([
+    const [marketInfoSync, marketInfoGet, borrowAmountR] = await Promise.all([
       fetchMarketInfo(
         poolId,
         marketId,
@@ -1827,27 +1839,50 @@ export async function fetchBorrowPositionChainDebug(
         "contract",
         "sync_market"
       ),
+      fetchMarketInfo(
+        poolId,
+        marketId,
+        networkId,
+        "contract",
+        "get_market"
+      ),
       ci.get_user_borrow_amount(userAddress, Number(marketId)),
     ]);
-    if (!marketInfo) {
+    if (!marketInfoSync) {
       return {
         ok: false,
         error: "fetchMarketInfo (contract, sync_market) failed",
       };
     }
+    if (!marketInfoGet) {
+      return {
+        ok: false,
+        error: "fetchMarketInfo (contract, get_market) failed",
+      };
+    }
+
+    const getSyncMarketIndexMatch =
+      String(marketInfoGet.borrowIndex) === String(marketInfoSync.borrowIndex) &&
+      String(marketInfoGet.depositIndex) === String(marketInfoSync.depositIndex);
 
     const scaledBorrows = userData.scaledBorrows.toString();
     const scaledDeposits = userData.scaledDeposits.toString();
     const userBorrowIndex = userData.borrowIndex.toString();
     const userDepositIndex = userData.depositIndex.toString();
-    const currentBorrowIndex = marketInfo.borrowIndex;
-    const marketDepositIndex = marketInfo.depositIndex;
+    const currentBorrowIndex = marketInfoSync.borrowIndex;
+    const marketDepositIndex = marketInfoSync.depositIndex;
     const decimals = token.decimals;
 
-    const debt = borrowDebtFromScaledAndIndices(
+    const debtSync = borrowDebtFromScaledAndIndices(
       scaledBorrows,
       userBorrowIndex,
       String(currentBorrowIndex),
+      decimals
+    );
+    const debtGet = borrowDebtFromScaledAndIndices(
+      scaledBorrows,
+      userBorrowIndex,
+      String(marketInfoGet.borrowIndex),
       decimals
     );
     const SCALE = BORROW_INDEX_SCALE;
@@ -1882,9 +1917,16 @@ export async function fetchBorrowPositionChainDebug(
         userDepositIndex,
         marketBorrowIndex: String(currentBorrowIndex),
         marketDepositIndex: String(marketDepositIndex),
+        getMarketBorrowIndex: String(marketInfoGet.borrowIndex),
+        getMarketDepositIndex: String(marketInfoGet.depositIndex),
+        getMarketChainLastUpdateIso: marketInfoGet.chainLastUpdateIso ?? "",
+        syncMarketChainLastUpdateIso: marketInfoSync.chainLastUpdateIso ?? "",
+        getSyncMarketIndexMatch,
         userLastUpdateTime: userData.lastUpdateTime.toString(),
-        totalDebtUnderlying: debt.totalDebt,
-        accruedInterestUnderlying: debt.indexIncrementAccrued,
+        totalDebtFromSyncMarket: debtSync.totalDebt,
+        totalDebtFromGetMarket: debtGet.totalDebt,
+        accruedInterestFromSyncMarket: debtSync.indexIncrementAccrued,
+        accruedInterestFromGetMarket: debtGet.indexIncrementAccrued,
         actualBorrowsRaw: actualBorrowsRaw.toString(),
         interestRaw: interestRaw.toString(),
       },
@@ -4111,8 +4153,8 @@ export const deposit = async (
       )
         ? poolId != null && poolId !== ""
           ? rawTokenConfigForDeposit.find(
-              (c) => String(c.poolId) === String(poolId)
-            ) ?? rawTokenConfigForDeposit[0]
+            (c) => String(c.poolId) === String(poolId)
+          ) ?? rawTokenConfigForDeposit[0]
           : rawTokenConfigForDeposit[0]
         : rawTokenConfigForDeposit;
 
@@ -6212,6 +6254,17 @@ export const repay = async (
             payment: p2 > 0 ? 28502 : 0,
           });
         }
+        // sync user market for price change
+        // {
+        //   const txnO = (
+        //     await builder.lending.sync_user_market_for_price_change(userAddress, Number(marketId))
+        //   ).obj as any;
+        //   buildN.push({
+        //     ...txnO,
+        //     payment: 1e5 + 0,
+        //     note: new TextEncoder().encode("lending sync_user_market_for_price_change"),
+        //   });
+        // }
         // repay tp lending pool
         {
           const txnO = (

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1037,7 +1037,7 @@ export const fetchAllMarkets = async (
             `Fetching market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
           );
 
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId, "contract", "sync_market"); // uses API by default
+          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId); // fetch from api
 
           if (marketInfo) {
             console.log(

--- a/src/utils/syncUserMarketsForPriceChange.ts
+++ b/src/utils/syncUserMarketsForPriceChange.ts
@@ -1,0 +1,174 @@
+/**
+ * Build, sign, and submit `sync_user_market_for_price_change` for one pool (optionally one market).
+ * After oracle price updates, this refreshes a user’s stored position price / index state on the lending app.
+ * Used from Portfolio and Admin.
+ */
+import algosdk from "algosdk";
+import { abi, CONTRACT } from "ulujs";
+import { APP_SPEC as LendingPoolAppSpec } from "@/clients/DorkFiLendingPoolClient";
+import algorandService from "@/services/algorandService";
+import {
+  getAllTokensWithDisplayInfo,
+  getAlgorandNetworkFromNetworkId,
+  getEnabledNetworks,
+  getNetworkConfig,
+  isAlgorandCompatibleNetwork,
+  type NetworkId,
+} from "@/config";
+import { updateTransactionMetadata } from "@/utils/transactionUtils";
+
+export type SyncUserMarketsForPriceChangeResult = {
+  txid: string;
+  networkId: NetworkId;
+  marketsSynced: number;
+  poolId: string;
+};
+
+function resolveNetworkForPool(poolId: string): NetworkId | null {
+  for (const networkId of getEnabledNetworks()) {
+    const networkConfig = getNetworkConfig(networkId);
+    const lendingPools = networkConfig?.contracts?.lendingPools || [];
+    if (lendingPools.some((p) => String(p) === String(poolId))) {
+      return networkId as NetworkId;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param userAddress - Account whose user market data is synced (usually the same as the signing wallet)
+ * @param signTransactions - Wallet `signTransactions` (unsigned txn bytes, same as Portfolio)
+ */
+export async function signAndSendSyncUserMarketsForPriceChangeTx(
+  userAddress: string,
+  poolId: string,
+  marketId: string | undefined,
+  signWalletAddress: string,
+  signTransactions: (
+    txns: Uint8Array[]
+  ) => Promise<Uint8Array | Uint8Array[]>
+): Promise<SyncUserMarketsForPriceChangeResult> {
+  if (!userAddress?.trim() || !poolId?.trim()) {
+    throw new Error("user address and pool app id are required");
+  }
+
+  const marketNetworkId = resolveNetworkForPool(String(poolId));
+  if (!marketNetworkId) {
+    throw new Error(
+      `No enabled network in config contains lending pool id ${poolId}. Check config lendingPools.`
+    );
+  }
+  if (!isAlgorandCompatibleNetwork(marketNetworkId)) {
+    throw new Error("Only Algorand-compatible networks support this call.");
+  }
+
+  const algorandNetwork = getAlgorandNetworkFromNetworkId(marketNetworkId);
+  if (!algorandNetwork) {
+    throw new Error(`No Algorand client mapping for network ${marketNetworkId}`);
+  }
+
+  const clients = algorandService.initializeClients(algorandNetwork);
+
+  let marketsToSync: Array<{ poolId: string; marketId: string }> = [];
+
+  if (marketId?.trim()) {
+    marketsToSync = [{ poolId, marketId: String(marketId).trim() }];
+  } else {
+    const tokens = getAllTokensWithDisplayInfo(marketNetworkId);
+    const matchingTokens = tokens.filter((t) => String(t.poolId) === String(poolId));
+    for (const token of matchingTokens) {
+      if (token.underlyingContractId) {
+        marketsToSync.push({
+          poolId,
+          marketId: token.underlyingContractId,
+        });
+      }
+    }
+  }
+
+  if (marketsToSync.length === 0) {
+    throw new Error(
+      marketId?.trim()
+        ? "No market to sync (check market / underlying id)."
+        : "No token config markets for this pool — provide a market id or check config."
+    );
+  }
+
+  const ci = new CONTRACT(
+    Number(poolId),
+    clients.algod,
+    clients.indexer,
+    abi.custom,
+    {
+      addr: signWalletAddress,
+      sk: new Uint8Array(),
+    }
+  );
+
+  const builder = {
+    lending: new CONTRACT(
+      Number(poolId),
+      clients.algod,
+      clients.indexer,
+      { ...LendingPoolAppSpec.contract, events: [] },
+      {
+        addr: signWalletAddress,
+        sk: new Uint8Array(),
+      },
+      true,
+      false,
+      true
+    ),
+  };
+
+  const buildN: Record<string, unknown>[] = [];
+  for (const { marketId: syncMarketId } of marketsToSync) {
+    const txnO = (
+      await builder.lending.sync_user_market_for_price_change(
+        userAddress,
+        Number(syncMarketId)
+      )
+    ).obj;
+    buildN.push({
+      ...txnO,
+      note: new TextEncoder().encode(
+        `lending sync_user_market_for_price_change ${syncMarketId}`
+      ),
+      payment: 1e5,
+    });
+  }
+
+  ci.setFee(10000);
+  ci.setEnableGroupResourceSharing(true);
+  ci.setExtraTxns(buildN);
+  if (marketNetworkId === "algorand-mainnet") {
+    ci.setBeaconId(3209233839);
+  }
+
+  const customR = await ci.custom();
+  if (!customR?.success || !Array.isArray(customR.txns) || customR.txns.length === 0) {
+    throw new Error("Failed to build sync transaction group");
+  }
+
+  const algorandClients = await algorandService.initializeClientsForTransactions(
+    algorandNetwork
+  );
+
+  const unsignedB64 = customR.txns as string[];
+  const toSign = unsignedB64.map((txn: string) =>
+    Uint8Array.from(atob(txn), (c) => c.charCodeAt(0))
+  );
+  const stxns = await signTransactions(toSign);
+
+  const res = await algorandClients.algod.sendRawTransaction(stxns as Uint8Array).do();
+  await algosdk.waitForConfirmation(algorandClients.algod, res.txid, 4);
+
+  await updateTransactionMetadata(res.txid, marketNetworkId);
+
+  return {
+    txid: res.txid,
+    networkId: marketNetworkId,
+    marketsSynced: marketsToSync.length,
+    poolId: String(poolId),
+  };
+}


### PR DESCRIPTION
## Summary
Refreshes the portfolio experience around long asset lists, fresher market/user reads, and a single shared path for `sync_user_market_for_price_change` (Portfolio + Admin).

## Portfolio
- **Pagination** for supplied and borrowed assets (10 rows per page with prev/next and "Showing x–y of n"), replacing the previous 5-row show more/less pattern.
- **Default borrow APY sort** is descending; **accrued interest sorting** uses USD (stored value when present, else token amount × price).
- **Remove LTV Usage** from the borrowed table (and related per-pool collateral logic).
- **Modal open** triggers `postRefreshMarketDataSnapshot` for the active market so modals see a fresher API snapshot; full-portfolio `postRefresh` for every position is removed in favor of the visible-row flow in `usePortfolioVisibleChainLive` (see below).
- **Balance display** on one path uses up to 6 fraction digits where appropriate; mobile borrow cards and `Actions` column layout tweaks.
- On-chain **sync** after price/oracle changes uses the new `signAndSendSyncUserMarketsForPriceChangeTx` helper (extracted from inline Portfolio code).

## Live / API flow (`usePortfolioVisibleChainLive`)
- For each **visible** position group, **POST `/market-data/...`** runs before **POST `/user-data/...`**, and returned price (when present) is merged into the in-memory market for that group.

## Admin
- New **"Sync user for price change"** tool: network, user, pool, optional market, quick-pick from token config, sign & send via the same helper as Portfolio.
- **Borrow position debugger** extended with `get_market` vs `sync_market` indices, last update timestamps, total debt / accrued from each path, and a match flag.

## Other
- **Markets table:** Phase 2 Incentive (VOI) reward entry.
- **`lendingService`:** `fetchMarketInfo` call comment; refresh flow no longer pre-POSTs all user positions in one loop (superseded by the hook + modal behavior).
- **New file:** `src/utils/syncUserMarketsForPriceChange.ts`.
- **Version:** `0.1.651` → `0.1.656`.

## Test plan
- [ ] Supplied/borrowed lists with more than 10 rows: pagination, filters reset page, scroll behavior.
- [ ] Open deposit/withdraw/borrow/repay modals: no console errors; market snapshot POST runs.
- [ ] "Sync for price change" from Admin on a test pool: transaction confirms; Portfolio path still works.
- [ ] Admin borrow debugger: new fields make sense for a known position.
