### PR TITLE
feat(nft): load manual unsigned claim from claim agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.695",
+  "version": "0.1.696",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/portfolio/NftHolderClaimManualModal.tsx
+++ b/src/components/portfolio/NftHolderClaimManualModal.tsx
@@ -189,7 +189,7 @@ export function NftHolderClaimManualModal({
           {loading ? (
             <div className="flex items-center justify-center gap-2 py-8 text-sm text-slate-400">
               <Loader2 className="h-5 w-5 animate-spin shrink-0" aria-hidden />
-              Loading unsigned transactions…
+              Loading claim info
             </div>
           ) : error ? (
             <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-red-200">

--- a/src/services/paidWorkflowGateway.ts
+++ b/src/services/paidWorkflowGateway.ts
@@ -143,86 +143,9 @@ function parseUnsignedClaimJson(json: unknown): NftHolderUnsignedClaimResponse {
   return { address: addr, claimable, slot, transactions, errors };
 }
 
-/** Temporary stub until `GET …/claim/:address/unsigned` is wired in production. */
-const HARDCODED_NFT_HOLDER_UNSIGNED_CLAIM: NftHolderUnsignedClaimResponse = {
-  address: "VDEVK22RGTKEE4EVKRTWVBPBPBB3IOFGO25RQCKDZCLZMRBKFBNNECRDLI",
-  claimable: true,
-  slot: {
-    campaignId: "dork",
-    campaignName: "Dorks Drip",
-    owner: "VDEVK22RGTKEE4EVKRTWVBPBPBB3IOFGO25RQCKDZCLZMRBKFBNNECRDLI",
-    collectionId: 313597,
-    tokenId: "5",
-    dripContractId: 49016540,
-    rewardTokenContractId: 420069,
-    rewardSymbol: "UNIT",
-    claimableRaw: "2400000000",
-    claimableDisplay: "24",
-  },
-  transactions: [
-    {
-      groupIndex: 0,
-      txnBase64:
-        "jaRhcGFhkcQEWHWfoqRhcGF0kcQgMHAKs8HmYq2OIhFCbTzdpY0jU7jsiNj8lp8SnJY143OkYXBmYZLOAATI/c4ABmjlpGFwaWTOAAW9HKNmZWXNA+iiZnbOARtjJ6NnZW6sdm9pbWFpbi12MS4womdoxCCvbR9JAjyBZ7+QVnOI2idI8JcvBxCYf+fFE6+ee55Y6aNncnDEIMK0z+yDEhTmWLskMsK7OK43Ee5GKTJOeNTfrEE+86fIomx2zgEbZw+kbm90ZcRZYXJjY2pzLXYyLjEwLjY6dSBjdXN0b20gR3JvdXAgcmVzb3VyY2Ugc2hhcmluZyB0cmFuc2FjdGlvbi4gQWNjb3VudHM6IDEgQXNzZXRzOiAwIEFwcHM6IDKjc25kxCCoyVVrUTTUQnCVVGdqheF4Q7Q4pna7GAlDyJeWRCooWqR0eXBlpGFwcGw=",
-      kind: "application",
-      feeMicros: "1000",
-      summary:
-        "appl: app 376092 method_selector=0x58759fa2; accounts=1 foreign_apps=2 boxes=0",
-    },
-    {
-      groupIndex: 1,
-      txnBase64:
-        "jaRhcGFhkcQEWHWfoqRhcGJ4kYKhaQGhbsQxZHJpcF9kYXRhAAAAAAAEyP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABaRhcGZhkc4C6+7cpGFwaWTOAAW9HKNmZWXNA+iiZnbOARtjJ6NnZW6sdm9pbWFpbi12MS4womdoxCCvbR9JAjyBZ7+QVnOI2idI8JcvBxCYf+fFE6+ee55Y6aNncnDEIMK0z+yDEhTmWLskMsK7OK43Ee5GKTJOeNTfrEE+86fIomx2zgEbZw+kbm90ZcRXYXJjY2pzLXYyLjEwLjY6dSBjdXN0b20gR3JvdXAgcmVzb3VyY2Ugc2hhcmluZyB0cmFuc2FjdGlvbi4gQm94ZXM6IDEgQXBwczogMSAoNDkwMTY1NDApo3NuZMQgqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFqkdHlwZaRhcHBs",
-      kind: "application",
-      feeMicros: "1000",
-      summary:
-        "appl: app 376092 method_selector=0x58759fa2; accounts=0 foreign_apps=1 boxes=1",
-    },
-    {
-      groupIndex: 2,
-      txnBase64:
-        "jaRhcGFhkcQEWHWfoqRhcGJ4k4KhaQGhbsQpYXBwcm92YWxzVA2gpPYeYqvY7xXBdD06kjTTGx1yhkMFXJdpScd7gJmCoWkBoW7EKGJhbGFuY2VzG6Kgp9URA8LHPTC+mxQt2cisxRS+2qbrDDEJdy0fm2iCoWkBoW7EKGJhbGFuY2VzqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFqkYXBmYZHOAAZo5aRhcGlkzgAFvRyjZmVlzQPoomZ2zgEbYyejZ2VurHZvaW1haW4tdjEuMKJnaMQgr20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOmjZ3JwxCDCtM/sgxIU5li7JDLCuziuNxHuRikyTnjU36xBPvOnyKJsds4BG2cPpG5vdGXEVWFyY2Nqcy12Mi4xMC42OnUgY3VzdG9tIEdyb3VwIHJlc291cmNlIHNoYXJpbmcgdHJhbnNhY3Rpb24uIEJveGVzOiAzIEFwcHM6IDEgKDQyMDA2OSmjc25kxCCoyVVrUTTUQnCVVGdqheF4Q7Q4pna7GAlDyJeWRCooWqR0eXBlpGFwcGw=",
-      kind: "application",
-      feeMicros: "1000",
-      summary:
-        "appl: app 376092 method_selector=0x58759fa2; accounts=0 foreign_apps=1 boxes=3",
-    },
-    {
-      groupIndex: 3,
-      txnBase64:
-        "jaRhcGFhkcQEWHWfoqRhcGJ4kYKhaQGhbsQhbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFpGFwZmGRzgAEyP2kYXBpZM4ABb0co2ZlZc0D6KJmds4BG2Mno2dlbqx2b2ltYWluLXYxLjCiZ2jEIK9tH0kCPIFnv5BWc4jaJ0jwly8HEJh/58UTr557nljpo2dycMQgwrTP7IMSFOZYuyQywrs4rjcR7kYpMk541N+sQT7zp8iibHbOARtnD6Rub3RlxFVhcmNjanMtdjIuMTAuNjp1IGN1c3RvbSBHcm91cCByZXNvdXJjZSBzaGFyaW5nIHRyYW5zYWN0aW9uLiBCb3hlczogMSBBcHBzOiAxICgzMTM1OTcpo3NuZMQgqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFqkdHlwZaRhcHBs",
-      kind: "application",
-      feeMicros: "1000",
-      summary:
-        "appl: app 376092 method_selector=0x58759fa2; accounts=0 foreign_apps=1 boxes=1",
-    },
-    {
-      groupIndex: 4,
-      txnBase64:
-        "i6NhbXTOAAEFVKNmZWXNA+iiZnbOARtjJ6NnZW6sdm9pbWFpbi12MS4womdoxCCvbR9JAjyBZ7+QVnOI2idI8JcvBxCYf+fFE6+ee55Y6aNncnDEIMK0z+yDEhTmWLskMsK7OK43Ee5GKTJOeNTfrEE+86fIomx2zgEbZw+kbm90ZcQuYXJjY2pzLXYyLjEwLjY6dSBjdXN0b20gUGF5bWVudCB0byBhcHBsaWNhdGlvbqNyY3bEIFzB94q91MpT+4ssW4fyo9E5ls9ITfZWVKd0kIy2BI2Qo3NuZMQgqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFqkdHlwZaNwYXk=",
-      kind: "payment",
-      feeMicros: "1000",
-      summary:
-        "pay: sender VDEVK22RGTKEE4EVKRTWVBPBPBB3IOFGO25RQCKDZCLZMRBKFBNNECRDLI → receiver LTA7PCV52TFFH64LFRNYP4VD2E4ZNT2IJX3FMVFHOSIIZNQERWIMFGYY24 (drip app escrow); amount 66900 micro-units",
-    },
-    {
-      groupIndex: 5,
-      txnBase64:
-        "i6RhcGFhlMQEPZAw98QgqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFrECAAAAAAABMj9xCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABaRhcGlkzgLr7tyjZmVlzQ+gomZ2zgEbYyejZ2VurHZvaW1haW4tdjEuMKJnaMQgr20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOmjZ3JwxCDCtM/sgxIU5li7JDLCuziuNxHuRikyTnjU36xBPvOnyKJsds4BG2cPpG5vdGXEKWFyY2Nqcy12Mi4xMC42OnUgY3VzdG9tIGV4dHJhIHRyYW5zYWN0aW9uo3NuZMQgqMlVa1E01EJwlVRnaoXheEO0OKZ2uxgJQ8iXlkQqKFqkdHlwZaRhcHBs",
-      kind: "application",
-      feeMicros: "4000",
-      summary:
-        "appl: app 49016540 method_selector=0x3d9030f7; accounts=0 foreign_apps=0 boxes=0",
-    },
-  ],
-  errors: [],
-};
-
 /**
- * Manual claim: unsigned transaction group from the same host as {@link getNftHolderClaimAgentBase}
- * (`GET /claim/:address/unsigned?relayer=…`).
- *
- * **Stub:** returns {@link HARDCODED_NFT_HOLDER_UNSIGNED_CLAIM} until the network path is restored.
+ * Manual claim: unsigned transaction group from {@link getNftHolderClaimAgentBase}
+ * (`GET …/claim/:address/unsigned?relayer=`).
  */
 export async function fetchNftHolderUnsignedClaim(params: {
   beneficiaryAddress: string;
@@ -236,8 +159,15 @@ export async function fetchNftHolderUnsignedClaim(params: {
   if (!relayer) {
     throw new Error("Missing relayer address for unsigned claim");
   }
-  await Promise.resolve();
-  return parseUnsignedClaimJson(HARDCODED_NFT_HOLDER_UNSIGNED_CLAIM as unknown);
+  const base = getNftHolderClaimAgentBase();
+  const url = new URL(`${base}/${encodeURIComponent(beneficiary)}/unsigned`);
+  url.searchParams.set("relayer", relayer);
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    throw new Error(`Unsigned claim HTTP ${res.status}`);
+  }
+  const json: unknown = await res.json();
+  return parseUnsignedClaimJson(json);
 }
 
 const DEFAULT_NFT_CLAIM_MANUAL_URL = "https://docs.dork.fi";


### PR DESCRIPTION
## Summary
- `fetchNftHolderUnsignedClaim` now performs `GET {claim-agent-base}/{beneficiary}/unsigned?relayer=…` and parses the JSON response (same base as portfolio claim-agent status; default Railway production).
- Removed the hardcoded unsigned-claim stub.
- Manual NFT claim modal loading copy: **Loading claim info**.

## Test plan
- [ ] Open portfolio with an NFT drip reward, open manual claim, confirm claim info and tx group load from the agent (no stub).
- [ ] Confirm `VITE_NFT_CLAIM_AGENT_BASE` override still applies if set.

`package.json` version bumped by the repo pre-commit hook (0.1.696).

Made with [Cursor](https://cursor.com)