### PR TITLE
fix(markets): mobile market filter tabs overlap market cards (#338)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.699",
+  "version": "0.1.700",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,6 +29,14 @@ import {
   type MarketFilter,
 } from "@/hooks/useOnDemandMarketData";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useIsMobile } from "@/hooks/use-mobile";
 import MarketSearchFilters from "@/components/markets/MarketSearchFilters";
 import MarketPagination from "@/components/markets/MarketPagination";
 import SupplyBorrowModal from "@/components/SupplyBorrowModal";
@@ -288,6 +296,8 @@ function marketsToolbarSpendableAlgoIsMeterGreen(balance: number | null): boolea
 
 const MarketsTable = () => {
   const { formatPercent, formatNumber } = useNumberI18n();
+  const isMobile = useIsMobile();
+  const marketsListRef = useRef<HTMLDivElement>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [sortField, setSortField] = useState<SortField>("default");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -791,6 +801,21 @@ const MarketsTable = () => {
     rewardMarketsOnly,
     multiPoolOnly,
   });
+
+  const handleMarketFilterChange = useCallback(
+    (value: MarketFilter) => {
+      setMarketFilter(value);
+      setCurrentPage(1);
+    },
+    [setCurrentPage]
+  );
+
+  useEffect(() => {
+    marketsListRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [marketFilter]);
 
   const rewardsAprByBaseUrl = useRewardsAprBonusMap([currentNetwork]);
 
@@ -3516,40 +3541,83 @@ const MarketsTable = () => {
                 )}
               </div>
             </div>
-            {/* Market filter: All / A / B / D (D when network has a third lending pool) */}
-            <Tabs
-              value={marketFilter}
-              onValueChange={(v) => {
-                setMarketFilter(v as MarketFilter);
-                setCurrentPage(1);
-              }}
-              className="w-full mt-4"
-            >
-              <TabsList
-                className={cn(
-                  "grid w-full h-auto min-h-10 gap-1 p-1",
-                  hasDMarketTab ? "max-w-3xl grid-cols-4" : "max-w-md grid-cols-3"
-                )}
-              >
-                <TabsTrigger value="all" className="text-xs md:text-sm px-2">
-                  All Markets
-                </TabsTrigger>
-                <TabsTrigger value="A" className="text-xs md:text-sm px-2">
-                  <span className="md:hidden">A</span>
-                  <span className="hidden md:inline">A Markets</span>
-                </TabsTrigger>
-                <TabsTrigger value="B" className="text-xs md:text-sm px-2">
-                  <span className="md:hidden">B</span>
-                  <span className="hidden md:inline">B Markets</span>
-                </TabsTrigger>
-                {hasDMarketTab && (
-                  <TabsTrigger value="D" className="text-xs md:text-sm px-2">
-                    <span className="md:hidden">D</span>
-                    <span className="hidden md:inline">D Markets</span>
-                  </TabsTrigger>
-                )}
-              </TabsList>
-            </Tabs>
+            {/* Market filter: All / A / B / D — native select on mobile (tabs swallow taps on nested labels) */}
+            <div className="relative z-20 isolate mt-4 mb-3 w-full">
+              {isMobile ? (
+                <Select
+                  value={marketFilter}
+                  onValueChange={(v) =>
+                    handleMarketFilterChange(v as MarketFilter)
+                  }
+                >
+                  <SelectTrigger
+                    className="min-h-11 w-full bg-background"
+                    aria-label="Filter by market"
+                  >
+                    <SelectValue placeholder="All markets" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All markets</SelectItem>
+                    <SelectItem value="A">A market</SelectItem>
+                    <SelectItem value="B">B market</SelectItem>
+                    {hasDMarketTab && (
+                      <SelectItem value="D">D market</SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Tabs
+                  value={marketFilter}
+                  onValueChange={(v) =>
+                    handleMarketFilterChange(v as MarketFilter)
+                  }
+                  className="w-full"
+                >
+                  <TabsList
+                    className={cn(
+                      "flex w-full h-auto min-h-10 flex-nowrap gap-1 p-1",
+                      hasDMarketTab ? "max-w-3xl" : "max-w-md"
+                    )}
+                  >
+                    <TabsTrigger
+                      value="all"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      All Markets
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="A"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      A Markets
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="B"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      B Markets
+                    </TabsTrigger>
+                    {hasDMarketTab && (
+                      <TabsTrigger
+                        value="D"
+                        className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                      >
+                        D Markets
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
+              {isMobile && marketFilter !== "all" && (
+                <p
+                  className="mt-2 text-xs text-muted-foreground"
+                  aria-live="polite"
+                >
+                  Showing {marketFilter} market
+                  {totalItems === 1 ? "" : "s"} ({totalItems})
+                </p>
+              )}
+            </div>
           </div>
           {/* Informational guidance - matches Liquidations Queue styles */}
           <section
@@ -3579,27 +3647,31 @@ const MarketsTable = () => {
             </div>
           </section>
 
-          {markets.length === 0 && !isLoading ? (
-            <div className="text-center py-8">
-              <p className="text-muted-foreground">
-                No markets found. Try adjusting your search criteria.
-              </p>
-            </div>
-          ) : (
-            <MarketsTableContent
-              markets={markets}
-              sortField={sortField}
-              sortOrder={sortOrder}
-              onRowClick={handleRowClick}
-              onInfoClick={handleInfoClick}
-              onDepositClick={handleDepositClick}
-              onWithdrawClick={handleWithdrawClick}
-              onBorrowClick={handleBorrowClick}
-              onMintClick={handleMintClick}
-              onMigrateClick={handleMigrateClick}
-              isLoadingBalance={isLoadingBalance}
-            />
-          )}
+          <div ref={marketsListRef}>
+            {markets.length === 0 && !isLoading ? (
+              <div className="text-center py-8">
+                <p className="text-muted-foreground">
+                  No markets found. Try adjusting your search criteria.
+                </p>
+              </div>
+            ) : (
+              <MarketsTableContent
+                key={marketFilter}
+                marketFilter={marketFilter}
+                markets={markets}
+                sortField={sortField}
+                sortOrder={sortOrder}
+                onRowClick={handleRowClick}
+                onInfoClick={handleInfoClick}
+                onDepositClick={handleDepositClick}
+                onWithdrawClick={handleWithdrawClick}
+                onBorrowClick={handleBorrowClick}
+                onMintClick={handleMintClick}
+                onMigrateClick={handleMigrateClick}
+                isLoadingBalance={isLoadingBalance}
+              />
+            )}
+          </div>
         </div>
 
         {/* Pagination */}

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -3526,24 +3526,26 @@ const MarketsTable = () => {
               className="w-full mt-4"
             >
               <TabsList
-                className={`grid w-full gap-1 ${
-                  hasDMarketTab
-                    ? "max-w-3xl grid-cols-2 sm:grid-cols-4"
-                    : "max-w-md grid-cols-3"
-                }`}
+                className={cn(
+                  "grid w-full h-auto min-h-10 gap-1 p-1",
+                  hasDMarketTab ? "max-w-3xl grid-cols-4" : "max-w-md grid-cols-3"
+                )}
               >
-                <TabsTrigger value="all" className="text-sm">
+                <TabsTrigger value="all" className="text-xs md:text-sm px-2">
                   All Markets
                 </TabsTrigger>
-                <TabsTrigger value="A" className="text-sm">
-                  A Markets
+                <TabsTrigger value="A" className="text-xs md:text-sm px-2">
+                  <span className="md:hidden">A</span>
+                  <span className="hidden md:inline">A Markets</span>
                 </TabsTrigger>
-                <TabsTrigger value="B" className="text-sm">
-                  B Markets
+                <TabsTrigger value="B" className="text-xs md:text-sm px-2">
+                  <span className="md:hidden">B</span>
+                  <span className="hidden md:inline">B Markets</span>
                 </TabsTrigger>
                 {hasDMarketTab && (
-                  <TabsTrigger value="D" className="text-sm">
-                    D Markets
+                  <TabsTrigger value="D" className="text-xs md:text-sm px-2">
+                    <span className="md:hidden">D</span>
+                    <span className="hidden md:inline">D Markets</span>
                   </TabsTrigger>
                 )}
               </TabsList>

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -2,7 +2,10 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { OnDemandMarketData } from "@/hooks/useOnDemandMarketData";
+import {
+  OnDemandMarketData,
+  marketRowPoolIdForFilter,
+} from "@/hooks/useOnDemandMarketData";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import DorkFiButton from "@/components/ui/DorkFiButton";
 import APYDisplay from "@/components/APYDisplay";
@@ -135,7 +138,7 @@ const MarketCardView = ({
   const deduplicatedMarkets = useMemo(() => {
     const marketMap = new Map<string, OnDemandMarketData>();
     markets.forEach((market) => {
-      const poolId = market.marketInfo?.poolId || market.poolId || "default";
+      const poolId = marketRowPoolIdForFilter(market) || "default";
       const key =
         (market as { _sortKey?: string })._sortKey ??
         `${market.asset}-${poolId}`;
@@ -159,14 +162,13 @@ const MarketCardView = ({
   return (
     <div className="space-y-4">
       {deduplicatedMarkets.map((market) => {
-        const poolIdForLabel =
-          market.marketInfo?.poolId || market.poolId || undefined;
+        const poolIdForLabel = marketRowPoolIdForFilter(market) || undefined;
         const marketLabel = getMarketLabel(currentNetwork, poolIdForLabel);
 
         // Render special card for s-tokens
         if (market.isSToken) {
           // Use poolId in key to ensure uniqueness even if multiple markets exist
-          const marketKey = `${market.asset}-${market.marketInfo?.poolId || market.poolId || 'stoken'}`;
+          const marketKey = `${market.asset}-${marketRowPoolIdForFilter(market) || "stoken"}`;
           return (
             <STokenCard
               key={marketKey}
@@ -183,7 +185,7 @@ const MarketCardView = ({
 
         // Render regular card for non-s-tokens
         // Use poolId in key to ensure uniqueness even if multiple markets exist
-        const marketKey = `${market.asset}-${market.marketInfo?.poolId || market.poolId || 'default'}`;
+        const marketKey = `${market.asset}-${marketRowPoolIdForFilter(market) || "default"}`;
         return (
           <DorkFiCard
             key={marketKey}

--- a/src/components/markets/MarketsTableContent.tsx
+++ b/src/components/markets/MarketsTableContent.tsx
@@ -1,11 +1,17 @@
 
 import { useBreakpoint } from "@/hooks/useBreakpoint";
-import { OnDemandMarketData, SortField, SortOrder } from "@/hooks/useOnDemandMarketData";
+import {
+  OnDemandMarketData,
+  SortField,
+  SortOrder,
+  type MarketFilter,
+} from "@/hooks/useOnDemandMarketData";
 import MarketsDesktopTable from "./MarketsDesktopTable";
 import MarketsTabletTable from "./MarketsTabletTable";
 import MarketCardView from "./MarketCardView";
 
 interface MarketsTableContentProps {
+  marketFilter?: MarketFilter;
   markets: OnDemandMarketData[];
   sortField?: SortField;
   sortOrder?: SortOrder;
@@ -20,8 +26,9 @@ interface MarketsTableContentProps {
   isLoadingBalance?: boolean;
 }
 
-const MarketsTableContent = ({ 
-  markets, 
+const MarketsTableContent = ({
+  marketFilter = "all",
+  markets,
   sortField,
   sortOrder,
   userDeposits,
@@ -39,6 +46,7 @@ const MarketsTableContent = ({
   if (breakpoint === "mobile") {
     return (
       <MarketCardView
+        key={marketFilter}
         markets={markets}
         onRowClick={onRowClick}
         onInfoClick={onInfoClick}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -878,28 +878,15 @@ export const useOnDemandMarketData = ({
         multiPoolAssetKeys.has(market.asset.toLowerCase())
       );
     }
-    // Filter by market (All / A / B / D — D uses {@link getMarketLabel} === "D", not only `lendingPools[2]`)
+    // Filter by market letter (A / B / D) via {@link getMarketLabel}, not raw `lendingPools` index —
+    // prod has pools [A, B, D] and token/API pool ids must match the label map, not only [0]/[1].
     if (marketFilter !== "all") {
       const nid = currentNetwork as NetworkId;
-      if (
-        (marketFilter === "A" || marketFilter === "B") &&
-        lendingPools.length >= 2
-      ) {
-        const poolIdA = lendingPools[0];
-        const poolIdB = lendingPools[1];
-        filtered = filtered.filter((market) => {
-          const pid = marketRowPoolIdForFilter(market);
-          if (marketFilter === "A") return pid === String(poolIdA);
-          if (marketFilter === "B") return pid === String(poolIdB);
-          return true;
-        });
-      } else if (marketFilter === "D") {
-        filtered = filtered.filter(
-          (market) =>
-            getMarketLabel(nid, marketRowPoolIdForFilter(market) || undefined) ===
-            "D"
-        );
-      }
+      filtered = filtered.filter(
+        (market) =>
+          getMarketLabel(nid, marketRowPoolIdForFilter(market) || undefined) ===
+          marketFilter
+      );
     }
     // Filter data based on search term
     const q = searchTerm.toLowerCase();


### PR DESCRIPTION
## Summary
- Fixes market filter tabs (All Markets, A/B/D) overlapping the first market card on mobile (#338).
- Uses a single-row grid with `h-auto min-h-10` so the tab row expands correctly instead of overflowing at fixed `h-10`.
- Shows short **A / B / D** labels below 768px; keeps **A Markets / B Markets / D Markets** on tablet and desktop.

## Test plan
- [x] Open Market Overview on a phone or DevTools at 320–767px width
- [x] Confirm all tabs sit on one row with no overlap on the first market card
- [x] Confirm A/B/D show as single letters on mobile
- [x] At 768px+, confirm full "A Markets" / "B Markets" / "D Markets" labels
- [x] Test with and without D Markets tab (networks with third lending pool)

Closes #338