### PR TITLE
feat(governance): Archives tab, governance API client, search, modal UX

### DIFF
--- a/docs/governance/GOVERNANCE_API_INTEGRATION.md
+++ b/docs/governance/GOVERNANCE_API_INTEGRATION.md
@@ -1,0 +1,169 @@
+# Governance API integration guide
+
+This document explains how to connect **any application** to the same governance HTTP API that **Governance Insight Hub** uses, and how to reuse patterns (or code) from that hub codebase.
+
+**In this repository:** `/governance` has two tabs: **Live** (see `src/services/governanceService.ts` and `src/hooks/useGovernanceData.ts`) and **Archives** (HTTP client in `src/lib/governanceApi.ts`, UI in `src/components/governance/GovernanceApiProposalsPanel.tsx`). **Archives** always calls `GET /proposals` without a `networkId` query (all chains). File paths such as `src/lib/api.ts` and `src/pages/Overview.tsx` below refer to the **Governance Insight Hub** reference app; this repo’s client module is `governanceApi.ts` instead of `api.ts`.
+
+## What you are integrating with
+
+The hub talks to a **JSON REST** service (the “governance node”). Requests are plain `GET` calls with optional query parameters. There is no auth layer in the hub’s reference client; if your deployment adds API keys or cookies, wire those in your own `fetch` wrapper.
+
+Base URL resolution in the hub app:
+
+1. Use `VITE_GOVERNANCE_API_BASE` when set (trimmed, no trailing slash).
+2. Otherwise fall back to  
+   `https://dorkfi-governance-node-production.up.railway.app`.
+
+In another app, mirror that with your framework’s env convention (for example `NEXT_PUBLIC_GOVERNANCE_API_BASE` in Next.js).
+
+## Configuration
+
+### Environment variable (Vite / hub)
+
+| Variable | Purpose |
+|----------|---------|
+| `VITE_GOVERNANCE_API_BASE` | Full origin (`https://api.example.com`) **or** same-origin path to a proxy (`/api/local`, `/api/railway`). |
+
+See `.env.example` in the hub repository root when available.
+
+### Dev proxy (optional)
+
+This repo’s `vite.config.ts` (and the hub’s) define example proxies so the browser never calls a remote origin directly (helps with CORS and ngrok interstitials during development):
+
+- `/api/local` → local governance node (`VITE_GOVERNANCE_LOCAL_TARGET`, default `http://127.0.0.1:8787`)  
+- `/api/railway` → production Railway host  
+- `/api/ngrok` → tunneled host (`VITE_GOVERNANCE_NGROK_TARGET`, same default) with `ngrok-skip-browser-warning`
+
+Point `VITE_GOVERNANCE_API_BASE=/api/local` (or `/api/railway`) while developing, and replicate the same rewrite pattern in **Next.js rewrites**, **webpack devServer.proxy**, or your API gateway.
+
+### Production CORS
+
+If the browser calls the governance API **directly**, the server must allow your site’s origin. If CORS is restrictive, use a **same-origin BFF** (server route) that proxies to the governance node and keep `GOVERNANCE_API_BASE` pointing at your own `/api/governance` path.
+
+## HTTP API surface
+
+All paths below are appended to the configured base (no trailing slash on the base).
+
+### `GET /health`
+
+Returns JSON with at least `status`; optional `database`, `counts`, etc. Typed as `HealthResponse` in `src/lib/api.ts`.
+
+### `GET /proposals`
+
+Query parameters (all optional):
+
+| Parameter | Description |
+|-----------|-------------|
+| `limit` | Page size (hub uses `20`). |
+| `networkId` | **Chain** id filter (e.g. `voi-mainnet`, `algorand-mainnet`). Not a product slug; see “Network IDs” below. |
+| `status` | Server-side status filter when supported. |
+| `cursor` | Opaque pagination cursor from a previous response. |
+
+Response is a JSON object (not always the same shape). The hub accepts:
+
+- `proposals` | `data` | `items` — array of proposals  
+- `nextCursor`, `cursor` — pagination  
+- `hasNextPage`, `hasMore`, `hasNext` — when present, used to decide if another page exists  
+- `activeCount`, `closedCount` — optional server tallies  
+
+Use `proposalsNextPageCursor()` from `src/lib/governanceApi.ts` (or `src/lib/api.ts` in the hub) when porting pagination: it avoids treating a echoed `cursor` as “next page” unless the API explicitly says there is more.
+
+### `GET /proposals/:id`
+
+Single proposal. Same fields as list items, including optional `byNetwork` for multichain aggregates.
+
+### `GET /proposals/:id/votes`
+
+Vote rows; hub reads `votes` or `data` array.
+
+## Response model (high level)
+
+Proposal objects are intentionally loose (`[key: string]: unknown` on types) because the node may evolve. Commonly used fields in the hub:
+
+- Identity: `id`, `title`, `description`, `status`, `createdAt`  
+- Voting: `votingStart`, `votingEnd` (or `startDate` / `endDate`), `votesFor`, `votesAgainst`, `votesAbstain`, `totalVotes`, `quorum`  
+- Multichain: `networkIds[]`, `byNetwork[]` (each row has `networkId`, tallies, power fields)  
+- Power / quorum UI: `proposalTotalPower`, `proposalYesPower` (often strings for bigint-safe values)  
+
+Display helpers worth copying:
+
+- `proposalDisplayStatus` — passed/rejected from power vs **69%** threshold when power fields exist  
+- `proposalYesPowerFraction`, `mergeProposalForNetwork`, `formatNetworkLabel`, `proposalsListNetworkParam`
+
+## Network IDs vs UI slugs
+
+- **`networkId` query param** must be a **chain** identifier the API understands (e.g. `voi-mainnet`, `algorand-mainnet`).
+- The hub’s sidebar may use a **protocol** value like `dorkfi`; `proposalsListNetworkParam()` maps that to **no** `networkId` query (same as “all chains”) so the list does not go empty.
+
+When you add per-chain filters in your own app, pass real chain ids to the API.
+
+## Client implementation notes
+
+### Content-Type and errors
+
+The reference client expects `Content-Type` to include `application/json`. If the body is HTML (common with ngrok interstitials or load balancers), the hub throws:
+
+- `NgrokInterstitialError` — detect ngrok warning pages  
+- `HtmlResponseError` — other HTML responses  
+
+Handle these in your UI (retry, open docs link, or proxy with `ngrok-skip-browser-warning`).
+
+### React + TanStack Query (hub)
+
+`Overview` uses `useQuery` with keys like `["proposals", apiNetworkId, cursor]`. Reuse the same key shape if you copy components so cache invalidation stays predictable.
+
+### Minimal standalone example
+
+```ts
+const BASE = (import.meta as any).env?.VITE_GOVERNANCE_API_BASE?.replace(/\/+$/, "")
+  ?? "https://dorkfi-governance-node-production.up.railway.app";
+
+export async function getProposals(options: {
+  limit?: number;
+  networkId?: string;
+  cursor?: string;
+} = {}) {
+  const sp = new URLSearchParams();
+  if (options.limit) sp.set("limit", String(options.limit));
+  if (options.networkId) sp.set("networkId", options.networkId);
+  if (options.cursor) sp.set("cursor", options.cursor);
+  const q = sp.toString();
+  const res = await fetch(`${BASE}/proposals${q ? `?${q}` : ""}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+```
+
+Adapt `import.meta.env` to `process.env.NEXT_PUBLIC_…` or your runtime.
+
+## Reusing code from Governance Insight Hub
+
+You can treat the hub repo as a **reference implementation** or copy files into a monorepo.
+
+| Area | Location | Notes |
+|------|----------|--------|
+| API + types + helpers | `src/lib/api.ts` | Single module; depends only on `fetch` / `import.meta.env`. |
+| Categories / badges | `src/lib/governanceCategories.ts`, `src/components/ProposalCategoryBadge.tsx` | UI-specific. |
+| Relative dates | `src/lib/formatRelativeTime.ts` | Pure `Intl`; optional `useNow` in `src/hooks/useNow.ts`. |
+| Deep linking pattern | `Overview` + `?proposal=` | Optional UX pattern for embeds. |
+
+Dependencies used by the hub UI (if you copy components): React 18, `react-router-dom`, `@tanstack/react-query`, Tailwind + shadcn-style UI under `src/components/ui/`.
+
+For a **non-React** app, copy only `api.ts` (after renaming env access) and implement your own views.
+
+## Embedding in another product
+
+1. **Iframe** — host the hub (or a route that renders only the overview) and align `VITE_GOVERNANCE_API_BASE` with the same API; watch X-Frame-Options / CSP on both sides.  
+2. **Shared BFF** — your backend proxies `/governance/*` to the node; the SPA uses a relative base.  
+3. **Monorepo package** — extract `src/lib/api.ts` (+ tests in `src/lib/api.governance.test.ts`) into `@org/governance-client` and import from your app.
+
+## Checklist
+
+- [ ] Set base URL for each environment (env + proxy if needed).  
+- [ ] Confirm CORS or use a same-origin proxy.  
+- [ ] List proposals with `limit` + optional `networkId` (chain id only).  
+- [ ] Paginate with `proposalsNextPageCursor` semantics (or your server’s contract).  
+- [ ] Detail view: `GET /proposals/:id` and optional votes endpoint.  
+- [ ] Handle HTML / ngrok error paths if you expose dev tunnels to browsers.  
+
+For behavior specifics (filters, badges, power bar), read the inline usage in `src/pages/Overview.tsx` and `src/components/ProposalsTable.tsx`.

--- a/docs/governance/index.md
+++ b/docs/governance/index.md
@@ -5,5 +5,6 @@ Guides for **DorkFi protocol governance** in this repository: using the Governan
 | Document | Summary |
 |----------|---------|
 | [Governance User Guide](GOVERNANCE_USER_GUIDE.md) | Participant manual: voting power, viewing proposals, single and batch voting, statuses, categories, mobile usage, troubleshooting. |
+| [Governance API integration](GOVERNANCE_API_INTEGRATION.md) | Developer guide: HTTP governance node, env and proxies, endpoints, response shapes, pagination, errors, and reusing hub client patterns. |
 
 Related contributor workflow (not in this folder): [Adding a new governance proposal category](../workflows/ADD_PROPOSAL_CATEGORY_TO_GOVERNANCE.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.687",
+  "version": "0.1.690",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/governance/GovernanceApiProposalsPanel.tsx
+++ b/src/components/governance/GovernanceApiProposalsPanel.tsx
@@ -1,0 +1,533 @@
+import { useState, useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  getGovernanceProposalsPage,
+  governanceApiBase,
+  proposalsNextPageCursor,
+} from "@/lib/governanceApi";
+import { apiRecordToProposal } from "@/utils/apiProposalToProposal";
+import { H2, Body, Caption } from "@/components/ui/Typography";
+import { Button } from "@/components/ui/button";
+import {
+  Loader2,
+  Activity,
+  Archive,
+  RefreshCw,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  HourglassIcon,
+  Search,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import DorkFiCard from "@/components/ui/DorkFiCard";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Proposal, ProposalCategory, ProposalStatus } from "@/types/governanceTypes";
+import {
+  GOVERNANCE_PASS_THRESHOLD_DISPLAY,
+  GOVERNANCE_PASS_THRESHOLD_YES_FRACTION,
+  PROPOSAL_CATEGORY_DISPLAY_NAMES,
+} from "@/constants/governanceConstants";
+import { ProposalDetailsModal } from "@/components/governance/ProposalDetailsModal";
+import { formatDistanceToNow } from "date-fns";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import { Input } from "@/components/ui/input";
+import { proposalMatchesSearch } from "@/utils/proposalSearchMatch";
+
+const PAGE_SIZE = 20;
+
+const categoryColors: Record<ProposalCategory, string> = {
+  "interest-rates": "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  "collateral-listing": "bg-green-500/10 text-green-600 dark:text-green-400",
+  "liquidation-settings": "bg-orange-500/10 text-orange-600 dark:text-orange-400",
+  "treasury": "bg-purple-500/10 text-purple-600 dark:text-purple-400",
+  "features": "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400",
+  "governance": "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  "infrastructure": "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+};
+
+/** Matches `ProposalCard` status chips for a consistent Live / Archives look. */
+const archiveStatusConfig: Record<
+  ProposalStatus,
+  { Icon: typeof Clock; color: string; bg: string }
+> = {
+  active: { Icon: Clock, color: "text-primary", bg: "bg-primary/10" },
+  passed: {
+    Icon: CheckCircle2,
+    color: "text-green-500",
+    bg: "bg-green-500/10",
+  },
+  rejected: {
+    Icon: XCircle,
+    color: "text-destructive",
+    bg: "bg-destructive/10",
+  },
+  pending: {
+    Icon: HourglassIcon,
+    color: "text-muted-foreground",
+    bg: "bg-muted",
+  },
+  executed: {
+    Icon: CheckCircle2,
+    color: "text-green-600 dark:text-green-400",
+    bg: "bg-green-600/10",
+  },
+};
+
+/** Optional compact suffix for Archives status chip (count-only rows only). */
+function archiveStatusThresholdSuffix(proposal: Proposal): string | null {
+  const { status, endTime, votesFor, votesAgainst, usesVotingPowerTally, totalVotes } =
+    proposal;
+  const ended = endTime.getTime() > 0 && endTime.getTime() < Date.now();
+  const powerTally = usesVotingPowerTally === true && totalVotes > 0;
+  const hadCountVotes = votesFor + votesAgainst > 0;
+
+  if (status === "passed" || status === "executed") {
+    if (powerTally) return null;
+    return ` · ≥${GOVERNANCE_PASS_THRESHOLD_DISPLAY}`;
+  }
+  if (status === "rejected" && ended && !powerTally && hadCountVotes) {
+    return ` · <${GOVERNANCE_PASS_THRESHOLD_DISPLAY} yes`;
+  }
+  return null;
+}
+
+function archiveStatusBadgeTitle(proposal: Proposal): string {
+  const powerTally = proposal.usesVotingPowerTally === true;
+  const base = powerTally
+    ? `Passing requires at least ${GOVERNANCE_PASS_THRESHOLD_DISPLAY} yes of total voting power cast once voting has ended (same rule as Live).`
+    : `Passing requires at least ${GOVERNANCE_PASS_THRESHOLD_DISPLAY} yes of votes cast once voting has ended when the node does not expose a power tally (same rule as Live).`;
+  if (proposal.status === "active") {
+    return `${base} This proposal is still open for votes.`;
+  }
+  return base;
+}
+
+function matchesStatusFilter(
+  proposal: Proposal,
+  filter: ProposalStatus | "all"
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "passed") {
+    return proposal.status === "passed" || proposal.status === "executed";
+  }
+  return proposal.status === filter;
+}
+
+function ArchiveQuorumCell({ proposal }: { proposal: Proposal }) {
+  const { formatPercent } = useNumberI18n();
+  const usePower = proposal.usesVotingPowerTally === true;
+  const yesPower = proposal.votesFor;
+  const totalPower =
+    usePower && proposal.totalVotes > 0 ? proposal.totalVotes : 0;
+  const countTotal = proposal.votesFor + proposal.votesAgainst;
+
+  const totalForBar =
+    usePower && totalPower > 0
+      ? totalPower
+      : Math.max(countTotal, proposal.totalVotes, 0);
+  const againstForBar =
+    usePower && totalPower > 0
+      ? Math.max(0, totalPower - yesPower)
+      : proposal.votesAgainst;
+
+  const norm = Math.max(proposal.quorum, totalForBar, 1e-9);
+  const forW = (yesPower / norm) * 100;
+  const againstW = (againstForBar / norm) * 100;
+  const quorumLine = Math.min(100, (proposal.quorum / norm) * 100);
+  const passLinePct = GOVERNANCE_PASS_THRESHOLD_YES_FRACTION * 100;
+
+  const denomForShare =
+    usePower && proposal.totalVotes > 0
+      ? proposal.totalVotes
+      : countTotal > 0
+        ? countTotal
+        : proposal.totalVotes > 0
+          ? proposal.totalVotes
+          : 0;
+  const yesSharePct =
+    denomForShare > 0 ? (yesPower / denomForShare) * 100 : 0;
+
+  if (totalForBar <= 0 && proposal.quorum <= 0) {
+    return <Caption className="text-muted-foreground">—</Caption>;
+  }
+
+  const passLineTitle = usePower
+    ? "Pass threshold (yes ÷ total voting power cast)"
+    : "Pass threshold (yes share of votes cast)";
+
+  return (
+    <div className="space-y-1.5 min-w-[120px] max-w-[200px]">
+      <div className="relative h-2 rounded-full bg-muted overflow-hidden">
+        <div className="absolute inset-y-0 left-0 flex w-full">
+          <div
+            className="h-full bg-green-500 dark:bg-green-500/90 transition-all"
+            style={{ width: `${Math.min(forW, 100)}%` }}
+          />
+          <div
+            className="h-full bg-red-500/85 dark:bg-red-400/80 transition-all"
+            style={{ width: `${Math.min(againstW, 100 - forW)}%` }}
+          />
+        </div>
+        <div
+          className="absolute top-0 bottom-0 w-px bg-amber-400 z-[11] rounded-full shadow-sm pointer-events-none"
+          style={{ left: `${passLinePct}%`, transform: "translateX(-50%)" }}
+          title={passLineTitle}
+        />
+        <div
+          className="absolute top-0 bottom-0 w-0.5 bg-yellow-400 z-10 rounded-full shadow-sm pointer-events-none"
+          style={{ left: `${quorumLine}%`, transform: "translateX(-50%)" }}
+          title="Quorum (participation) reference"
+        />
+      </div>
+      <Caption className="text-muted-foreground tabular-nums">
+        {denomForShare > 0
+          ? `${formatPercent(yesSharePct / 100, { maximumFractionDigits: 1 })} yes`
+          : "No votes yet"}
+      </Caption>
+    </div>
+  );
+}
+
+type GovernanceApiProposalsPanelProps = {
+  /** When false, queries do not run (e.g. inactive tab). */
+  queriesEnabled: boolean;
+};
+
+export function GovernanceApiProposalsPanel({
+  queriesEnabled,
+}: GovernanceApiProposalsPanelProps) {
+  const base = governanceApiBase();
+  const [statusFilter, setStatusFilter] = useState<ProposalStatus | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [detailProposal, setDetailProposal] = useState<Proposal | null>(null);
+
+  const proposalsQuery = useInfiniteQuery({
+    queryKey: ["governance-node-proposals", base],
+    enabled: queriesEnabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
+      const page = await getGovernanceProposalsPage({
+        limit: PAGE_SIZE,
+        cursor: pageParam,
+      });
+      const proposals = page.items.map((item) =>
+        apiRecordToProposal(
+          typeof item === "object" && item !== null
+            ? (item as Record<string, unknown>)
+            : {}
+        )
+      );
+      return {
+        body: page.body,
+        proposals,
+        requestCursor: page.requestCursor,
+      };
+    },
+    getNextPageParam: (lastPage) =>
+      proposalsNextPageCursor(lastPage.body, lastPage.requestCursor),
+  });
+
+  const flatProposals = useMemo(
+    () => proposalsQuery.data?.pages.flatMap((p) => p.proposals) ?? [],
+    [proposalsQuery.data]
+  );
+
+  const firstBody = proposalsQuery.data?.pages[0]?.body;
+  const apiActive =
+    typeof firstBody?.activeCount === "number"
+      ? firstBody.activeCount
+      : undefined;
+  const apiClosed =
+    typeof firstBody?.closedCount === "number"
+      ? firstBody.closedCount
+      : undefined;
+
+  const loadedActive = useMemo(
+    () => flatProposals.filter((p) => p.status === "active").length,
+    [flatProposals]
+  );
+  const loadedClosed = useMemo(
+    () => flatProposals.filter((p) => p.status !== "active").length,
+    [flatProposals]
+  );
+
+  const displayActive = apiActive ?? loadedActive;
+  const displayClosed = apiClosed ?? loadedClosed;
+
+  const proposalsMatchingStatus = useMemo(
+    () => flatProposals.filter((p) => matchesStatusFilter(p, statusFilter)),
+    [flatProposals, statusFilter]
+  );
+
+  const filteredProposals = useMemo(
+    () =>
+      proposalsMatchingStatus.filter((p) =>
+        proposalMatchesSearch(p, searchQuery)
+      ),
+    [proposalsMatchingStatus, searchQuery]
+  );
+
+  const statuses: (ProposalStatus | "all")[] = [
+    "all",
+    "active",
+    "passed",
+    "rejected",
+  ];
+
+  const handleRefresh = () => {
+    void proposalsQuery.refetch();
+  };
+
+  const dateLabel = (p: Proposal) => {
+    const ref =
+      p.status === "pending" || p.status === "active"
+        ? p.startTime
+        : p.endTime;
+    if (!ref || ref.getTime() <= 0) return "—";
+    try {
+      return formatDistanceToNow(ref, { addSuffix: true });
+    } catch {
+      return "—";
+    }
+  };
+
+  return (
+    <div className="space-y-4 mt-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+        <DorkFiCard className="p-4 sm:p-5" hoverable={false}>
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 rounded-xl bg-primary/15 text-primary">
+              <Activity className="h-5 w-5 sm:h-6 sm:w-6" />
+            </div>
+            <div>
+              <Caption className="text-muted-foreground uppercase tracking-wide text-[10px] sm:text-xs">
+                Active proposals
+              </Caption>
+              <div className="text-3xl sm:text-4xl font-bold text-primary tabular-nums">
+                {proposalsQuery.isLoading ? "—" : displayActive}
+              </div>
+            </div>
+          </div>
+        </DorkFiCard>
+        <DorkFiCard className="p-4 sm:p-5" hoverable={false}>
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 rounded-xl bg-green-500/15 text-green-600 dark:text-green-400">
+              <Archive className="h-5 w-5 sm:h-6 sm:w-6" />
+            </div>
+            <div>
+              <Caption className="text-muted-foreground uppercase tracking-wide text-[10px] sm:text-xs">
+                Closed proposals
+              </Caption>
+              <div className="text-3xl sm:text-4xl font-bold text-green-600 dark:text-green-400 tabular-nums">
+                {proposalsQuery.isLoading ? "—" : displayClosed}
+              </div>
+            </div>
+          </div>
+        </DorkFiCard>
+      </div>
+
+      <DorkFiCard className="p-0 overflow-hidden" hoverable={false}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between px-4 pt-4 pb-2 sm:px-5 border-b border-border/60">
+          <H2 className="text-lg sm:text-xl m-0">All proposals</H2>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0 gap-2 w-full sm:w-auto"
+            onClick={handleRefresh}
+            disabled={
+              proposalsQuery.isFetching || proposalsQuery.isFetchingNextPage
+            }
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${proposalsQuery.isFetching ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </Button>
+        </div>
+
+        <div className="px-4 sm:px-5 pb-3 space-y-3">
+          <Tabs
+            value={statusFilter}
+            onValueChange={(v) => setStatusFilter(v as ProposalStatus | "all")}
+          >
+            <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 h-auto min-h-9 p-1 gap-1">
+              {statuses.map((s) => (
+                <TabsTrigger
+                  key={s}
+                  value={s}
+                  className="text-xs sm:text-sm px-2 py-2"
+                >
+                  {s === "all" ? "All" : s.charAt(0).toUpperCase() + s.slice(1)}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+          <div className="relative">
+            <Search
+              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none"
+              aria-hidden
+            />
+            <Input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search title, description, ID, proposer…"
+              className="pl-9"
+              aria-label="Search proposals"
+            />
+          </div>
+        </div>
+
+        <Caption className="px-4 sm:px-5 pb-2 block text-muted-foreground">
+          All chains · read-only · vote on Live
+        </Caption>
+
+        {proposalsQuery.isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          </div>
+        ) : proposalsQuery.isError ? (
+          <div className="text-center py-12 px-4 space-y-2">
+            <p className="text-destructive font-medium">Could not load proposals</p>
+            <Body className="text-sm text-muted-foreground">
+              {proposalsQuery.error instanceof Error
+                ? proposalsQuery.error.message
+                : "Unknown error"}
+            </Body>
+          </div>
+        ) : flatProposals.length === 0 ? (
+          <div className="px-4 pb-8">
+            <p className="text-muted-foreground text-center py-8">
+              No proposals returned.
+            </p>
+          </div>
+        ) : proposalsMatchingStatus.length === 0 ? (
+          <div className="px-4 pb-8">
+            <p className="text-muted-foreground text-center py-8">
+              No proposals match this filter.
+            </p>
+          </div>
+        ) : filteredProposals.length === 0 ? (
+          <div className="px-4 pb-8">
+            <p className="text-muted-foreground text-center py-8">
+              No proposals match your search. Try different keywords or clear the search field.
+            </p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent border-border/60">
+                <TableHead className="min-w-[140px] sm:min-w-[200px]">
+                  Title
+                </TableHead>
+                <TableHead className="w-[100px] sm:w-[120px]">Status</TableHead>
+                <TableHead className="hidden md:table-cell w-[180px]">
+                  Votes / quorum
+                </TableHead>
+                <TableHead className="w-[100px] sm:w-[120px] text-right">
+                  Date
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredProposals.map((proposal) => {
+                const st = archiveStatusConfig[proposal.status];
+                const StatusIcon = st.Icon;
+                const thresholdSuffix = archiveStatusThresholdSuffix(proposal);
+                return (
+                  <TableRow
+                    key={`archive-${proposal.id}`}
+                    className="cursor-pointer border-border/50"
+                    onClick={() => setDetailProposal(proposal)}
+                  >
+                    <TableCell className="align-top py-3">
+                      <div className="space-y-2">
+                        <div className="font-semibold text-sm sm:text-base leading-snug line-clamp-2">
+                          {proposal.title}
+                        </div>
+                        <Badge className={categoryColors[proposal.category]}>
+                          {PROPOSAL_CATEGORY_DISPLAY_NAMES[proposal.category]}
+                        </Badge>
+                        <div className="md:hidden pt-1">
+                          <ArchiveQuorumCell proposal={proposal} />
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="align-top py-3">
+                      <Badge
+                        title={archiveStatusBadgeTitle(proposal)}
+                        className={`${st.bg} border-transparent inline-flex max-w-[11rem] flex-wrap items-center gap-x-1 gap-y-0.5 shrink-0 px-2.5 py-0.5 text-[10px] sm:text-xs font-semibold tracking-wide`}
+                      >
+                        <span className="inline-flex items-center gap-1.5">
+                          <StatusIcon
+                            className={`h-3.5 w-3.5 shrink-0 ${st.color}`}
+                          />
+                          <span className={st.color}>
+                            {proposal.status.toUpperCase()}
+                          </span>
+                        </span>
+                        {thresholdSuffix ? (
+                          <span
+                            className={`font-medium normal-case tracking-tight ${proposal.status === "rejected" ? "text-muted-foreground" : st.color} opacity-90`}
+                          >
+                            {thresholdSuffix}
+                          </span>
+                        ) : null}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell align-middle py-3">
+                      <ArchiveQuorumCell proposal={proposal} />
+                    </TableCell>
+                    <TableCell className="align-top py-3 text-right text-muted-foreground text-xs sm:text-sm tabular-nums whitespace-nowrap">
+                      {dateLabel(proposal)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+
+        {proposalsQuery.hasNextPage && (
+          <div className="flex justify-center p-4 border-t border-border/60">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={proposalsQuery.isFetchingNextPage}
+              onClick={() => proposalsQuery.fetchNextPage()}
+            >
+              {proposalsQuery.isFetchingNextPage ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Loading…
+                </>
+              ) : (
+                "Load more"
+              )}
+            </Button>
+          </div>
+        )}
+      </DorkFiCard>
+
+      {detailProposal ? (
+        <ProposalDetailsModal
+          open
+          onOpenChange={(open) => {
+            if (!open) setDetailProposal(null);
+          }}
+          proposal={detailProposal}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/governance/ProposalCard.tsx
+++ b/src/components/governance/ProposalCard.tsx
@@ -29,6 +29,8 @@ interface ProposalCardProps {
   voteNetworkId?: string;
   batchMode?: boolean;
   isSelectionDisabled?: boolean;
+  /** When true, hides voting and batch UI (e.g. governance HTTP node list). */
+  readOnly?: boolean;
 }
 
 const categoryColors: Record<ProposalCategory, string> = {
@@ -61,6 +63,7 @@ export const ProposalCard = ({
   voteNetworkId,
   batchMode = false,
   isSelectionDisabled = false,
+  readOnly = false,
 }: ProposalCardProps) => {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -138,7 +141,7 @@ export const ProposalCard = ({
         <div className="flex items-start justify-between gap-3 sm:gap-4 flex-wrap">
           <div className="space-y-2 flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              {batchMode && isActive && canVote && userVote === undefined && (
+              {!readOnly && batchMode && isActive && canVote && userVote === undefined && (
                 <Checkbox
                   checked={isSelected}
                   onCheckedChange={handleSelectChange}
@@ -256,7 +259,7 @@ export const ProposalCard = ({
             </Caption>
           )}
 
-          {isActive && (
+          {!readOnly && isActive && (
             <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
               {userVote === undefined ? (
                 batchMode && isSelected ? (

--- a/src/components/governance/ProposalDetailsModal.tsx
+++ b/src/components/governance/ProposalDetailsModal.tsx
@@ -5,31 +5,24 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Proposal } from "@/types/governanceTypes";
 import { PROPOSAL_CATEGORY_DISPLAY_NAMES } from "@/constants/governanceConstants";
-import { 
-  Clock, 
-  TrendingUp, 
-  TrendingDown, 
-  CheckCircle2, 
-  XCircle, 
+import {
+  Clock,
+  TrendingUp,
+  TrendingDown,
+  CheckCircle2,
+  XCircle,
   HourglassIcon,
-  User,
-  Hash,
   Calendar,
   Network,
-  Copy,
 } from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 import { getNetworkConfig } from "@/config";
 import { getNetworkLogoPath } from "@/utils/tokenImageUtils";
 import type { NetworkId } from "@/config";
-import { useState } from "react";
-import { toast } from "@/hooks/use-toast";
-
 interface ProposalDetailsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -60,8 +53,6 @@ export const ProposalDetailsModal = ({
   proposal,
 }: ProposalDetailsModalProps) => {
   const { formatNumber, formatPercent } = useNumberI18n();
-  const [copiedId, setCopiedId] = useState(false);
-  const [copiedProposer, setCopiedProposer] = useState(false);
 
   const StatusIcon = statusConfig[proposal.status].icon;
   const votesForPercent = (proposal.votesFor / Math.max(proposal.totalVotes, 1)) * 100;
@@ -74,36 +65,17 @@ export const ProposalDetailsModal = ({
       ? [proposal.networkId]
       : [];
 
-  const copyToClipboard = async (text: string, type: "id" | "proposer") => {
-    try {
-      await navigator.clipboard.writeText(text);
-      if (type === "id") {
-        setCopiedId(true);
-        setTimeout(() => setCopiedId(false), 2000);
-      } else {
-        setCopiedProposer(true);
-        setTimeout(() => setCopiedProposer(false), 2000);
-      }
-      toast({
-        title: "Copied to clipboard",
-        description: `${type === "id" ? "Proposal ID" : "Proposer address"} copied`,
-      });
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto p-6 sm:p-8">
-        <DialogHeader className="pb-4">
+      <DialogContent className="w-full max-w-lg sm:max-w-xl max-h-[90vh] overflow-y-auto p-8 sm:p-10 sm:pt-12">
+        <DialogHeader className="pb-6">
           <DialogTitle className="text-xl sm:text-2xl">{proposal.title}</DialogTitle>
           <DialogDescription className="text-sm sm:text-base mt-2">
             {proposal.description}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6">
+        <div className="space-y-8">
           {/* Badges */}
           <div className="flex flex-wrap items-center gap-2">
             {networkIdsList.length > 0 && (
@@ -140,44 +112,6 @@ export const ProposalDetailsModal = ({
                 {proposal.status.toUpperCase()}
               </span>
             </Badge>
-          </div>
-
-          {/* Proposal ID */}
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <Hash className="h-4 w-4" />
-              <span>Proposal ID</span>
-            </div>
-            <div className="flex items-center gap-2 p-2 bg-muted rounded-md">
-              <code className="text-xs flex-1 break-all font-mono">{proposal.id}</code>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0 shrink-0"
-                onClick={() => copyToClipboard(proposal.id, "id")}
-              >
-                <Copy className={`h-4 w-4 ${copiedId ? "text-green-500" : ""}`} />
-              </Button>
-            </div>
-          </div>
-
-          {/* Proposer */}
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <User className="h-4 w-4" />
-              <span>Proposer</span>
-            </div>
-            <div className="flex items-center gap-2 p-2 bg-muted rounded-md">
-              <code className="text-xs flex-1 break-all font-mono">{proposal.proposer}</code>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0 shrink-0"
-                onClick={() => copyToClipboard(proposal.proposer, "proposer")}
-              >
-                <Copy className={`h-4 w-4 ${copiedProposer ? "text-green-500" : ""}`} />
-              </Button>
-            </div>
           </div>
 
           {/* Timestamps */}
@@ -291,18 +225,6 @@ export const ProposalDetailsModal = ({
               </div>
             </div>
           </div>
-
-          {/* Proposal Details (if available) */}
-          {proposal.details && Object.keys(proposal.details).length > 1 && (
-            <div className="space-y-2">
-              <div className="text-sm font-medium">Additional Details</div>
-              <div className="p-3 bg-muted rounded-md">
-                <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap break-words">
-                  {JSON.stringify(proposal.details, null, 2)}
-                </pre>
-              </div>
-            </div>
-          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/lib/governanceApi.test.ts
+++ b/src/lib/governanceApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { proposalsNextPageCursor } from "./governanceApi";
+
+describe("proposalsNextPageCursor", () => {
+  it("prefers nextCursor when present", () => {
+    expect(
+      proposalsNextPageCursor({ nextCursor: "abc", cursor: "old" }, "old")
+    ).toBe("abc");
+  });
+
+  it("returns undefined when no more pages", () => {
+    expect(proposalsNextPageCursor({ cursor: "x" }, undefined)).toBeUndefined();
+  });
+
+  it("uses cursor when hasMore and cursor differs from request", () => {
+    expect(
+      proposalsNextPageCursor(
+        { hasNextPage: true, cursor: "page2" },
+        "page1"
+      )
+    ).toBe("page2");
+  });
+
+  it("does not reuse echoed cursor when it matches requested cursor", () => {
+    expect(
+      proposalsNextPageCursor({ hasNextPage: true, cursor: "same" }, "same")
+    ).toBeUndefined();
+  });
+
+  it("allows echoed cursor when first page had no cursor", () => {
+    expect(
+      proposalsNextPageCursor({ hasNextPage: true, cursor: "first" }, undefined)
+    ).toBe("first");
+  });
+});

--- a/src/lib/governanceApi.ts
+++ b/src/lib/governanceApi.ts
@@ -1,0 +1,197 @@
+/**
+ * HTTP client for the DorkFi governance node (JSON REST).
+ * Base URL: VITE_GOVERNANCE_API_BASE (trimmed, no trailing slash) or production Railway default.
+ */
+
+export const GOVERNANCE_API_DEFAULT_ORIGIN =
+  "https://dorkfi-governance-node-production.up.railway.app";
+
+export function governanceApiBase(): string {
+  const raw = import.meta.env.VITE_GOVERNANCE_API_BASE as string | undefined;
+  const t = typeof raw === "string" ? raw.trim().replace(/\/+$/, "") : "";
+  return t || GOVERNANCE_API_DEFAULT_ORIGIN;
+}
+
+/** `networkId` query for GET /proposals — omit for all chains. */
+export function proposalsListNetworkParam(
+  networkId: string | null | undefined
+): string | undefined {
+  if (!networkId || !networkId.trim()) return undefined;
+  return networkId.trim();
+}
+
+export class NgrokInterstitialError extends Error {
+  constructor(message = "Received ngrok browser interstitial instead of JSON") {
+    super(message);
+    this.name = "NgrokInterstitialError";
+  }
+}
+
+export class HtmlResponseError extends Error {
+  constructor(message = "Expected JSON but received HTML") {
+    super(message);
+    this.name = "HtmlResponseError";
+  }
+}
+
+export type HealthResponse = {
+  status?: string;
+  database?: string;
+  counts?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+function isLikelyNgrokInterstitial(html: string): boolean {
+  const h = html.toLowerCase();
+  return (
+    h.includes("ngrok") &&
+    (h.includes("browser warning") || h.includes("visit site") || h.includes("you are about to visit"))
+  );
+}
+
+async function parseGovernanceJsonResponse(
+  res: Response,
+  pathForErrors: string
+): Promise<unknown> {
+  const ct = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+
+  if (!res.ok) {
+    throw new Error(`Governance API ${pathForErrors}: HTTP ${res.status} ${text.slice(0, 200)}`);
+  }
+
+  if (!ct.includes("application/json")) {
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith("<")) {
+      if (isLikelyNgrokInterstitial(text)) {
+        throw new NgrokInterstitialError();
+      }
+      throw new HtmlResponseError(
+        `Governance API ${pathForErrors}: non-JSON body (Content-Type: ${ct || "missing"})`
+      );
+    }
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`Governance API ${pathForErrors}: invalid JSON`);
+  }
+}
+
+async function governanceGetJson(path: string): Promise<unknown> {
+  const base = governanceApiBase();
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  return parseGovernanceJsonResponse(res, path);
+}
+
+export async function getGovernanceHealth(): Promise<HealthResponse> {
+  const data = await governanceGetJson("/health");
+  return (typeof data === "object" && data !== null ? data : {}) as HealthResponse;
+}
+
+export function proposalsArrayFromBody(body: Record<string, unknown>): unknown[] {
+  const raw = body.proposals ?? body.data ?? body.items;
+  return Array.isArray(raw) ? raw : [];
+}
+
+/**
+ * Next page cursor for GET /proposals pagination.
+ * Avoids treating an echoed `cursor` as a next page unless the API signals more data.
+ */
+export function proposalsNextPageCursor(
+  body: Record<string, unknown>,
+  requestedCursor: string | undefined
+): string | undefined {
+  const next =
+    typeof body.nextCursor === "string" && body.nextCursor.length > 0
+      ? body.nextCursor
+      : undefined;
+  if (next) return next;
+
+  const more =
+    body.hasNextPage === true ||
+    body.hasMore === true ||
+    body.hasNext === true;
+
+  if (!more) return undefined;
+
+  const echoed =
+    typeof body.cursor === "string" && body.cursor.length > 0
+      ? body.cursor
+      : undefined;
+  if (!echoed) return undefined;
+  if (requestedCursor !== undefined && echoed === requestedCursor) {
+    return undefined;
+  }
+  return echoed;
+}
+
+export type GovernanceProposalsPageResult = {
+  body: Record<string, unknown>;
+  items: unknown[];
+  /** Cursor sent with this request (for pagination helper). */
+  requestCursor: string | undefined;
+};
+
+export async function getGovernanceProposalsPage(options: {
+  limit?: number;
+  networkId?: string;
+  cursor?: string;
+} = {}): Promise<GovernanceProposalsPageResult> {
+  const sp = new URLSearchParams();
+  if (options.limit != null) sp.set("limit", String(options.limit));
+  if (options.networkId) sp.set("networkId", options.networkId);
+  if (options.cursor) sp.set("cursor", options.cursor);
+  const q = sp.toString();
+  const path = `/proposals${q ? `?${q}` : ""}`;
+  const data = await governanceGetJson(path);
+  const body =
+    typeof data === "object" && data !== null
+      ? (data as Record<string, unknown>)
+      : {};
+  return {
+    body,
+    items: proposalsArrayFromBody(body),
+    requestCursor: options.cursor,
+  };
+}
+
+export async function getGovernanceProposalById(
+  id: string
+): Promise<Record<string, unknown>> {
+  const data = await governanceGetJson(`/proposals/${encodeURIComponent(id)}`);
+  return typeof data === "object" && data !== null
+    ? (data as Record<string, unknown>)
+    : {};
+}
+
+export async function getGovernanceProposalVotes(
+  id: string
+): Promise<unknown[]> {
+  const data = await governanceGetJson(
+    `/proposals/${encodeURIComponent(id)}/votes`
+  );
+  if (Array.isArray(data)) return data;
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "votes" in data &&
+    Array.isArray((data as { votes: unknown }).votes)
+  ) {
+    return (data as { votes: unknown[] }).votes;
+  }
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "data" in data &&
+    Array.isArray((data as { data: unknown }).data)
+  ) {
+    return (data as { data: unknown[] }).data;
+  }
+  return [];
+}

--- a/src/pages/Governance.tsx
+++ b/src/pages/Governance.tsx
@@ -8,7 +8,7 @@ import { ProposalCard } from "@/components/governance/ProposalCard";
 import { BatchVoteConfirmationModal } from "@/components/governance/BatchVoteConfirmationModal";
 import { useGovernanceData } from "@/hooks/useGovernanceData";
 import { ProposalStatus, Proposal } from "@/types/governanceTypes";
-import { Loader2, ChevronDown } from "lucide-react";
+import { Loader2, ChevronDown, Search } from "lucide-react";
 import { H2 } from "@/components/ui/Typography";
 import { Button } from "@/components/ui/button";
 import { calculateNFTMultiplier } from "@/components/governance/NFTMultiplierDropdown";
@@ -31,10 +31,15 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { getNetworkLogoPath } from "@/utils/tokenImageUtils";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { GovernanceApiProposalsPanel } from "@/components/governance/GovernanceApiProposalsPanel";
+import { Input } from "@/components/ui/input";
+import { proposalMatchesSearch } from "@/utils/proposalSearchMatch";
 
 const MAX_SELECTION_LIMIT = 8;
 
 const Governance = () => {
+  const [sourceTab, setSourceTab] = useState<"onchain" | "api">("onchain");
   const { currentNetwork, switchNetwork } = useNetwork();
   const governanceNetworks = useMemo(() => getNetworksWithGovernance(), []);
   const networkSelectorNetworks = useMemo(
@@ -52,6 +57,7 @@ const Governance = () => {
   const { proposals, stats, loading, error, userVotes, vote, batchVote, userVoterInfo, getVoteKey } =
     useGovernanceData(effectiveGovernanceNetwork);
   const [selectedStatus, setSelectedStatus] = useState<ProposalStatus | "all">("all");
+  const [proposalSearch, setProposalSearch] = useState("");
   const [batchMode, setBatchMode] = useState(false);
   const [selectedProposals, setSelectedProposals] = useState<Set<string>>(new Set());
   const [selectedVotes, setSelectedVotes] = useState<Map<string, boolean>>(new Map());
@@ -191,9 +197,22 @@ const Governance = () => {
     }
   };
 
-  const filteredProposals = proposals
-    .filter((proposal) => selectedStatus === "all" || proposal.status === selectedStatus)
-    .sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
+  const proposalsMatchingStatus = useMemo(
+    () =>
+      proposals.filter(
+        (proposal) => selectedStatus === "all" || proposal.status === selectedStatus
+      ),
+    [proposals, selectedStatus]
+  );
+
+  const searchTrimmed = proposalSearch.trim();
+  const filteredProposals = useMemo(
+    () =>
+      proposalsMatchingStatus
+        .filter((proposal) => proposalMatchesSearch(proposal, searchTrimmed))
+        .sort((a, b) => b.startTime.getTime() - a.startTime.getTime()),
+    [proposalsMatchingStatus, searchTrimmed]
+  );
 
   const activeProposals = filteredProposals.filter(
     (p) =>
@@ -203,7 +222,11 @@ const Governance = () => {
   // Validate that all selected proposals have a vote direction
   const allSelectedHaveVotes = selectedProposals.size > 0 && 
     Array.from(selectedProposals).every((id) => selectedVotes.has(id));
-  const canBatchVote = batchMode && selectedProposals.size > 0 && allSelectedHaveVotes;
+  const canBatchVote =
+    sourceTab === "onchain" &&
+    batchMode &&
+    selectedProposals.size > 0 &&
+    allSelectedHaveVotes;
   
   const allActiveSelected = batchMode && activeProposals.length > 0 && 
     activeProposals.every((p) => selectedProposals.has(p.id));
@@ -342,150 +365,187 @@ const Governance = () => {
           </div>
         )}
 
-        {/* Hero - Full Width when viewing a governance network */}
-        {effectiveGovernanceNetwork && <GovernanceHero stats={stats} />}
+        <Tabs
+          value={sourceTab}
+          onValueChange={(v) => setSourceTab(v as "onchain" | "api")}
+          className="mt-2"
+        >
+          <TabsList className="grid w-full grid-cols-2 sm:inline-flex sm:w-auto h-auto min-h-10 p-1 gap-1">
+            <TabsTrigger value="onchain" className="text-xs sm:text-sm px-2 sm:px-3">
+              Live
+            </TabsTrigger>
+            <TabsTrigger value="api" className="text-xs sm:text-sm px-2 sm:px-3">
+              Archives
+            </TabsTrigger>
+          </TabsList>
 
-        {!effectiveGovernanceNetwork ? (
-          <div className="flex flex-col items-center justify-center py-20 gap-4 text-muted-foreground">
-            <p>Switch to a governance-enabled network above to view proposals.</p>
-          </div>
-        ) : loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="h-8 w-8 animate-spin text-primary" />
-          </div>
-        ) : (
-          <>
-            {/* Governance Voting Info Card */}
-            <div className="mt-6">
-              <GovernanceVotingInfoCard />
-            </div>
+          <TabsContent value="onchain" className="mt-4">
+            {effectiveGovernanceNetwork && <GovernanceHero stats={stats} />}
 
-            {/* Unified Dashboard Card */}
-            <div className="mt-6">
-              <GovernanceDashboardCard
-                stats={stats}
-                selectedStatus={selectedStatus}
-                onStatusChange={setSelectedStatus}
-                userVoterInfo={userVoterInfo}
-              />
-            </div>
+            {!effectiveGovernanceNetwork ? (
+              <div className="flex flex-col items-center justify-center py-20 gap-4 text-muted-foreground">
+                <p>Switch to a governance-enabled network above to view proposals.</p>
+              </div>
+            ) : loading ? (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              </div>
+            ) : (
+              <>
+                <div className="mt-6">
+                  <GovernanceVotingInfoCard />
+                </div>
 
-            {/* Proposals List - Full Width Below */}
-            <div className="mt-6 space-y-4">
-              <div className="space-y-4">
-                <H2 className="text-xl sm:text-2xl">
-                  {selectedStatus === "all" ? "All" : selectedStatus.charAt(0).toUpperCase() + selectedStatus.slice(1)} Proposals
-                </H2>
-                {activeProposals.length > 0 && (
-                  <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
-                    <div className="flex items-center gap-2">
-                      <Switch
-                        id="batch-mode"
-                        checked={batchMode}
-                        onCheckedChange={(checked) => {
-                          setBatchMode(checked);
-                          if (!checked) {
-                            setSelectedProposals(new Set());
-                            setSelectedVotes(new Map());
-                          }
-                        }}
-                      />
-                      <Label htmlFor="batch-mode" className="cursor-pointer text-sm sm:text-base">
-                        Batch Vote Mode
-                      </Label>
+                <div className="mt-6">
+                  <GovernanceDashboardCard
+                    stats={stats}
+                    selectedStatus={selectedStatus}
+                    onStatusChange={setSelectedStatus}
+                    userVoterInfo={userVoterInfo}
+                  />
+                </div>
+
+                <div className="mt-6 space-y-4">
+                  <div className="space-y-4">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+                      <H2 className="text-xl sm:text-2xl m-0 shrink-0">
+                        {selectedStatus === "all" ? "All" : selectedStatus.charAt(0).toUpperCase() + selectedStatus.slice(1)} Proposals
+                      </H2>
+                      <div className="relative w-full sm:max-w-md">
+                        <Search
+                          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none"
+                          aria-hidden
+                        />
+                        <Input
+                          type="search"
+                          value={proposalSearch}
+                          onChange={(e) => setProposalSearch(e.target.value)}
+                          placeholder="Search title, description, ID, proposer…"
+                          className="pl-9"
+                          aria-label="Search proposals"
+                        />
+                      </div>
                     </div>
-                    {batchMode && activeProposals.length > 0 && (
-                      <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 flex-1">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={handleSelectAll}
-                          className="text-sm w-full sm:w-auto"
-                        >
-                          {allActiveSelected 
-                            ? "Deselect All" 
-                            : `Select All (${Math.min(activeProposals.length, MAX_SELECTION_LIMIT)})`}
-                        </Button>
-                        {selectedProposals.size > 0 && (
-                          <span className="text-sm text-muted-foreground text-center sm:text-left">
-                            {selectedProposals.size}/{MAX_SELECTION_LIMIT} selected
-                          </span>
+                    {activeProposals.length > 0 && (
+                      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+                        <div className="flex items-center gap-2">
+                          <Switch
+                            id="batch-mode"
+                            checked={batchMode}
+                            onCheckedChange={(checked) => {
+                              setBatchMode(checked);
+                              if (!checked) {
+                                setSelectedProposals(new Set());
+                                setSelectedVotes(new Map());
+                              }
+                            }}
+                          />
+                          <Label htmlFor="batch-mode" className="cursor-pointer text-sm sm:text-base">
+                            Batch Vote Mode
+                          </Label>
+                        </div>
+                        {batchMode && activeProposals.length > 0 && (
+                          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 flex-1">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={handleSelectAll}
+                              className="text-sm w-full sm:w-auto"
+                            >
+                              {allActiveSelected 
+                                ? "Deselect All" 
+                                : `Select All (${Math.min(activeProposals.length, MAX_SELECTION_LIMIT)})`}
+                            </Button>
+                            {selectedProposals.size > 0 && (
+                              <span className="text-sm text-muted-foreground text-center sm:text-left">
+                                {selectedProposals.size}/{MAX_SELECTION_LIMIT} selected
+                              </span>
+                            )}
+                          </div>
+                        )}
+                        {canBatchVote && (
+                          <Button
+                            onClick={handleBatchVoteClick}
+                            disabled={isBatchVoting}
+                            className="bg-primary hover:bg-primary/90 w-full sm:w-auto min-h-[44px]"
+                          >
+                            {isBatchVoting ? (
+                              <>
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                Voting...
+                              </>
+                            ) : (
+                              `Vote on ${selectedProposals.size} Proposal${selectedProposals.size > 1 ? 's' : ''}`
+                            )}
+                          </Button>
                         )}
                       </div>
                     )}
-                    {canBatchVote && (
-                      <Button
-                        onClick={handleBatchVoteClick}
-                        disabled={isBatchVoting}
-                        className="bg-primary hover:bg-primary/90 w-full sm:w-auto min-h-[44px]"
-                      >
-                        {isBatchVoting ? (
-                          <>
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                            Voting...
-                          </>
-                        ) : (
-                          `Vote on ${selectedProposals.size} Proposal${selectedProposals.size > 1 ? 's' : ''}`
-                        )}
-                      </Button>
-                    )}
                   </div>
-                )}
-              </div>
-              
-              {filteredProposals.length === 0 ? (
-                <div className="text-center py-12 px-4 space-y-2">
-                  {error ? (
-                    <>
-                      <p className="text-destructive font-medium">
-                        Could not load proposals
-                      </p>
-                      <p className="text-sm text-muted-foreground">{error}</p>
-                    </>
-                  ) : proposals.length === 0 ? (
-                    <p className="text-muted-foreground">
-                      No on-chain proposals yet. When the indexer has indexed proposal events, they
-                      will appear here.
-                    </p>
+                  
+                  {filteredProposals.length === 0 ? (
+                    <div className="text-center py-12 px-4 space-y-2">
+                      {error ? (
+                        <>
+                          <p className="text-destructive font-medium">
+                            Could not load proposals
+                          </p>
+                          <p className="text-sm text-muted-foreground">{error}</p>
+                        </>
+                      ) : proposals.length === 0 ? (
+                        <p className="text-muted-foreground">
+                          No on-chain proposals yet. When the indexer has indexed proposal events, they
+                          will appear here.
+                        </p>
+                      ) : proposalsMatchingStatus.length === 0 ? (
+                        <p className="text-muted-foreground">
+                          No proposals match the selected status filter. Try &quot;All&quot; to see every
+                          proposal.
+                        </p>
+                      ) : (
+                        <p className="text-muted-foreground">
+                          No proposals match your search. Try different keywords or clear the search field.
+                        </p>
+                      )}
+                    </div>
                   ) : (
-                    <p className="text-muted-foreground">
-                      No proposals match the selected status filter. Try &quot;All&quot; to see every
-                      proposal.
-                    </p>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-4 lg:gap-6">
+                      {filteredProposals.map((proposal) => {
+                        const isSelected = selectedProposals.has(proposal.id);
+                        const isLimitReached = selectedProposals.size >= MAX_SELECTION_LIMIT && !isSelected;
+                        const voteKeyForUser = getVoteKey(proposal, effectiveGovernanceNetwork ?? undefined);
+                        const voteNetworkId =
+                          effectiveGovernanceNetwork && proposal.networkIds?.includes(effectiveGovernanceNetwork)
+                            ? effectiveGovernanceNetwork
+                            : proposal.networkId;
+                        return (
+                          <ProposalCard
+                            key={proposal.id}
+                            proposal={proposal}
+                            onVote={handleVote}
+                            userVote={userVotes.get(voteKeyForUser)}
+                            votingPower={effectiveVotingPower}
+                            isSelected={isSelected}
+                            selectedVote={selectedVotes.get(proposal.id) ?? null}
+                            onSelect={handleSelectProposal}
+                            onSelectVote={handleSelectVote}
+                            voteNetworkId={voteNetworkId}
+                            batchMode={batchMode}
+                            isSelectionDisabled={isLimitReached}
+                          />
+                        );
+                      })}
+                    </div>
                   )}
                 </div>
-              ) : (
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-4 lg:gap-6">
-                  {filteredProposals.map((proposal) => {
-                    const isSelected = selectedProposals.has(proposal.id);
-                    const isLimitReached = selectedProposals.size >= MAX_SELECTION_LIMIT && !isSelected;
-                    const voteKeyForUser = getVoteKey(proposal, effectiveGovernanceNetwork ?? undefined);
-                    const voteNetworkId =
-                      effectiveGovernanceNetwork && proposal.networkIds?.includes(effectiveGovernanceNetwork)
-                        ? effectiveGovernanceNetwork
-                        : proposal.networkId;
-                    return (
-                      <ProposalCard
-                        key={proposal.id}
-                        proposal={proposal}
-                        onVote={handleVote}
-                        userVote={userVotes.get(voteKeyForUser)}
-                        votingPower={effectiveVotingPower}
-                        isSelected={isSelected}
-                        selectedVote={selectedVotes.get(proposal.id) ?? null}
-                        onSelect={handleSelectProposal}
-                        onSelectVote={handleSelectVote}
-                        voteNetworkId={voteNetworkId}
-                        batchMode={batchMode}
-                        isSelectionDisabled={isLimitReached}
-                      />
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </>
-        )}
+              </>
+            )}
+          </TabsContent>
+
+          <TabsContent value="api" className="mt-4">
+            <GovernanceApiProposalsPanel queriesEnabled={sourceTab === "api"} />
+          </TabsContent>
+        </Tabs>
 
         {/* Batch Vote Confirmation Modal */}
         {canBatchVote && (

--- a/src/types/governanceTypes.ts
+++ b/src/types/governanceTypes.ts
@@ -28,6 +28,11 @@ export interface Proposal {
   networkId?: string;
   /** When proposals are merged across networks, all source network IDs. */
   networkIds?: string[];
+  /**
+   * When true (e.g. governance node with power fields), `votesFor` is yes voting power
+   * and `totalVotes` is total voting power cast — use their ratio for pass % and bars.
+   */
+  usesVotingPowerTally?: boolean;
 }
 
 export type ProposalDetails = 

--- a/src/utils/apiProposalToProposal.test.ts
+++ b/src/utils/apiProposalToProposal.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  apiRecordToProposal,
+  deriveClosedStatusFromVoteCounts,
+  normalizeApiProposalCategory,
+} from "./apiProposalToProposal";
+
+describe("normalizeApiProposalCategory", () => {
+  it("maps contract category id", () => {
+    expect(normalizeApiProposalCategory({ categoryId: 4 })).toBe("treasury");
+    expect(normalizeApiProposalCategory({ proposalCategoryId: "2" })).toBe(
+      "collateral-listing"
+    );
+  });
+
+  it("maps slug strings", () => {
+    expect(
+      normalizeApiProposalCategory({ category: "collateral-listing" })
+    ).toBe("collateral-listing");
+    expect(
+      normalizeApiProposalCategory({ category: "collateral_listing" })
+    ).toBe("collateral-listing");
+  });
+
+  it("maps display labels from API", () => {
+    expect(normalizeApiProposalCategory({ category: "Treasury" })).toBe(
+      "treasury"
+    );
+    expect(
+      normalizeApiProposalCategory({ category: "Collateral Listing" })
+    ).toBe("collateral-listing");
+  });
+
+  it("reads nested category object", () => {
+    expect(
+      normalizeApiProposalCategory({
+        category: { slug: "infrastructure" },
+      })
+    ).toBe("infrastructure");
+  });
+});
+
+describe("deriveClosedStatusFromVoteCounts (69% yes of cast)", () => {
+  const ended = new Date(Date.now() - 86_400_000);
+
+  it("fails below 69% yes share", () => {
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 30, 70, 0)
+    ).toBe("rejected");
+    expect(
+      deriveClosedStatusFromVoteCounts("passed", ended, 30, 70, 0)
+    ).toBe("rejected");
+  });
+
+  it("passes at or above 69% yes share", () => {
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 70, 30, 0)
+    ).toBe("passed");
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 690, 310, 0)
+    ).toBe("passed");
+  });
+
+  it("includes abstain in denominator", () => {
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 68, 20, 11)
+    ).toBe("rejected");
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 69, 10, 10)
+    ).toBe("passed");
+  });
+
+  it("leaves executed unchanged", () => {
+    expect(
+      deriveClosedStatusFromVoteCounts("executed", ended, 1, 99, 0)
+    ).toBe("executed");
+  });
+
+  it("uses total power denominator when larger than for+against+abstain", () => {
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 60, 40, 0, 200)
+    ).toBe("rejected");
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 60, 40, 0, 100)
+    ).toBe("rejected");
+    expect(
+      deriveClosedStatusFromVoteCounts("active", ended, 70, 30, 0, 100)
+    ).toBe("passed");
+  });
+});
+
+describe("apiRecordToProposal pass threshold", () => {
+  it("applies 69% to count-only rows after end", () => {
+    const endedIso = new Date(Date.now() - 86_400_000).toISOString();
+    const rejected = apiRecordToProposal({
+      status: "active",
+      votingEnd: endedIso,
+      votesFor: 300,
+      votesAgainst: 700,
+    });
+    expect(rejected.status).toBe("rejected");
+
+    const passed = apiRecordToProposal({
+      status: "active",
+      votingEnd: endedIso,
+      votesFor: 700,
+      votesAgainst: 300,
+    });
+    expect(passed.status).toBe("passed");
+  });
+
+  it("reconciles API passed when power tally is under 69%", () => {
+    const endedIso = new Date(Date.now() - 86_400_000).toISOString();
+    const p = apiRecordToProposal({
+      status: "passed",
+      votingEnd: endedIso,
+      proposalTotalPower: 100 * 1e8,
+      proposalYesPower: 30 * 1e8,
+    });
+    expect(p.status).toBe("rejected");
+    expect(p.usesVotingPowerTally).toBe(true);
+  });
+});

--- a/src/utils/apiProposalToProposal.ts
+++ b/src/utils/apiProposalToProposal.ts
@@ -1,0 +1,318 @@
+import type {
+  Proposal,
+  ProposalCategory,
+  ProposalStatus,
+} from "@/types/governanceTypes";
+import { config, type NetworkId } from "@/config";
+import {
+  CATEGORY_ID_TO_CATEGORY,
+  GOVERNANCE_PASS_THRESHOLD_YES_FRACTION,
+  PROPOSAL_CATEGORY_DISPLAY_NAMES,
+} from "@/constants/governanceConstants";
+
+const VALID_CATEGORIES = new Set<ProposalCategory>([
+  "interest-rates",
+  "collateral-listing",
+  "liquidation-settings",
+  "treasury",
+  "features",
+  "governance",
+  "infrastructure",
+]);
+
+function isNetworkIdConfigured(id: string): id is NetworkId {
+  return id in config.networks;
+}
+
+function filterKnownNetworkIds(ids: unknown): NetworkId[] | undefined {
+  if (!Array.isArray(ids)) return undefined;
+  const out: NetworkId[] = [];
+  for (const x of ids) {
+    if (typeof x !== "string") continue;
+    if (isNetworkIdConfigured(x)) out.push(x);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function parseNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function parseDateField(v: unknown): Date | null {
+  if (v == null) return null;
+  if (typeof v === "number" && Number.isFinite(v)) {
+    const ms = v < 1e12 ? v * 1000 : v;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof v === "string" && v.length > 0) {
+    const d = new Date(v);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+function normalizeStatus(raw: unknown): ProposalStatus {
+  if (typeof raw !== "string") return "pending";
+  const s = raw.toLowerCase().trim() as ProposalStatus;
+  if (
+    s === "active" ||
+    s === "passed" ||
+    s === "rejected" ||
+    s === "pending" ||
+    s === "executed"
+  ) {
+    return s;
+  }
+  return "pending";
+}
+
+/**
+ * After voting ends, align status with the ≥69% rule (on-chain style).
+ * Uses `totalPowerOrVotesTotal` as denominator when it is a valid total (yes / total power),
+ * otherwise for + against + abstain. Call for **both** power-based and count-only API rows so
+ * an optimistic `passed` from the node is corrected when tallies disagree.
+ */
+export function deriveClosedStatusFromVoteCounts(
+  status: ProposalStatus,
+  end: Date,
+  votesFor: number,
+  votesAgainst: number,
+  votesAbstain: number,
+  totalPowerOrVotesTotal?: number | null
+): ProposalStatus {
+  if (status === "executed") return status;
+  if (status === "pending") return status;
+
+  if (!end || end.getTime() <= 0 || end.getTime() > Date.now()) {
+    return status;
+  }
+
+  const abstain = Math.max(0, votesAbstain);
+  const sum = votesFor + votesAgainst + abstain;
+  const totalFromField =
+    totalPowerOrVotesTotal != null &&
+    Number.isFinite(totalPowerOrVotesTotal) &&
+    totalPowerOrVotesTotal > 0
+      ? totalPowerOrVotesTotal
+      : 0;
+  const denom =
+    totalFromField > 0 && totalFromField + 1e-9 >= votesFor
+      ? totalFromField
+      : sum;
+
+  if (denom <= 0) {
+    if (status === "active") return "rejected";
+    if (status === "passed") return "rejected";
+    return status;
+  }
+
+  const met =
+    votesFor >= denom * GOVERNANCE_PASS_THRESHOLD_YES_FRACTION;
+  if (status === "active") {
+    return met ? "passed" : "rejected";
+  }
+  if (status === "passed" || status === "rejected") {
+    return met ? "passed" : "rejected";
+  }
+  return status;
+}
+
+function categoryFromContractId(id: number): ProposalCategory | undefined {
+  return CATEGORY_ID_TO_CATEGORY[id as keyof typeof CATEGORY_ID_TO_CATEGORY];
+}
+
+/**
+ * Resolves `ProposalCategory` from governance-node payloads (slug, display name, contract id, etc.).
+ */
+export function normalizeApiProposalCategory(
+  record: Record<string, unknown>
+): ProposalCategory {
+  const idKeys = [
+    "categoryId",
+    "proposalCategoryId",
+    "category_id",
+    "proposal_category_id",
+  ] as const;
+  for (const key of idKeys) {
+    const v = record[key];
+    const n = parseNumber(v);
+    if (n != null && Number.isInteger(n) && n >= 0) {
+      const c = categoryFromContractId(n);
+      if (c) return c;
+    }
+  }
+
+  let catRaw: unknown =
+    record.category ??
+    record.type ??
+    record.proposalType ??
+    record.tag ??
+    record.proposalCategory;
+
+  if (typeof catRaw === "object" && catRaw !== null) {
+    const o = catRaw as Record<string, unknown>;
+    catRaw =
+      o.slug ?? o.id ?? o.key ?? o.name ?? o.label ?? o.code ?? null;
+  }
+
+  if (typeof catRaw === "number" && Number.isInteger(catRaw)) {
+    const c = categoryFromContractId(catRaw);
+    if (c) return c;
+  }
+
+  if (typeof catRaw !== "string" || !catRaw.trim()) {
+    return "governance";
+  }
+
+  const trimmed = catRaw.trim();
+  const asSlug = trimmed
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/_/g, "-");
+
+  if (VALID_CATEGORIES.has(asSlug as ProposalCategory)) {
+    return asSlug as ProposalCategory;
+  }
+
+  const tl = trimmed.toLowerCase();
+  for (const [cat, label] of Object.entries(
+    PROPOSAL_CATEGORY_DISPLAY_NAMES
+  ) as [ProposalCategory, string][]) {
+    if (label.toLowerCase() === tl) return cat;
+  }
+
+  return "governance";
+}
+
+/**
+ * Maps a loose governance-node proposal record into the UI `Proposal` shape.
+ */
+export function apiRecordToProposal(record: Record<string, unknown>): Proposal {
+  const idRaw =
+    record.id ?? record.proposalId ?? record.uuid ?? record.slug ?? "";
+  const id = String(idRaw);
+
+  const title =
+    typeof record.title === "string" && record.title.trim()
+      ? record.title.trim()
+      : id
+        ? `Proposal ${id.slice(0, 12)}${id.length > 12 ? "…" : ""}`
+        : "Untitled proposal";
+
+  const description =
+    typeof record.description === "string"
+      ? record.description
+      : typeof record.summary === "string"
+        ? record.summary
+        : "";
+
+  const category = normalizeApiProposalCategory(record);
+
+  const proposer =
+    typeof record.proposer === "string" && record.proposer
+      ? record.proposer
+      : typeof record.author === "string" && record.author
+        ? record.author
+        : "—";
+
+  const startTime =
+    parseDateField(record.votingStart) ??
+    parseDateField(record.startDate) ??
+    parseDateField(record.createdAt) ??
+    new Date(0);
+
+  const endTime =
+    parseDateField(record.votingEnd) ??
+    parseDateField(record.endDate) ??
+    parseDateField(record.votingEndTime) ??
+    new Date(0);
+
+  let status = normalizeStatus(record.status);
+  const totalPowerRaw =
+    parseNumber(record.proposalTotalPower) ??
+    parseNumber(record.totalPower) ??
+    null;
+  const yesPowerRaw =
+    parseNumber(record.proposalYesPower) ??
+    parseNumber(record.votesFor) ??
+    null;
+
+  let votesFor = parseNumber(record.votesFor) ?? 0;
+  let votesAgainst = parseNumber(record.votesAgainst) ?? 0;
+  let totalVotes = parseNumber(record.totalVotes);
+
+  if (totalPowerRaw != null && yesPowerRaw != null) {
+    totalVotes = totalPowerRaw / 1e8;
+    votesFor = yesPowerRaw / 1e8;
+    votesAgainst = Math.max(0, totalVotes - votesFor);
+  } else if (totalVotes == null || !Number.isFinite(totalVotes)) {
+    totalVotes = votesFor + votesAgainst;
+  }
+
+  if (!Number.isFinite(totalVotes) || totalVotes < 0) totalVotes = 0;
+  if (!Number.isFinite(votesFor) || votesFor < 0) votesFor = 0;
+  if (!Number.isFinite(votesAgainst) || votesAgainst < 0) votesAgainst = 0;
+
+  const votesAbstain =
+    parseNumber(record.votesAbstain) ??
+    parseNumber(record.votes_abstain) ??
+    0;
+  const usedPowerPath = totalPowerRaw != null && yesPowerRaw != null;
+  status = deriveClosedStatusFromVoteCounts(
+    status,
+    endTime,
+    votesFor,
+    votesAgainst,
+    votesAbstain,
+    totalVotes
+  );
+
+  let quorum = parseNumber(record.quorum) ?? parseNumber(record.quorumThreshold) ?? 0;
+  if (!Number.isFinite(quorum) || quorum <= 0) {
+    quorum = Math.max(1, totalVotes || 1);
+  }
+
+  const networkIds =
+    filterKnownNetworkIds(record.networkIds) ??
+    (typeof record.networkId === "string" && isNetworkIdConfigured(record.networkId)
+      ? [record.networkId]
+      : undefined);
+
+  const singleNetwork =
+    typeof record.networkId === "string" && isNetworkIdConfigured(record.networkId)
+      ? record.networkId
+      : networkIds?.length === 1
+        ? networkIds[0]
+        : undefined;
+
+  return {
+    id,
+    title,
+    description,
+    category,
+    proposer,
+    status,
+    votesFor,
+    votesAgainst,
+    totalVotes,
+    quorum,
+    startTime,
+    endTime,
+    details: {
+      type: "governance",
+      description: description || title,
+    },
+    ...(usedPowerPath ? { usesVotingPowerTally: true as const } : {}),
+    ...(networkIds && networkIds.length > 1
+      ? { networkIds, networkId: undefined as undefined }
+      : singleNetwork
+        ? { networkId: singleNetwork, networkIds: [singleNetwork] }
+        : {}),
+  };
+}

--- a/src/utils/proposalSearchMatch.test.ts
+++ b/src/utils/proposalSearchMatch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { Proposal } from "@/types/governanceTypes";
+import { proposalMatchesSearch } from "./proposalSearchMatch";
+
+const sample: Proposal = {
+  id: "prop-42",
+  title: "Treasury allocation Q1",
+  description: "Fund the community pool",
+  category: "treasury",
+  proposer: "ALGO7DUMMYADDRESS",
+  status: "active",
+  votesFor: 0,
+  votesAgainst: 0,
+  totalVotes: 0,
+  quorum: 1,
+  startTime: new Date("2025-01-01"),
+  endTime: new Date("2026-01-01"),
+  details: { type: "treasury", recipient: "r", amount: 1, asset: "a", purpose: "p" },
+};
+
+describe("proposalMatchesSearch", () => {
+  it("matches when query is empty or whitespace", () => {
+    expect(proposalMatchesSearch(sample, "")).toBe(true);
+    expect(proposalMatchesSearch(sample, "   ")).toBe(true);
+  });
+
+  it("matches title and id case-insensitively", () => {
+    expect(proposalMatchesSearch(sample, "treasury allocation")).toBe(true);
+    expect(proposalMatchesSearch(sample, "PROP-42")).toBe(true);
+  });
+
+  it("matches proposer substring", () => {
+    expect(proposalMatchesSearch(sample, "dummyaddress")).toBe(true);
+  });
+
+  it("matches category display name", () => {
+    expect(proposalMatchesSearch(sample, "treasury")).toBe(true);
+  });
+
+  it("returns false when no field contains the query", () => {
+    expect(proposalMatchesSearch(sample, "zzzz-not-found")).toBe(false);
+  });
+});

--- a/src/utils/proposalSearchMatch.ts
+++ b/src/utils/proposalSearchMatch.ts
@@ -1,0 +1,19 @@
+import type { Proposal } from "@/types/governanceTypes";
+import { PROPOSAL_CATEGORY_DISPLAY_NAMES } from "@/constants/governanceConstants";
+
+/** Case-insensitive substring match across common proposal fields (loaded proposals only). */
+export function proposalMatchesSearch(proposal: Proposal, rawQuery: string): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = [
+    proposal.title,
+    proposal.description,
+    proposal.id,
+    proposal.proposer,
+    PROPOSAL_CATEGORY_DISPLAY_NAMES[proposal.category],
+    proposal.status,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(q);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,20 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+const GOVERNANCE_RAILWAY =
+  "https://dorkfi-governance-node-production.up.railway.app";
+
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const governanceLocalTarget =
+    env.VITE_GOVERNANCE_LOCAL_TARGET || "http://127.0.0.1:8787";
+  const governanceNgrokTarget =
+    env.VITE_GOVERNANCE_NGROK_TARGET || "http://127.0.0.1:8787";
+
+  return {
   server: {
     host: "::",
     port: 8080,
@@ -16,6 +26,26 @@ export default defineConfig(({ mode }) => ({
         target: 'https://orca-api.nautilus.sh',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/orca/, '/api'),
+      },
+      "/api/local": {
+        target: governanceLocalTarget,
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/local/, "") || "/",
+      },
+      "/api/railway": {
+        target: GOVERNANCE_RAILWAY,
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/railway/, "") || "/",
+      },
+      "/api/ngrok": {
+        target: governanceNgrokTarget,
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/ngrok/, "") || "/",
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq) => {
+            proxyReq.setHeader("ngrok-skip-browser-warning", "true");
+          });
+        },
       },
     },
   },
@@ -55,4 +85,5 @@ export default defineConfig(({ mode }) => ({
     ],
     force: true, // Force re-optimization on next dev server start
   },
-}));
+};
+});


### PR DESCRIPTION
## Summary

This PR adds a **Live** vs **Archives** split on the Governance page, integrates the governance HTTP API for Archives (paginated, all-chain proposals), and polishes the proposal details modal.

## Changes

- **Archives**: New panel with stats, status filters, read-only table with quorum visualization, row opens proposal details modal. Client in `src/lib/governanceApi.ts`, mapping in `src/utils/apiProposalToProposal.ts`.
- **Dev**: Vite proxies for `/api/local`, `/api/railway`, `/api/ngrok` governance targets; docs in `docs/governance/GOVERNANCE_API_INTEGRATION.md`.
- **Types / ProposalCard**: Read-only mode and optional power-tally metadata where needed.
- **Search**: Shared `proposalMatchesSearch` for Live and Archives proposal lists.
- **Modal**: Removed Proposal ID, proposer, and raw additional-details JSON; adjusted padding and narrower max width.

## Testing

- Vitest: `governanceApi`, `apiProposalToProposal`, `proposalSearchMatch`.

Made with [Cursor](https://cursor.com)