### PR TITLE
fix(nft): accept on-chain Envoi avatar for NFT reward claim eligibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.697",
+  "version": "0.1.699",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.696",
+  "version": "0.1.697",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -2302,7 +2302,7 @@ const Portfolio = () => {
       collateralUsd: totalCollateral,
       borrowedUsd: totalBorrowed,
       healthFactor: displayHealthFactor,
-      hasProfileAvatar: Boolean(userProfileAvatar?.trim()),
+      hasProfileAvatar: Boolean(displayAvatar?.trim()),
     };
   }, [
     displayAddress,
@@ -2310,7 +2310,7 @@ const Portfolio = () => {
     totalCollateral,
     totalBorrowed,
     displayHealthFactor,
-    userProfileAvatar,
+    displayAvatar,
   ]);
 
   /** Which lending market the headline HF refers to (worst pool or tightest at-risk deposit). */


### PR DESCRIPTION
## Summary
- Updates the "Set avatar" eligibility check in the NFT holder rewards modal to use `displayAvatar` (API profile avatar **or** on-chain Envoi `avatar_dorkfi` NFT image) instead of only `userProfileAvatar`.
- This matches the same avatar resolution logic the health factor gauge already uses, so users who set their avatar via Envoi name service are no longer incorrectly marked as "not met".

## Test plan
- [ ] Connect a wallet that has an Envoi name with an `avatar_dorkfi` text record set but no API profile avatar — confirm the "Set avatar" check shows as **met** in the NFT holder rewards modal.
- [ ] Connect a wallet with an API profile avatar — confirm the check still shows as **met**.
- [ ] Connect a wallet with neither avatar source — confirm the check shows as **not met**.


Made with [Cursor](https://cursor.com)