### PR TITLE
fix: resolve xChain portfolio loading race conditions (#322)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.699",
+  "version": "0.1.700",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -3790,7 +3790,11 @@ const Portfolio = () => {
     fetchUserInFlight.current = true;
     fetchUserAddressRef.current = userAddress;
 
+    const isCurrentFetchUser = () =>
+      fetchUserAddressRef.current === userAddress;
+
     const applyPortfolioComputed = (user: Record<string, unknown>) => {
+      if (!isCurrentFetchUser()) return;
       if (!user.globalUserData || !Array.isArray(user.globalUserData)) {
         return;
       }
@@ -3879,6 +3883,7 @@ const Portfolio = () => {
         },
       };
       console.log("[Portfolio] User:", computedUser);
+      if (!isCurrentFetchUser()) return;
       setUser(computedUser);
       console.log("[Portfolio] Network values:", networkValues);
     };
@@ -3892,6 +3897,7 @@ const Portfolio = () => {
       console.log("[Portfolio] API response:", apiResponse);
 
       if (apiResponse.success && apiResponse.data) {
+        if (!isCurrentFetchUser()) return;
         const user = apiResponse.data as Record<string, unknown>;
         console.log("[Portfolio] User data fetched from API:", user);
 
@@ -3914,7 +3920,7 @@ const Portfolio = () => {
         `[Portfolio] API failed; falling back to chain for ${userAddress}`
       );
       const chain = await fetchUserDataFromChain(userAddress);
-      if (chain) {
+      if (chain && isCurrentFetchUser()) {
         setUserProfileAvatar(null);
         applyPortfolioComputed({
           address: userAddress,
@@ -3926,7 +3932,7 @@ const Portfolio = () => {
     } catch (error) {
       console.error("Error fetching user global data:", error);
       const chain = await fetchUserDataFromChain(userAddress);
-      if (chain) {
+      if (chain && isCurrentFetchUser()) {
         setUserProfileAvatar(null);
         applyPortfolioComputed({
           address: userAddress,

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -498,6 +498,9 @@ const Portfolio = () => {
   const [userProfileAvatar, setUserProfileAvatar] = useState<string | null>(
     null
   );
+  // Guards for fetchUser: prevent concurrent fetches and stale-address races
+  const fetchUserInFlight = useRef(false);
+  const fetchUserAddressRef = useRef<string | null>(null);
 
   // Compute final avatar: prioritize user profile avatar > resolver avatar
   // If neither exists, components will show placeholder
@@ -3782,6 +3785,11 @@ const Portfolio = () => {
   ]);
 
   const fetchUser = async (userAddress: string) => {
+    // Deduplicate concurrent calls for the same address; cancel stale-address results
+    if (fetchUserInFlight.current && fetchUserAddressRef.current === userAddress) return;
+    fetchUserInFlight.current = true;
+    fetchUserAddressRef.current = userAddress;
+
     const applyPortfolioComputed = (user: Record<string, unknown>) => {
       if (!user.globalUserData || !Array.isArray(user.globalUserData)) {
         return;
@@ -3927,20 +3935,29 @@ const Portfolio = () => {
           userDataSource: "chain",
         });
       }
+    } finally {
+      // Only clear the in-flight flag if this call is still the current one
+      if (fetchUserAddressRef.current === userAddress) {
+        fetchUserInFlight.current = false;
+      }
     }
   };
 
   useEffect(() => {
-    if (displayAddress) {
-      fetchUser(displayAddress);
-    }
+    if (!displayAddress) return;
+    // Reset in-flight state when address changes so new address always fetches
+    fetchUserInFlight.current = false;
+    fetchUserAddressRef.current = null;
+    fetchUser(displayAddress);
   }, [displayAddress]);
 
-  // Fetch market data for all enabled networks when user data is available
+  // Fetch market data for all enabled networks when user data is available.
+  // Also fires after a 6s timeout so markets load even if fetchUser stalls (xChain race).
   useEffect(() => {
     const fetchMarketDataForAllNetworks = async () => {
-      if (!user?.computed) {
-        return; // Wait for user data to be available
+      // Proceed if user data is ready OR address is present (markets don't require user data)
+      if (!displayAddress && !user?.computed) {
+        return;
       }
 
       try {
@@ -3975,7 +3992,12 @@ const Portfolio = () => {
     };
 
     fetchMarketDataForAllNetworks();
-  }, [user?.computed, activeAccount?.address]);
+    // Fallback: if user data hasn't resolved in 6s (xChain wallet init race), load markets anyway
+    const fallbackTimer = setTimeout(() => {
+      if (displayAddress) void fetchMarketDataForAllNetworks();
+    }, 6000);
+    return () => clearTimeout(fallbackTimer);
+  }, [user?.computed, activeAccount?.address, displayAddress]);
 
   // Fetch user global data and market data when wallet connects
   // useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #322 — xChain Portfolio page not consistently loading positions and balances.

## Root Causes Found

### 1. Concurrent `fetchUser` calls (race condition)
For xChain/RainbowKit wallets, `activeAccount.address` resolves asynchronously after wagmi initializes the EVM↔Algorand account mapping. The `useEffect` on `displayAddress` could fire multiple times in quick succession — two concurrent `fetchUser` calls would race, and the slower one could overwrite a valid result with stale or error data.

### 2. No stale-address cancellation
If the address changed mid-flight (e.g. wagmi reconnect), the previous call had no way to know it was stale. It could complete and call `setUser` with data for the wrong address.

### 3. Market data permanently gated on `user?.computed`
```ts
useEffect(() => {
  if (!user?.computed) return; // waits forever if fetchUser stalled
  ...fetchAllMarkets
}, [user?.computed])
```
If `fetchUser` fails silently (API 404 + chain fallback empty), `user` stays `null` permanently → markets never load → no positions ever render. This is the most visible symptom: the page spins indefinitely.

## Fixes

| Fix | Description |
|-----|-------------|
| `fetchUserInFlight` ref | Deduplicates concurrent calls for the same address |
| `fetchUserAddressRef` ref | Tracks current address; stale calls skip clearing the flag |
| useEffect address reset | Clears both refs on address change so new address always fetches |
| 6s fallback timer | Loads market data independently if `user?.computed` hasn't resolved — unblocks rendering for xChain users whose API lookup returns 404 on first connect |

## Files Changed
- `src/components/Portfolio.tsx` (+29 / -7)

## Testing
- Connect with xChain wallet → portfolio should load positions consistently without refresh
- Disconnect and reconnect → data should reload cleanly without stale state
- Test with slow network / API 404 for new address → markets should still load after ~6s