### PR TITLE
feat(markets): fiTINY Folks adapters and live ecosystem intrinsic APY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.678",
+  "version": "0.1.679",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -153,6 +153,7 @@ import { useXalgoGovernanceLiveApyPercent } from "@/hooks/useXalgoGovernanceLive
 import { useFolksMainnetAlgoDepositLiveApyPercent } from "@/hooks/useFolksMainnetAlgoDepositLiveApyPercent";
 import { useFolksMainnetUsdcPoolLiveApyPercent } from "@/hooks/useFolksMainnetUsdcPoolLiveApyPercent";
 import { useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent";
+import { useFolksMainnetFiTinyEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent";
 
 /* eslint-disable no-case-declarations -- many sort switch blocks use const in cases */
 /* eslint-disable react-hooks/exhaustive-deps -- many callbacks intentionally use stable deps subset */
@@ -342,6 +343,9 @@ const Portfolio = () => {
   const folksFiUsdcEcosystemLiveApy = useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent(
     liveIntrinsicApyFetchEnabled
   );
+  const folksFiTinyEcosystemLiveApy = useFolksMainnetFiTinyEcosystemPoolLiveApyPercent(
+    liveIntrinsicApyFetchEnabled
+  );
   const liveIntrinsicSupplyApy = useMemo<LiveIntrinsicSupplyApySnapshot>(
     () => ({
       tinymanLiquidStakingPercent: tinymanLiveIntrinsicApyPct,
@@ -353,6 +357,10 @@ const Portfolio = () => {
         folksFiUsdcEcosystemLiveApy?.depositPercent ?? null,
       folksMainnetFiUsdcEcosystemBorrowPercent:
         folksFiUsdcEcosystemLiveApy?.borrowPercent ?? null,
+      folksMainnetFiTinyEcosystemDepositPercent:
+        folksFiTinyEcosystemLiveApy?.depositPercent ?? null,
+      folksMainnetFiTinyEcosystemBorrowPercent:
+        folksFiTinyEcosystemLiveApy?.borrowPercent ?? null,
     }),
     [
       tinymanLiveIntrinsicApyPct,
@@ -360,6 +368,7 @@ const Portfolio = () => {
       folksAlgoDepositLiveApyPct,
       folksUsdcPoolLiveApy,
       folksFiUsdcEcosystemLiveApy,
+      folksFiTinyEcosystemLiveApy,
     ]
   );
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,7 @@
 import {
   FOLKS_FINANCE_ALGORAND_MAINNET_POOLS_BY_KEY,
   FOLKS_FINANCE_FIUSDC_ADAPTER_POOL_PARAMS,
+  FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
   type FolksFinancePoolParams,
 } from "@/constants/folksFinance";
 
@@ -153,7 +154,8 @@ export interface TokenConfig {
   | "xalgo_governance_lambda"
   | "folks_mainnet_algo_pool_deposit"
   | "folks_mainnet_usdc_pool_deposit"
-  | "folks_mainnet_fiusdc_ecosystem_pool_deposit";
+  | "folks_mainnet_fiusdc_ecosystem_pool_deposit"
+  | "folks_mainnet_fitiny_ecosystem_pool_deposit";
   /**
    * Optional intrinsic borrow APY in percentage points (e.g. 1.5 for 1.5%), added to displayed
    * borrow APY for this listing (e.g. wrapped-asset borrow uplift).
@@ -168,7 +170,8 @@ export interface TokenConfig {
   | "xalgo_governance_lambda"
   | "folks_mainnet_algo_pool_deposit"
   | "folks_mainnet_usdc_pool_borrow"
-  | "folks_mainnet_fiusdc_ecosystem_pool_borrow";
+  | "folks_mainnet_fiusdc_ecosystem_pool_deposit"
+  | "folks_mainnet_fitiny_ecosystem_pool_deposit";
   /**
    * Optional wrapped-asset / bridge adapters (e.g. Folks mint/redeem), in order.
    * Use {@link TokenAdapterConfig.phases} to split deposit vs withdraw legs, and `id` + `label`
@@ -528,6 +531,87 @@ export const FOLKS_MAINNET_FIUSDC_REPAY_UNDERLYING = {
   repayWalletBasis: "underlying" as const,
   phases: ["repay"] as const,
   folksParams: FOLKS_FINANCE_FIUSDC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+/** Folks Algorand Ecosystem TINY (fiTINY) — same phase split as {@link FOLKS_MAINNET_FIUSDC_DEPOSIT_FIUSDC_WALLET}. */
+export const FOLKS_MAINNET_FITINY_DEPOSIT_FITINY_WALLET = {
+  id: "folks-mainnet-fitiny-deposit-fitiny",
+  name: "fiTINY",
+  type: "folks" as const,
+  label: "fiTINY",
+  depositWalletBasis: "market_token" as const,
+  phases: ["deposit"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_DEPOSIT_UNDERLYING = {
+  id: "folks-mainnet-fitiny-deposit-tiny",
+  name: "TINY",
+  type: "folks" as const,
+  label: "TINY",
+  depositWalletBasis: "underlying" as const,
+  phases: ["deposit"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_WITHDRAW = {
+  id: "folks-mainnet-fitiny-withdraw-tiny",
+  name: "TINY",
+  type: "folks" as const,
+  label: "TINY",
+  withdrawReceiveBasis: "underlying" as const,
+  phases: ["withdraw"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_WITHDRAW_FASSET_WALLET = {
+  id: "folks-mainnet-fitiny-withdraw-fitiny",
+  name: "fiTINY",
+  type: "folks" as const,
+  label: "fiTINY",
+  withdrawReceiveBasis: "market_token" as const,
+  phases: ["withdraw"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_BORROW_FITINY_WALLET = {
+  id: "folks-mainnet-fitiny-borrow-fitiny",
+  name: "fiTINY",
+  type: "folks" as const,
+  label: "fiTINY",
+  borrowReceiveBasis: "market_token" as const,
+  phases: ["borrow"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_BORROW_UNDERLYING = {
+  id: "folks-mainnet-fitiny-borrow-tiny",
+  name: "TINY",
+  type: "folks" as const,
+  label: "TINY",
+  borrowReceiveBasis: "underlying" as const,
+  phases: ["borrow"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_REPAY_FITINY_WALLET = {
+  id: "folks-mainnet-fitiny-repay-fitiny",
+  name: "fiTINY",
+  type: "folks" as const,
+  label: "fiTINY",
+  repayWalletBasis: "market_token" as const,
+  phases: ["repay"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_FITINY_REPAY_UNDERLYING = {
+  id: "folks-mainnet-fitiny-repay-tiny",
+  name: "TINY",
+  type: "folks" as const,
+  label: "TINY",
+  repayWalletBasis: "underlying" as const,
+  phases: ["repay"] as const,
+  folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
 } satisfies TokenAdapterConfig;
 
 export type FolksTokenAdapterConfig = Extract<
@@ -2220,7 +2304,7 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
     intrinsicApyPercent: 7.78,
     intrinsicBorrowApyPercent: 7.78,
     intrinsicApyLiveSource: "folks_mainnet_fiusdc_ecosystem_pool_deposit",
-    intrinsicBorrowApyLiveSource: "folks_mainnet_fiusdc_ecosystem_pool_borrow",
+    intrinsicBorrowApyLiveSource: "folks_mainnet_fiusdc_ecosystem_pool_deposit",
     iconBadgeFromSymbol: "FOLKS",
   },
   UNIT: {
@@ -2286,6 +2370,39 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
     symbol: "TINY",
     logoPath: "/lovable-uploads/TINY.webp",
     tokenStandard: "asa",
+  },
+  fiTINY: {
+    assetId: "3184331789",
+    poolId: "3345940978",
+    contractId: "3540827780",
+    nTokenId: "3540842561",
+    decimals: 6,
+    name: "Folks V2 Isolated TINY",
+    symbol: "fiTINY",
+    marketOverride: {
+      displayName: "TINY",
+      displaySymbol: "TINY",
+      isSmartContract: true,
+    },
+    logoPath: "/lovable-uploads/TINY.webp",
+    tokenStandard: "asa",
+    requireStandaloneFAssetOptInBeforeDeposit: true,
+    adapters: [
+      FOLKS_MAINNET_FITINY_DEPOSIT_FITINY_WALLET,
+      FOLKS_MAINNET_FITINY_DEPOSIT_UNDERLYING,
+      FOLKS_MAINNET_FITINY_WITHDRAW,
+      FOLKS_MAINNET_FITINY_WITHDRAW_FASSET_WALLET,
+      FOLKS_MAINNET_FITINY_BORROW_FITINY_WALLET,
+      FOLKS_MAINNET_FITINY_BORROW_UNDERLYING,
+      FOLKS_MAINNET_FITINY_REPAY_FITINY_WALLET,
+      FOLKS_MAINNET_FITINY_REPAY_UNDERLYING,
+    ],
+    intrinsicApyPercent: 4.66,
+    intrinsicBorrowApyPercent: 4.66,
+    intrinsicApyLiveSource: "folks_mainnet_fitiny_ecosystem_pool_deposit",
+    intrinsicBorrowApyLiveSource: "folks_mainnet_fitiny_ecosystem_pool_deposit",
+    iconBadgeFromSymbol: "FOLKS",
+    dataAddedAt: "2026-04-29T00:00:00.000Z",
   },
   FINITE: [{
     assetId: "400593267",
@@ -3424,6 +3541,10 @@ export type LiveIntrinsicSupplyApySnapshot = {
   folksMainnetFiUsdcEcosystemDepositPercent?: number | null;
   /** Folks Algorand Ecosystem USDC pool variable borrow yield, percentage points. */
   folksMainnetFiUsdcEcosystemBorrowPercent?: number | null;
+  /** Folks Algorand Ecosystem TINY pool (fiTINY) deposit yield, percentage points. */
+  folksMainnetFiTinyEcosystemDepositPercent?: number | null;
+  /** Folks Algorand Ecosystem TINY pool variable borrow yield, percentage points. */
+  folksMainnetFiTinyEcosystemBorrowPercent?: number | null;
 };
 
 /**
@@ -3480,6 +3601,13 @@ export const resolveIntrinsicSupplyApyPercent = (
     }
     return base;
   }
+  if (source === "folks_mainnet_fitiny_ecosystem_pool_deposit") {
+    const v = live?.folksMainnetFiTinyEcosystemDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
+      return v;
+    }
+    return base;
+  }
   return base;
 };
 
@@ -3501,7 +3629,8 @@ export const tokenRowUsesLiveIntrinsicApy = (
     s === "xalgo_governance_lambda" ||
     s === "folks_mainnet_algo_pool_deposit" ||
     s === "folks_mainnet_usdc_pool_deposit" ||
-    s === "folks_mainnet_fiusdc_ecosystem_pool_deposit"
+    s === "folks_mainnet_fiusdc_ecosystem_pool_deposit" ||
+    s === "folks_mainnet_fitiny_ecosystem_pool_deposit"
   );
 };
 
@@ -3523,7 +3652,8 @@ export const tokenRowUsesLiveIntrinsicBorrowApy = (
     s === "xalgo_governance_lambda" ||
     s === "folks_mainnet_algo_pool_deposit" ||
     s === "folks_mainnet_usdc_pool_borrow" ||
-    s === "folks_mainnet_fiusdc_ecosystem_pool_borrow"
+    s === "folks_mainnet_fiusdc_ecosystem_pool_borrow" ||
+    s === "folks_mainnet_fitiny_ecosystem_pool_borrow"
   );
 };
 
@@ -3593,6 +3723,13 @@ export const resolveIntrinsicBorrowApyPercent = (
   }
   if (source === "folks_mainnet_fiusdc_ecosystem_pool_borrow") {
     const v = live?.folksMainnetFiUsdcEcosystemBorrowPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
+      return v;
+    }
+    return base;
+  }
+  if (source === "folks_mainnet_fitiny_ecosystem_pool_borrow") {
+    const v = live?.folksMainnetFiTinyEcosystemBorrowPercent;
     if (typeof v === "number" && Number.isFinite(v) && v > 0) {
       return v;
     }

--- a/src/constants/folksFinance.ts
+++ b/src/constants/folksFinance.ts
@@ -282,6 +282,15 @@ export const FOLKS_FINANCE_FIUSDC_ADAPTER_POOL_PARAMS: FolksFinancePoolParams = 
   pool: FOLKS_ALGORAND_ECOSYSTEM_USDC_SDK_POOL_NAME,
 };
 
+/**
+ * Adapter + SDK mint/withdraw params for fiTINY (same app/asset ids as `TINY` in ecosystem table).
+ * `pool` is the Folks SDK mainnet key `ISOLATED_TINY` (not the docs display name `"TINY"`).
+ */
+export const FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS: FolksFinancePoolParams = {
+  ...FOLKS_FINANCE_ALGORAND_ECOSYSTEM_POOLS_BY_KEY.TINY,
+  pool: "ISOLATED_TINY",
+};
+
 /** Resolve a mainnet pool row by `Pool` name from the docs (e.g. `ALGO`, `WBTC (old)`). */
 export function lookupFolksAlgorandMainnetPool(
   pool: string

--- a/src/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent.ts
+++ b/src/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAlgorandNetworkFromNetworkId } from "@/config";
+import algorandService from "@/services/algorandService";
+import {
+  fetchFolksMainnetFiTinyEcosystemPoolApySnapshot,
+  type FolksMainnetUsdcPoolApySnapshot,
+} from "@/services/folksMainnetDepositApyService";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Live Folks Algorand Ecosystem TINY pool APYs (fiTINY) — pass as
+ * `live.folksMainnetFiTinyEcosystemDepositPercent` / `live.folksMainnetFiTinyEcosystemBorrowPercent`.
+ */
+export function useFolksMainnetFiTinyEcosystemPoolLiveApyPercent(
+  enabled: boolean
+): FolksMainnetUsdcPoolApySnapshot | null {
+  const { data } = useQuery({
+    queryKey: ["folks-mainnet-fitiny-ecosystem-pool-apy"],
+    queryFn: async () => {
+      const net = getAlgorandNetworkFromNetworkId("algorand-mainnet");
+      if (!net) {
+        throw new Error("algorand-mainnet not mapped to algod network");
+      }
+      const { algod } = algorandService.initializeClients(net);
+      return fetchFolksMainnetFiTinyEcosystemPoolApySnapshot(algod);
+    },
+    enabled,
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+
+  return data ?? null;
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -30,6 +30,7 @@ import { useXalgoGovernanceLiveApyPercent } from "@/hooks/useXalgoGovernanceLive
 import { useFolksMainnetAlgoDepositLiveApyPercent } from "@/hooks/useFolksMainnetAlgoDepositLiveApyPercent";
 import { useFolksMainnetUsdcPoolLiveApyPercent } from "@/hooks/useFolksMainnetUsdcPoolLiveApyPercent";
 import { useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent";
+import { useFolksMainnetFiTinyEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent";
 import { resolveTokenIconBadgeUrl } from "@/utils/tokenImageUtils";
 
 export interface OnDemandMarketData {
@@ -263,6 +264,9 @@ export const useOnDemandMarketData = ({
   const folksFiUsdcEcosystemLiveApy = useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent(
     algorandMainnetMarkets
   );
+  const folksFiTinyEcosystemLiveApy = useFolksMainnetFiTinyEcosystemPoolLiveApyPercent(
+    algorandMainnetMarkets
+  );
   const liveIntrinsicSupplyApy = useMemo<LiveIntrinsicSupplyApySnapshot>(
     () => ({
       tinymanLiquidStakingPercent: tinymanLiveIntrinsicApyPct,
@@ -274,6 +278,10 @@ export const useOnDemandMarketData = ({
         folksFiUsdcEcosystemLiveApy?.depositPercent ?? null,
       folksMainnetFiUsdcEcosystemBorrowPercent:
         folksFiUsdcEcosystemLiveApy?.borrowPercent ?? null,
+      folksMainnetFiTinyEcosystemDepositPercent:
+        folksFiTinyEcosystemLiveApy?.depositPercent ?? null,
+      folksMainnetFiTinyEcosystemBorrowPercent:
+        folksFiTinyEcosystemLiveApy?.borrowPercent ?? null,
     }),
     [
       tinymanLiveIntrinsicApyPct,
@@ -281,6 +289,7 @@ export const useOnDemandMarketData = ({
       folksAlgoDepositLiveApyPct,
       folksUsdcPoolLiveApy,
       folksFiUsdcEcosystemLiveApy,
+      folksFiTinyEcosystemLiveApy,
     ]
   );
 

--- a/src/services/folksMainnetDepositApyService.ts
+++ b/src/services/folksMainnetDepositApyService.ts
@@ -86,3 +86,22 @@ export async function fetchFolksMainnetFiUsdcEcosystemPoolApySnapshot(
     ),
   };
 }
+
+/**
+ * Folks Algorand Ecosystem TINY pool (fiTINY) deposit + variable borrow yields — same
+ * `retrievePoolInfo` shape as {@link fetchFolksMainnetFiUsdcEcosystemPoolApySnapshot}, using
+ * {@link MainnetPools.ISOLATED_TINY}.
+ */
+export async function fetchFolksMainnetFiTinyEcosystemPoolApySnapshot(
+  algod: Algodv2
+): Promise<FolksMainnetUsdcPoolApySnapshot> {
+  const info = await retrievePoolInfo(algod, MainnetPools.ISOLATED_TINY);
+  return {
+    depositPercent: yieldFixed16ToApyPercentPoints(
+      info.interest.depositInterestYield
+    ),
+    borrowPercent: yieldFixed16ToApyPercentPoints(
+      info.variableBorrow.variableBorrowInterestYield
+    ),
+  };
+}


### PR DESCRIPTION
Add FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS (ISOLATED_TINY) and phase-split Folks adapters on fiTINY (deposit/withdraw/borrow/repay, underlying vs fiTINY).

Wire live deposit/borrow yield from MainnetPools.ISOLATED_TINY via fetchFolksMainnetFiTinyEcosystemPoolApySnapshot and useFolksMainnetFiTinyEcosystemPoolLiveApyPercent; extend LiveIntrinsicSupplyApySnapshot and resolve helpers for folks_mainnet_fitiny_ecosystem_pool_* sources.

Hook into Portfolio and useOnDemandMarketData; enable standalone f-ASA opt-in before deposit (same pattern as fiUSDC). Fix intrinsicBorrowApyLiveSource to use the borrow feed variant.