### PR TITLE
Release beta: markets UX, modal performance, and xChain portfolio fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.699",
+  "version": "0.1.700",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.700",
+  "version": "0.1.711",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketDetailModal.tsx
+++ b/src/components/MarketDetailModal.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -17,6 +17,12 @@ import { getAllTokensWithDisplayInfo } from "@/config";
 import { APYCalculationResult } from "@/utils/apyCalculations";
 import { useToast } from "@/hooks/use-toast";
 import { isAtBorrowCap as isAtBorrowCapUtil } from "@/constants/lendingCaps";
+import {
+  createDebouncedPrefetch,
+  warmBorrowModalMaxAndPool,
+  type MarketActionTokenParams,
+} from "@/utils/modalPrefetch";
+import type { NetworkId } from "@/config";
 import {
   borrowApyBadgeClassName,
   BORROW_APY_BADGE_DEFAULT,
@@ -92,6 +98,20 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
     setSupplyModal({ isOpen: true, asset });
   };
 
+  const debouncedPrefetch = useMemo(() => createDebouncedPrefetch(), []);
+
+  const prefetchBorrowOnHover = useCallback(() => {
+    if (!activeAccount?.address) return;
+    const params: MarketActionTokenParams = {
+      userAddress: activeAccount.address,
+      networkId: currentNetwork as NetworkId,
+      asset,
+    };
+    debouncedPrefetch(`borrowDetail:${currentNetwork}:${asset}`, () =>
+      warmBorrowModalMaxAndPool(params)
+    );
+  }, [activeAccount?.address, currentNetwork, asset, debouncedPrefetch]);
+
   const handleBorrowClick = async () => {
     if (isAtBorrowCap) {
       toast({
@@ -102,44 +122,43 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
       });
       return;
     }
+
+    setBorrowModal({ isOpen: true, asset });
+
     setIsLoadingGlobalData(true);
-    
-    try {
-      // Fetch user global data before opening modal (only if wallet is connected)
-      if (activeAccount?.address) {
-        const globalData = await fetchUserGlobalData(activeAccount.address, currentNetwork);
-        setUserGlobalData(globalData);
-        
-        // Fetch user's current borrow balance for this specific asset
-        const tokens = getAllTokensWithDisplayInfo(currentNetwork);
-        const token = tokens.find((t) => t.symbol === asset);
-        
-        if (token && token.poolId && token.underlyingContractId) {
-          const borrowData = await fetchUserBorrowBalance(
+    void (async () => {
+      try {
+        if (activeAccount?.address) {
+          const globalData = await fetchUserGlobalData(
             activeAccount.address,
-            token.poolId,
-            token.underlyingContractId,
             currentNetwork
           );
-          setUserBorrowBalance(borrowData?.balance || 0);
+          setUserGlobalData(globalData);
+
+          const tokens = getAllTokensWithDisplayInfo(currentNetwork);
+          const token = tokens.find((t) => t.symbol === asset);
+
+          if (token && token.poolId && token.underlyingContractId) {
+            const borrowData = await fetchUserBorrowBalance(
+              activeAccount.address,
+              token.poolId,
+              token.underlyingContractId,
+              currentNetwork
+            );
+            setUserBorrowBalance(borrowData?.balance || 0);
+          } else {
+            setUserBorrowBalance(0);
+          }
         } else {
+          setUserGlobalData(null);
           setUserBorrowBalance(0);
         }
-      } else {
-        // Not connected, set empty data
-        setUserGlobalData(null);
-        setUserBorrowBalance(0);
+      } catch (error) {
+        console.error("Error fetching user data for borrow:", error);
+      } finally {
+        setIsLoadingGlobalData(false);
       }
-      
-      // Open modal regardless of connection status
-      setBorrowModal({ isOpen: true, asset });
-    } catch (error) {
-      console.error("Error fetching user data for borrow:", error);
-      // Still open modal even if data fetch fails
-      setBorrowModal({ isOpen: true, asset });
-    } finally {
-      setIsLoadingGlobalData(false);
-    }
+    })();
   };
 
   const handleCloseSupplyModal = () => {
@@ -564,6 +583,7 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
                 Deposit {asset}
               </Button>
               <Button
+                onMouseEnter={prefetchBorrowOnHover}
                 onClick={handleBorrowClick}
                 variant="outline"
                 disabled={isAtBorrowCap}
@@ -598,6 +618,7 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
           assetData={getAssetData()}
           userGlobalData={userGlobalData}
           userBorrowBalance={userBorrowBalance}
+          isLoadingBorrowGlobalData={isLoadingGlobalData}
         />
       )}
      </>

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,6 +29,14 @@ import {
   type MarketFilter,
 } from "@/hooks/useOnDemandMarketData";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useIsMobile } from "@/hooks/use-mobile";
 import MarketSearchFilters from "@/components/markets/MarketSearchFilters";
 import MarketPagination from "@/components/markets/MarketPagination";
 import SupplyBorrowModal from "@/components/SupplyBorrowModal";
@@ -288,6 +296,8 @@ function marketsToolbarSpendableAlgoIsMeterGreen(balance: number | null): boolea
 
 const MarketsTable = () => {
   const { formatPercent, formatNumber } = useNumberI18n();
+  const isMobile = useIsMobile();
+  const marketsListRef = useRef<HTMLDivElement>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [sortField, setSortField] = useState<SortField>("default");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -791,6 +801,21 @@ const MarketsTable = () => {
     rewardMarketsOnly,
     multiPoolOnly,
   });
+
+  const handleMarketFilterChange = useCallback(
+    (value: MarketFilter) => {
+      setMarketFilter(value);
+      setCurrentPage(1);
+    },
+    [setCurrentPage]
+  );
+
+  useEffect(() => {
+    marketsListRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [marketFilter]);
 
   const rewardsAprByBaseUrl = useRewardsAprBonusMap([currentNetwork]);
 
@@ -3516,38 +3541,83 @@ const MarketsTable = () => {
                 )}
               </div>
             </div>
-            {/* Market filter: All / A / B / D (D when network has a third lending pool) */}
-            <Tabs
-              value={marketFilter}
-              onValueChange={(v) => {
-                setMarketFilter(v as MarketFilter);
-                setCurrentPage(1);
-              }}
-              className="w-full mt-4"
-            >
-              <TabsList
-                className={`grid w-full gap-1 ${
-                  hasDMarketTab
-                    ? "max-w-3xl grid-cols-2 sm:grid-cols-4"
-                    : "max-w-md grid-cols-3"
-                }`}
-              >
-                <TabsTrigger value="all" className="text-sm">
-                  All Markets
-                </TabsTrigger>
-                <TabsTrigger value="A" className="text-sm">
-                  A Markets
-                </TabsTrigger>
-                <TabsTrigger value="B" className="text-sm">
-                  B Markets
-                </TabsTrigger>
-                {hasDMarketTab && (
-                  <TabsTrigger value="D" className="text-sm">
-                    D Markets
-                  </TabsTrigger>
-                )}
-              </TabsList>
-            </Tabs>
+            {/* Market filter: All / A / B / D — native select on mobile (tabs swallow taps on nested labels) */}
+            <div className="relative z-20 isolate mt-4 mb-3 w-full">
+              {isMobile ? (
+                <Select
+                  value={marketFilter}
+                  onValueChange={(v) =>
+                    handleMarketFilterChange(v as MarketFilter)
+                  }
+                >
+                  <SelectTrigger
+                    className="min-h-11 w-full bg-background"
+                    aria-label="Filter by market"
+                  >
+                    <SelectValue placeholder="All markets" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All markets</SelectItem>
+                    <SelectItem value="A">A market</SelectItem>
+                    <SelectItem value="B">B market</SelectItem>
+                    {hasDMarketTab && (
+                      <SelectItem value="D">D market</SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Tabs
+                  value={marketFilter}
+                  onValueChange={(v) =>
+                    handleMarketFilterChange(v as MarketFilter)
+                  }
+                  className="w-full"
+                >
+                  <TabsList
+                    className={cn(
+                      "flex w-full h-auto min-h-10 flex-nowrap gap-1 p-1",
+                      hasDMarketTab ? "max-w-3xl" : "max-w-md"
+                    )}
+                  >
+                    <TabsTrigger
+                      value="all"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      All Markets
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="A"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      A Markets
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="B"
+                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                    >
+                      B Markets
+                    </TabsTrigger>
+                    {hasDMarketTab && (
+                      <TabsTrigger
+                        value="D"
+                        className="min-h-10 min-w-0 flex-1 px-2 text-sm"
+                      >
+                        D Markets
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
+              {isMobile && marketFilter !== "all" && (
+                <p
+                  className="mt-2 text-xs text-muted-foreground"
+                  aria-live="polite"
+                >
+                  Showing {marketFilter} market
+                  {totalItems === 1 ? "" : "s"} ({totalItems})
+                </p>
+              )}
+            </div>
           </div>
           {/* Informational guidance - matches Liquidations Queue styles */}
           <section
@@ -3577,27 +3647,31 @@ const MarketsTable = () => {
             </div>
           </section>
 
-          {markets.length === 0 && !isLoading ? (
-            <div className="text-center py-8">
-              <p className="text-muted-foreground">
-                No markets found. Try adjusting your search criteria.
-              </p>
-            </div>
-          ) : (
-            <MarketsTableContent
-              markets={markets}
-              sortField={sortField}
-              sortOrder={sortOrder}
-              onRowClick={handleRowClick}
-              onInfoClick={handleInfoClick}
-              onDepositClick={handleDepositClick}
-              onWithdrawClick={handleWithdrawClick}
-              onBorrowClick={handleBorrowClick}
-              onMintClick={handleMintClick}
-              onMigrateClick={handleMigrateClick}
-              isLoadingBalance={isLoadingBalance}
-            />
-          )}
+          <div ref={marketsListRef}>
+            {markets.length === 0 && !isLoading ? (
+              <div className="text-center py-8">
+                <p className="text-muted-foreground">
+                  No markets found. Try adjusting your search criteria.
+                </p>
+              </div>
+            ) : (
+              <MarketsTableContent
+                key={marketFilter}
+                marketFilter={marketFilter}
+                markets={markets}
+                sortField={sortField}
+                sortOrder={sortOrder}
+                onRowClick={handleRowClick}
+                onInfoClick={handleInfoClick}
+                onDepositClick={handleDepositClick}
+                onWithdrawClick={handleWithdrawClick}
+                onBorrowClick={handleBorrowClick}
+                onMintClick={handleMintClick}
+                onMigrateClick={handleMigrateClick}
+                isLoadingBalance={isLoadingBalance}
+              />
+            )}
+          </div>
         </div>
 
         {/* Pagination */}

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -101,6 +101,14 @@ import {
   XchainUsdcBridgeControls,
   shouldShowXchainUsdcBridgeControls,
 } from "@/components/xchain/XchainUsdcBridgeControls";
+import {
+  createDebouncedPrefetch,
+  warmMarketDetailUserPositionRpc,
+  poolIdFromMarketRow,
+  marketRowKeyFromMarket,
+  type MarketActionTokenParams,
+} from "@/utils/modalPrefetch";
+import { buildMarketHoverHandlers } from "@/utils/modalHoverHandlers";
 
 const MAX_CLAIMS_PER_TX = 3;
 
@@ -992,58 +1000,42 @@ const MarketsTable = () => {
       }
     }
 
+    const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
+    setDepositModal({
+      isOpen: true,
+      asset,
+      poolId,
+      marketRowKey,
+      configSymbol,
+    });
+
     setIsLoadingBalance(true);
+    void (async () => {
+      try {
+        await fetchWalletBalance(asset, poolId, marketRowKey);
 
-    try {
-      // Fetch wallet balance before opening modal
-      await fetchWalletBalance(asset, poolId, marketRowKey, {
-        bypassCache: true,
-      });
-
-      let poolCollateralRows: PoolCollateralMarketRow[] = [];
-      if (activeAccount?.address && poolId != null && poolId !== "") {
-        try {
-          poolCollateralRows = await fetchPoolCollateralMarketRowsForDeposit(
-            activeAccount.address,
-            currentNetwork as NetworkId,
-            poolId
-          );
-        } catch (e) {
-          console.error("Error loading pool collateral markets for deposit:", e);
+        if (activeAccount?.address && poolId != null && poolId !== "") {
+          try {
+            const poolCollateralRows =
+              await fetchPoolCollateralMarketRowsForDeposit(
+                activeAccount.address,
+                currentNetwork as NetworkId,
+                poolId
+              );
+            setDepositPoolCollateralMarkets(poolCollateralRows);
+          } catch (e) {
+            console.error(
+              "Error loading pool collateral markets for deposit:",
+              e
+            );
+          }
         }
+      } catch (error) {
+        console.error("Error fetching wallet balance for deposit:", error);
+      } finally {
+        setIsLoadingBalance(false);
       }
-      setDepositPoolCollateralMarkets(poolCollateralRows);
-
-      // Open modal after balance is fetched
-      const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
-      console.log("Opening deposit modal with:", {
-        asset,
-        poolId,
-        marketRowKey,
-        configSymbol,
-      });
-      setDepositModal({
-        isOpen: true,
-        asset,
-        poolId,
-        marketRowKey,
-        configSymbol,
-      });
-    } catch (error) {
-      console.error("Error fetching wallet balance for deposit:", error);
-      setDepositPoolCollateralMarkets([]);
-      // Still open modal even if balance fetch fails
-      const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
-      setDepositModal({
-        isOpen: true,
-        asset,
-        poolId,
-        marketRowKey,
-        configSymbol,
-      });
-    } finally {
-      setIsLoadingBalance(false);
-    }
+    })();
   };
 
   const handleWithdrawClick = (asset: string) => {
@@ -1071,77 +1063,69 @@ const MarketsTable = () => {
       }
     }
 
+    const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
+    setBorrowModal({
+      isOpen: true,
+      asset,
+      poolId,
+      marketRowKey,
+      configSymbol,
+    });
+
     setIsLoadingGlobalData(true);
-
-    try {
-      // Fetch user global data before opening modal (only if wallet is connected)
-      if (activeAccount?.address) {
-        const globalData = await fetchUserGlobalData(
-          activeAccount.address,
-          currentNetwork
-        );
-        setUserGlobalData(globalData);
-
-        // Fetch user's current borrow balance for this specific asset
-        const token = resolveTokenForDisplayedAsset(asset, poolId, marketRowKey);
-
-        if (token && token.poolId && token.underlyingContractId) {
-          const borrowData = await fetchUserBorrowBalance(
+    void (async () => {
+      try {
+        if (activeAccount?.address) {
+          const globalData = await fetchUserGlobalData(
             activeAccount.address,
-            token.poolId,
-            token.underlyingContractId,
             currentNetwork
           );
-          setUserBorrowBalance(borrowData?.balance || 0);
+          setUserGlobalData(globalData);
+
+          const token = resolveTokenForDisplayedAsset(
+            asset,
+            poolId,
+            marketRowKey
+          );
+
+          if (token && token.poolId && token.underlyingContractId) {
+            const borrowData = await fetchUserBorrowBalance(
+              activeAccount.address,
+              token.poolId,
+              token.underlyingContractId,
+              currentNetwork
+            );
+            setUserBorrowBalance(borrowData?.balance || 0);
+          } else {
+            setUserBorrowBalance(0);
+          }
+
+          if (poolId != null && poolId !== "") {
+            try {
+              const poolCollateralRows =
+                await fetchPoolCollateralMarketRowsForDeposit(
+                  activeAccount.address,
+                  currentNetwork as NetworkId,
+                  poolId
+                );
+              setDepositPoolCollateralMarkets(poolCollateralRows);
+            } catch (e) {
+              console.error(
+                "Error loading pool collateral markets for borrow:",
+                e
+              );
+            }
+          }
         } else {
+          setUserGlobalData(null);
           setUserBorrowBalance(0);
         }
-      } else {
-        // Not connected, set empty data
-        setUserGlobalData(null);
-        setUserBorrowBalance(0);
+      } catch (error) {
+        console.error("Error fetching user data for borrow:", error);
+      } finally {
+        setIsLoadingGlobalData(false);
       }
-
-      let poolCollateralRows: PoolCollateralMarketRow[] = [];
-      if (activeAccount?.address && poolId != null && poolId !== "") {
-        try {
-          poolCollateralRows = await fetchPoolCollateralMarketRowsForDeposit(
-            activeAccount.address,
-            currentNetwork as NetworkId,
-            poolId
-          );
-        } catch (e) {
-          console.error(
-            "Error loading pool collateral markets for borrow:",
-            e
-          );
-        }
-      }
-      setDepositPoolCollateralMarkets(poolCollateralRows);
-
-      // Open modal regardless of connection status
-      const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
-      setBorrowModal({
-        isOpen: true,
-        asset,
-        poolId,
-        marketRowKey,
-        configSymbol,
-      });
-    } catch (error) {
-      console.error("Error fetching user data for borrow:", error);
-      setDepositPoolCollateralMarkets([]);
-      const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
-      setBorrowModal({
-        isOpen: true,
-        asset,
-        poolId,
-        marketRowKey,
-        configSymbol,
-      });
-    } finally {
-      setIsLoadingGlobalData(false);
-    }
+    })();
   };
 
   const handleMintClick = async (
@@ -1149,45 +1133,45 @@ const MarketsTable = () => {
     poolId?: string,
     marketRowKey?: string
   ) => {
+    setMintModal({ isOpen: true, asset, poolId, marketRowKey });
+
     setIsLoadingGlobalData(true);
-
-    try {
-      // Fetch user global data before opening modal (only if wallet is connected)
-      if (activeAccount?.address) {
-        const globalData = await fetchUserGlobalData(
-          activeAccount.address,
-          currentNetwork
-        );
-        setUserGlobalData(globalData);
-
-        const token = resolveTokenForDisplayedAsset(asset, poolId, marketRowKey);
-
-        if (token && token.poolId && token.underlyingContractId) {
-          const borrowData = await fetchUserBorrowBalance(
+    void (async () => {
+      try {
+        if (activeAccount?.address) {
+          const globalData = await fetchUserGlobalData(
             activeAccount.address,
-            token.poolId,
-            token.underlyingContractId,
             currentNetwork
           );
-          setUserBorrowBalance(borrowData?.balance || 0);
+          setUserGlobalData(globalData);
+
+          const token = resolveTokenForDisplayedAsset(
+            asset,
+            poolId,
+            marketRowKey
+          );
+
+          if (token && token.poolId && token.underlyingContractId) {
+            const borrowData = await fetchUserBorrowBalance(
+              activeAccount.address,
+              token.poolId,
+              token.underlyingContractId,
+              currentNetwork
+            );
+            setUserBorrowBalance(borrowData?.balance || 0);
+          } else {
+            setUserBorrowBalance(0);
+          }
         } else {
+          setUserGlobalData(null);
           setUserBorrowBalance(0);
         }
-      } else {
-        // Not connected, set empty data
-        setUserGlobalData(null);
-        setUserBorrowBalance(0);
+      } catch (error) {
+        console.error("Error fetching user data for mint:", error);
+      } finally {
+        setIsLoadingGlobalData(false);
       }
-
-      // Open modal regardless of connection status, pass poolId if available
-      setMintModal({ isOpen: true, asset, poolId, marketRowKey });
-    } catch (error) {
-      console.error("Error fetching user data for mint:", error);
-      // Still open modal even if data fetch fails
-      setMintModal({ isOpen: true, asset, poolId, marketRowKey });
-    } finally {
-      setIsLoadingGlobalData(false);
-    }
+    })();
   };
 
   const handleMigrateClick = async (asset: string) => {
@@ -1560,9 +1544,27 @@ const MarketsTable = () => {
 
   // When the detail modal is open, replace the snapshot row with the refreshed row from
   // `loadMarketDataWithBypass` (chain-sourced marketInfo) once it lands in `markets`.
-  // Compare `lastFetched` so we do not churn on unrelated `markets` remaps (e.g. rewards APR).
+  // Key off `lastFetched` only — `markets` is remapped often (rewards APR) with new object refs.
+  const detailModalRowLastFetched = useMemo(() => {
+    if (!detailModal.isOpen || !detailModal.asset) return undefined;
+    const fresh = findMarketRowOnPage(
+      markets as Record<string, unknown>[],
+      detailModal.asset,
+      detailModal.poolId,
+      detailModal.marketRowKey
+    );
+    return (fresh as { lastFetched?: number } | undefined)?.lastFetched;
+  }, [
+    markets,
+    detailModal.isOpen,
+    detailModal.asset,
+    detailModal.poolId,
+    detailModal.marketRowKey,
+  ]);
+
   useEffect(() => {
     if (!detailModal.isOpen || !detailModal.asset) return;
+    if (detailModalRowLastFetched === undefined) return;
     const fresh = findMarketRowOnPage(
       markets as Record<string, unknown>[],
       detailModal.asset,
@@ -1572,20 +1574,17 @@ const MarketsTable = () => {
     if (!fresh) return;
     setDetailModal((prev) => {
       if (!prev.isOpen || !prev.marketData) return prev;
-      if (fresh === prev.marketData) return prev;
       const prevLast = (prev.marketData as { lastFetched?: number }).lastFetched;
-      const freshLast = (fresh as { lastFetched?: number }).lastFetched;
       if (
         prevLast !== undefined &&
-        freshLast !== undefined &&
-        freshLast <= prevLast
+        detailModalRowLastFetched <= prevLast
       ) {
         return prev;
       }
       return { ...prev, marketData: fresh };
     });
   }, [
-    markets,
+    detailModalRowLastFetched,
     detailModal.isOpen,
     detailModal.asset,
     detailModal.poolId,
@@ -2868,6 +2867,65 @@ const MarketsTable = () => {
     }
   };
 
+  const debouncedPrefetch = useMemo(() => createDebouncedPrefetch(), []);
+
+  const marketHoverBundle = useMemo(
+    () => ({
+      debounced: debouncedPrefetch,
+      userAddress: activeAccount?.address,
+      networkId: currentNetwork as NetworkId,
+      warmWalletBalance: (p: MarketActionTokenParams) => {
+        if (!activeAccount?.address) return;
+        const rowKey = p.configSymbol
+          ? `${p.asset}|${p.configSymbol}|${p.poolId ?? ""}`
+          : undefined;
+        void fetchWalletBalance(p.asset, p.poolId, rowKey);
+      },
+    }),
+    [debouncedPrefetch, activeAccount?.address, currentNetwork]
+  );
+
+  const getMarketActionHoverHandlers = useCallback(
+    (asset: string, poolId?: string, marketRowKey?: string) =>
+      buildMarketHoverHandlers(
+        marketHoverBundle,
+        asset,
+        poolId,
+        marketRowKey
+      ),
+    [marketHoverBundle]
+  );
+
+  const prefetchMarketRowOnHover = useCallback(
+    (market: Record<string, unknown>) => {
+      if (!activeAccount?.address) return;
+      const asset = typeof market.asset === "string" ? market.asset : null;
+      if (!asset) return;
+      const poolId = poolIdFromMarketRow(
+        market as { marketInfo?: { poolId?: string }; poolId?: string }
+      );
+      const rowKey = marketRowKeyFromMarket(
+        market as { asset?: string; poolId?: string; configSymbol?: string; _sortKey?: string }
+      );
+      const configSymbol =
+        typeof (market as { configSymbol?: string }).configSymbol === "string"
+          ? (market as { configSymbol?: string }).configSymbol
+          : configSymbolFromMarketRowKey(rowKey);
+      debouncedPrefetch(
+        `detailRow:${currentNetwork}:${asset}:${poolId ?? ""}:${configSymbol ?? ""}`,
+        () =>
+          warmMarketDetailUserPositionRpc({
+            userAddress: activeAccount.address,
+            networkId: currentNetwork as NetworkId,
+            asset,
+            poolId,
+            configSymbol,
+          })
+      );
+    },
+    [activeAccount?.address, currentNetwork, debouncedPrefetch]
+  );
+
   const getAssetData = (asset: string, poolId?: string, marketRowKey?: string) => {
     const poolIdStr = poolId != null && poolId !== "" ? String(poolId) : null;
     let market: (typeof markets)[0] | undefined;
@@ -2987,10 +3045,12 @@ const MarketsTable = () => {
     };
   };
 
+  const detailPositionLoadKeyRef = useRef<string | null>(null);
   const detailPositionLoadIdRef = useRef(0);
 
   useEffect(() => {
     if (!detailModal.isOpen) {
+      detailPositionLoadKeyRef.current = null;
       setDetailModalUserPosition(null);
       setDetailModalUserPositionLoad("idle");
       return;
@@ -3011,15 +3071,28 @@ const MarketsTable = () => {
     }
 
     const poolId = detailModal.poolId;
-    const configSymbol =
-      typeof (row as { configSymbol?: string }).configSymbol === "string"
-        ? (row as { configSymbol?: string }).configSymbol
-        : undefined;
-    const token = resolveTokenForMarketPosition(currentNetwork, {
+    const rowLastFetched = (row as { lastFetched?: number }).lastFetched;
+    const loadKey = [
       asset,
-      poolId,
-      configSymbol,
-    });
+      poolId ?? "",
+      detailModal.marketRowKey ?? "",
+      activeAccount.address,
+      currentNetwork,
+      rowLastFetched ?? "",
+    ].join("|");
+
+    const tokens = getAllTokensWithDisplayInfo(currentNetwork);
+    const token =
+      resolveTokenForDisplayedAsset(
+        asset,
+        poolId,
+        detailModal.marketRowKey
+      ) ??
+      (poolId != null && poolId !== ""
+        ? tokens.find(
+            (t) => t.symbol === asset && String(t.poolId) === String(poolId)
+          )
+        : tokens.find((t) => t.symbol === asset));
 
     if (!token?.poolId || !token.underlyingContractId) {
       setDetailModalUserPosition(null);
@@ -3050,14 +3123,11 @@ const MarketsTable = () => {
 
       const dep = depositBal ?? 0;
       const bor = borrowData?.balance ?? 0;
-      const effectivePrice = price > 0 ? price : dep > 0 || bor > 0 ? 1 : 0;
-      const suppliedUsdRaw = dep * effectivePrice;
+      const suppliedUsdRaw = dep * price;
       const suppliedUsd = roundUsdToCents(suppliedUsdRaw);
-      const borrowedUsd = roundUsdToCents(bor * effectivePrice);
+      const borrowedUsd = roundUsdToCents(bor * price);
       const withdrawableTokens = maxWithdrawUnderlying ?? dep;
-      const withdrawableUsd = roundUsdToCents(
-        withdrawableTokens * effectivePrice
-      );
+      const withdrawableUsd = roundUsdToCents(withdrawableTokens * price);
 
       const collateralFactor =
         assetData?.collateralFactor ?? norm.maxLTV ?? 0;
@@ -3066,20 +3136,47 @@ const MarketsTable = () => {
         const cfDec = collateralFactor / 100;
         borrowableUsd = Math.max(
           0,
-          globalData.totalCollateralValue * cfDec - globalData.totalBorrowValue
+          globalData.totalCollateralValue * cfDec -
+            globalData.totalBorrowValue
         );
         const totalBorrow =
           assetData?.totalBorrow ?? Number(row.totalBorrow ?? 0);
         const borrowCap = assetData?.maxTotalBorrows ?? 0;
-        if (borrowCap > 0 && effectivePrice > 0) {
-          const remainingBorrowCapTokens = Math.max(0, borrowCap - totalBorrow);
-          const remainingBorrowCapUsd = remainingBorrowCapTokens * effectivePrice;
+        if (borrowCap > 0 && price > 0) {
+          const remainingBorrowCapTokens = Math.max(
+            0,
+            borrowCap - totalBorrow
+          );
+          const remainingBorrowCapUsd = remainingBorrowCapTokens * price;
           borrowableUsd = Math.min(borrowableUsd, remainingBorrowCapUsd);
         }
       }
       borrowableUsd = roundUsdToCents(borrowableUsd);
 
-      const healthFactor = portfolioHealthFactor ?? 0;
+      let healthFactor = 0;
+      if (
+        portfolioHealthFactor != null &&
+        Number.isFinite(portfolioHealthFactor)
+      ) {
+        healthFactor = portfolioHealthFactor;
+      } else if (globalData) {
+        if (globalData.healthFactorIndex != null) {
+          healthFactor = globalData.healthFactorIndex;
+        } else if (
+          globalData.totalBorrowValue <= 0 &&
+          globalData.totalCollateralValue > 0
+        ) {
+          healthFactor = 3;
+        } else if (
+          globalData.totalBorrowValue > 0 &&
+          globalData.totalCollateralValue > 0
+        ) {
+          healthFactor = Math.min(
+            globalData.totalCollateralValue / globalData.totalBorrowValue,
+            3
+          );
+        }
+      }
 
       const supplyAPY = norm.supplyAPY;
       const earnings =
@@ -3096,6 +3193,8 @@ const MarketsTable = () => {
         earnings,
       };
     };
+
+    detailPositionLoadKeyRef.current = loadKey;
 
     const load = async () => {
       try {
@@ -3201,8 +3300,12 @@ const MarketsTable = () => {
     detailModal.asset,
     detailModal.poolId,
     detailModal.marketRowKey,
+    detailModalRowLastFetched,
     activeAccount?.address,
     currentNetwork,
+    // Do not depend on `markets`, `detailModal.marketData` (new refs from rewards remap), or
+    // `resolveTokenForDisplayedAsset` (recreated when `markets` changes) — those caused a
+    // fetch/setState loop while the detail modal stayed open.
   ]);
 
   return (
@@ -3684,31 +3787,29 @@ const MarketsTable = () => {
             </div>
           </section>
 
-          <div ref={marketsListRef}>
-            {markets.length === 0 && !isLoading ? (
-              <div className="text-center py-8">
-                <p className="text-muted-foreground">
-                  No markets found. Try adjusting your search criteria.
-                </p>
-              </div>
-            ) : (
-              <MarketsTableContent
-                key={marketFilter}
-                marketFilter={marketFilter}
-                markets={markets}
-                sortField={sortField}
-                sortOrder={sortOrder}
-                onRowClick={handleRowClick}
-                onInfoClick={handleInfoClick}
-                onDepositClick={handleDepositClick}
-                onWithdrawClick={handleWithdrawClick}
-                onBorrowClick={handleBorrowClick}
-                onMintClick={handleMintClick}
-                onMigrateClick={handleMigrateClick}
-                isLoadingBalance={isLoadingBalance}
-              />
-            )}
-          </div>
+          {markets.length === 0 && !isLoading ? (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground">
+                No markets found. Try adjusting your search criteria.
+              </p>
+            </div>
+          ) : (
+            <MarketsTableContent
+              markets={markets}
+              sortField={sortField}
+              sortOrder={sortOrder}
+              onRowClick={handleRowClick}
+              onInfoClick={handleInfoClick}
+              onDepositClick={handleDepositClick}
+              onWithdrawClick={handleWithdrawClick}
+              onBorrowClick={handleBorrowClick}
+              onMintClick={handleMintClick}
+              onMigrateClick={handleMigrateClick}
+              isLoadingBalance={isLoadingBalance}
+              getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+              onRowMouseEnter={prefetchMarketRowOnHover}
+            />
+          )}
         </div>
 
         {/* Pagination */}
@@ -3792,6 +3893,7 @@ const MarketsTable = () => {
                 ]?.balanceUSD || 0
               }
               poolCollateralMarkets={depositPoolCollateralMarkets}
+              isLoadingWalletBalance={isLoadingBalance}
               onRefreshWalletBalance={
                 depositModal.asset
                   ? () => {
@@ -3903,6 +4005,7 @@ const MarketsTable = () => {
               onSelectAsset={handleSelectBorrowMarket}
               userGlobalData={userGlobalData}
               userBorrowBalance={userBorrowBalance}
+              isLoadingBorrowGlobalData={isLoadingGlobalData}
               poolCollateralMarkets={depositPoolCollateralMarkets}
               onTransactionSuccess={() => {
                 // Refresh market data after successful borrow

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -15,6 +15,7 @@ import {
   getAllTokensWithDisplayInfo,
   getFolksAdaptersForPhase,
   getTokenConfig,
+  resolveTokenForMarketPosition,
   getAlgorandNetworkFromNetworkId,
   tokenStandardUsesNativeWalletBalance,
 } from "@/config";
@@ -50,13 +51,19 @@ import {
   fetchUserGlobalData,
   fetchUserBorrowBalance,
   fetchUserDepositBalance,
+  fetchGlobalUserRowsFromChain,
   getMaxWithdrawableForMarket,
   migrate,
   deposit,
   fetchMarketInfo,
   isMarketPaused,
 } from "@/services/lendingService";
-import type { UserPosition as MarketDetailUserPosition } from "@/components/market-modal/types";
+import { withRpcReadCache } from "@/utils/rpcReadCache";
+import { computePortfolioDisplayHealthFactor } from "@/utils/portfolioDisplayHealthFactor";
+import type {
+  UserPosition as MarketDetailUserPosition,
+  UserPositionLoadState,
+} from "@/components/market-modal/types";
 import { normalizeWadUsdPerToken, roundUsdToCents, cn } from "@/lib/utils";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
@@ -373,6 +380,8 @@ const MarketsTable = () => {
   /** Live position for PremiumMarketModal (on-chain + pool caps). */
   const [detailModalUserPosition, setDetailModalUserPosition] =
     useState<MarketDetailUserPosition | null>(null);
+  const [detailModalUserPositionLoad, setDetailModalUserPositionLoad] =
+    useState<UserPositionLoadState>("idle");
 
   // Mock user deposits - in real app, this would come from user's wallet/backend
   const [userDeposits] = useState<Record<string, number>>({});
@@ -848,31 +857,16 @@ const MarketsTable = () => {
       poolId: string | undefined,
       marketRowKey: string | undefined
     ) => {
-      const tokens = getAllTokensWithDisplayInfo(currentNetwork);
-      if (marketRowKey) {
-        const row = markets.find(
-          (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
-        );
-        const cs = row?.configSymbol;
-        if (cs) {
-          const t = tokens.find(
-            (x) =>
-              (x.originalSymbol ?? x.symbol) === cs &&
-              (poolId == null ||
-                poolId === "" ||
-                String(x.poolId) === String(poolId))
-          );
-          if (t) return t;
-        }
-      }
-      if (poolId != null && poolId !== "") {
-        return tokens.find(
-          (t) => t.symbol === asset && String(t.poolId) === String(poolId)
-        );
-      }
-      return tokens.find((t) => t.symbol === asset);
+      const configSymbol = marketRowKey
+        ? configSymbolFromMarketRowKey(marketRowKey)
+        : undefined;
+      return resolveTokenForMarketPosition(currentNetwork, {
+        asset,
+        poolId,
+        configSymbol,
+      });
     },
-    [markets, currentNetwork]
+    [currentNetwork, configSymbolFromMarketRowKey]
   );
 
   const borrowModalAvailableAssets = useMemo(() => {
@@ -1532,6 +1526,17 @@ const MarketsTable = () => {
     void loadMarketDataWithBypass(
       marketKeyForOnDemandLoad(poolId, configSymbol, asset)
     );
+    if (activeAccount?.address) {
+      const addr = activeAccount.address;
+      void fetchUserGlobalData(addr, currentNetwork).then((data) => {
+        if (data) setUserGlobalData(data);
+      });
+      void withRpcReadCache(
+        `globalUserRows:${addr}`,
+        () => fetchGlobalUserRowsFromChain(addr),
+        30_000
+      );
+    }
   };
 
   const handleRowClick = (market: Record<string, unknown>) => {
@@ -2982,9 +2987,12 @@ const MarketsTable = () => {
     };
   };
 
+  const detailPositionLoadIdRef = useRef(0);
+
   useEffect(() => {
     if (!detailModal.isOpen) {
       setDetailModalUserPosition(null);
+      setDetailModalUserPositionLoad("idle");
       return;
     }
 
@@ -2992,180 +3000,209 @@ const MarketsTable = () => {
     const asset = detailModal.asset;
     if (!row || !asset) {
       setDetailModalUserPosition(null);
+      setDetailModalUserPositionLoad("idle");
       return;
     }
 
     if (!activeAccount?.address) {
       setDetailModalUserPosition(null);
+      setDetailModalUserPositionLoad("idle");
       return;
     }
 
     const poolId = detailModal.poolId;
-    const tokens = getAllTokensWithDisplayInfo(currentNetwork);
-    const token =
-      resolveTokenForDisplayedAsset(
-        asset,
-        poolId,
-        detailModal.marketRowKey
-      ) ??
-      (poolId != null && poolId !== ""
-        ? tokens.find(
-            (t) => t.symbol === asset && String(t.poolId) === String(poolId)
-          )
-        : tokens.find((t) => t.symbol === asset));
+    const configSymbol =
+      typeof (row as { configSymbol?: string }).configSymbol === "string"
+        ? (row as { configSymbol?: string }).configSymbol
+        : undefined;
+    const token = resolveTokenForMarketPosition(currentNetwork, {
+      asset,
+      poolId,
+      configSymbol,
+    });
 
     if (!token?.poolId || !token.underlyingContractId) {
       setDetailModalUserPosition(null);
+      setDetailModalUserPositionLoad("idle");
       return;
     }
 
-    let cancelled = false;
+    const loadId = ++detailPositionLoadIdRef.current;
+    const userAddress = activeAccount.address;
+    const rpcPoolId = token.poolId;
+    const rpcMarketId = token.underlyingContractId;
+    const tokenDecimals = token.decimals;
 
-    const load = async () => {
+    setDetailModalUserPosition(null);
+    setDetailModalUserPositionLoad("loading");
+
+    const buildPosition = (
+      depositBal: number | null,
+      borrowData: { balance: number; interest: number } | null,
+      globalData: Awaited<ReturnType<typeof fetchUserGlobalData>>,
+      portfolioHealthFactor: number | null,
+      maxWithdrawUnderlying: number | null
+    ): MarketDetailUserPosition => {
       const norm = normalizeMarketData(row);
       const price =
         norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
       const assetData = getAssetData(asset, poolId, detailModal.marketRowKey);
 
-      setDetailModalUserPosition({
-        supplied: 0,
-        borrowed: 0,
-        withdrawable: 0,
-        borrowable: 0,
-        healthFactor: 0,
-        earnings: 0,
-      });
+      const dep = depositBal ?? 0;
+      const bor = borrowData?.balance ?? 0;
+      const effectivePrice = price > 0 ? price : dep > 0 || bor > 0 ? 1 : 0;
+      const suppliedUsdRaw = dep * effectivePrice;
+      const suppliedUsd = roundUsdToCents(suppliedUsdRaw);
+      const borrowedUsd = roundUsdToCents(bor * effectivePrice);
+      const withdrawableTokens = maxWithdrawUnderlying ?? dep;
+      const withdrawableUsd = roundUsdToCents(
+        withdrawableTokens * effectivePrice
+      );
 
+      const collateralFactor =
+        assetData?.collateralFactor ?? norm.maxLTV ?? 0;
+      let borrowableUsd = 0;
+      if (globalData) {
+        const cfDec = collateralFactor / 100;
+        borrowableUsd = Math.max(
+          0,
+          globalData.totalCollateralValue * cfDec - globalData.totalBorrowValue
+        );
+        const totalBorrow =
+          assetData?.totalBorrow ?? Number(row.totalBorrow ?? 0);
+        const borrowCap = assetData?.maxTotalBorrows ?? 0;
+        if (borrowCap > 0 && effectivePrice > 0) {
+          const remainingBorrowCapTokens = Math.max(0, borrowCap - totalBorrow);
+          const remainingBorrowCapUsd = remainingBorrowCapTokens * effectivePrice;
+          borrowableUsd = Math.min(borrowableUsd, remainingBorrowCapUsd);
+        }
+      }
+      borrowableUsd = roundUsdToCents(borrowableUsd);
+
+      const healthFactor = portfolioHealthFactor ?? 0;
+
+      const supplyAPY = norm.supplyAPY;
+      const earnings =
+        supplyAPY > 0 && suppliedUsdRaw > 0
+          ? roundUsdToCents(suppliedUsdRaw * (supplyAPY / 100))
+          : 0;
+
+      return {
+        supplied: suppliedUsd,
+        borrowed: borrowedUsd,
+        withdrawable: withdrawableUsd,
+        borrowable: borrowableUsd,
+        healthFactor,
+        earnings,
+      };
+    };
+
+    const load = async () => {
       try {
-        const [
-          depositBal,
-          borrowData,
-          globalData,
-          maxWithdrawResult,
-        ] = await Promise.all([
+        const [depositBal, borrowData, globalData] = await Promise.all([
           fetchUserDepositBalance(
-            activeAccount.address,
-            token.poolId!,
-            token.underlyingContractId!,
+            userAddress,
+            rpcPoolId,
+            rpcMarketId,
             currentNetwork
           ),
           fetchUserBorrowBalance(
-            activeAccount.address,
-            token.poolId!,
-            token.underlyingContractId!,
+            userAddress,
+            rpcPoolId,
+            rpcMarketId,
             currentNetwork
           ),
-          fetchUserGlobalData(activeAccount.address, currentNetwork),
-          getMaxWithdrawableForMarket(
-            token.poolId!,
-            token.underlyingContractId!,
-            activeAccount.address,
-            currentNetwork,
-            token.decimals
-          ),
+          fetchUserGlobalData(userAddress, currentNetwork),
         ]);
 
-        if (cancelled) return;
+        if (loadId !== detailPositionLoadIdRef.current) return;
 
-        const dep = depositBal ?? 0;
-        const bor = borrowData?.balance ?? 0;
-        const suppliedUsdRaw = dep * price;
-        const suppliedUsd = roundUsdToCents(suppliedUsdRaw);
-        const borrowedUsd = roundUsdToCents(bor * price);
-        const withdrawableTokens =
-          maxWithdrawResult?.maxWithdrawUnderlying ?? dep;
-        const withdrawableUsd = roundUsdToCents(withdrawableTokens * price);
+        const position = buildPosition(
+          depositBal,
+          borrowData,
+          globalData,
+          null,
+          null
+        );
+        setDetailModalUserPosition(position);
+        setDetailModalUserPositionLoad("ready");
 
-        const collateralFactor =
-          assetData?.collateralFactor ?? norm.maxLTV ?? 0;
-        let borrowableUsd = 0;
-        if (globalData) {
-          const cfDec = collateralFactor / 100;
-          borrowableUsd = Math.max(
-            0,
-            globalData.totalCollateralValue * cfDec -
-              globalData.totalBorrowValue
-          );
-          const totalBorrow =
-            assetData?.totalBorrow ?? Number(row.totalBorrow ?? 0);
-          const borrowCap = assetData?.maxTotalBorrows ?? 0;
-          if (borrowCap > 0 && price > 0) {
-            const remainingBorrowCapTokens = Math.max(
-              0,
-              borrowCap - totalBorrow
+        void withRpcReadCache(
+          `globalUserRows:${userAddress}`,
+          () => fetchGlobalUserRowsFromChain(userAddress),
+          30_000
+        )
+          .then((globalUserRows) => {
+            if (loadId !== detailPositionLoadIdRef.current) return;
+            const portfolioHealthFactor = computePortfolioDisplayHealthFactor({
+              globalUserData: globalUserRows,
+              deposits: [],
+              marketData: markets,
+              useMarketRowsForPoolLt: true,
+            });
+            if (portfolioHealthFactor == null) return;
+            setDetailModalUserPosition((prev) =>
+              prev
+                ? { ...prev, healthFactor: portfolioHealthFactor }
+                : prev
             );
-            const remainingBorrowCapUsd = remainingBorrowCapTokens * price;
-            borrowableUsd = Math.min(borrowableUsd, remainingBorrowCapUsd);
-          }
-        }
-        borrowableUsd = roundUsdToCents(borrowableUsd);
+          })
+          .catch((e) => {
+            console.warn("Market detail: portfolio health factor refresh failed:", e);
+          });
 
-        let healthFactor = 0;
-        if (globalData) {
-          if (globalData.healthFactorIndex != null) {
-            healthFactor = globalData.healthFactorIndex;
-          } else if (
-            globalData.totalBorrowValue <= 0 &&
-            globalData.totalCollateralValue > 0
-          ) {
-            healthFactor = 3;
-          } else if (
-            globalData.totalBorrowValue > 0 &&
-            globalData.totalCollateralValue > 0
-          ) {
-            healthFactor = Math.min(
-              globalData.totalCollateralValue / globalData.totalBorrowValue,
-              3
+        void getMaxWithdrawableForMarket(
+          rpcPoolId,
+          rpcMarketId,
+          userAddress,
+          currentNetwork,
+          tokenDecimals
+        )
+          .then((maxWithdrawResult) => {
+            if (loadId !== detailPositionLoadIdRef.current) return;
+            if (maxWithdrawResult?.maxWithdrawUnderlying == null) return;
+            setDetailModalUserPosition((prev) => {
+              if (!prev) return prev;
+              const norm = normalizeMarketData(row);
+              const price =
+                norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
+              const dep =
+                maxWithdrawResult.maxWithdrawUnderlying > 0
+                  ? maxWithdrawResult.maxWithdrawUnderlying
+                  : 0;
+              const effectivePrice =
+                price > 0 ? price : dep > 0 ? 1 : 0;
+              return {
+                ...prev,
+                withdrawable: roundUsdToCents(
+                  maxWithdrawResult.maxWithdrawUnderlying * effectivePrice
+                ),
+              };
+            });
+          })
+          .catch((e) => {
+            console.warn(
+              "Market detail: max withdrawable refresh failed (position still shown):",
+              e
             );
-          }
-        }
-
-        const supplyAPY = norm.supplyAPY;
-        const earnings =
-          supplyAPY > 0 && suppliedUsdRaw > 0
-            ? roundUsdToCents(suppliedUsdRaw * (supplyAPY / 100))
-            : 0;
-
-        setDetailModalUserPosition({
-          supplied: suppliedUsd,
-          borrowed: borrowedUsd,
-          withdrawable: withdrawableUsd,
-          borrowable: borrowableUsd,
-          healthFactor,
-          earnings,
-        });
+          });
       } catch (e) {
         console.error("Failed to load market detail user position:", e);
-        if (!cancelled) {
-          setDetailModalUserPosition({
-            supplied: 0,
-            borrowed: 0,
-            withdrawable: 0,
-            borrowable: 0,
-            healthFactor: 0,
-            earnings: 0,
-          });
+        if (loadId === detailPositionLoadIdRef.current) {
+          setDetailModalUserPosition(null);
+          setDetailModalUserPositionLoad("error");
         }
       }
     };
 
     void load();
-
-    return () => {
-      cancelled = true;
-    };
   }, [
     detailModal.isOpen,
     detailModal.asset,
     detailModal.poolId,
     detailModal.marketRowKey,
-    detailModal.marketData,
     activeAccount?.address,
     currentNetwork,
-    resolveTokenForDisplayedAsset,
-    // Not `markets`: that list is rebuilt on every row/rewards update and caused a full
-    // Promise.all per tick while the modal stayed open. `detailModal.marketData` is enough;
-    // the sync effect updates it when the selected row’s `lastFetched` advances.
   ]);
 
   return (
@@ -3693,6 +3730,7 @@ const MarketsTable = () => {
             rawMarket={detailModal.marketData}
             marketData={normalizeMarketData(detailModal.marketData)}
             userPosition={detailModalUserPosition ?? undefined}
+            userPositionLoadState={detailModalUserPositionLoad}
             onDeposit={() =>
               handleDepositClick(
                 detailModal.asset!,

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -498,6 +498,9 @@ const Portfolio = () => {
   const [userProfileAvatar, setUserProfileAvatar] = useState<string | null>(
     null
   );
+  // Guards for fetchUser: prevent concurrent fetches and stale-address races
+  const fetchUserInFlight = useRef(false);
+  const fetchUserAddressRef = useRef<string | null>(null);
 
   // Compute final avatar: prioritize user profile avatar > resolver avatar
   // If neither exists, components will show placeholder
@@ -3782,7 +3785,16 @@ const Portfolio = () => {
   ]);
 
   const fetchUser = async (userAddress: string) => {
+    // Deduplicate concurrent calls for the same address; cancel stale-address results
+    if (fetchUserInFlight.current && fetchUserAddressRef.current === userAddress) return;
+    fetchUserInFlight.current = true;
+    fetchUserAddressRef.current = userAddress;
+
+    const isCurrentFetchUser = () =>
+      fetchUserAddressRef.current === userAddress;
+
     const applyPortfolioComputed = (user: Record<string, unknown>) => {
+      if (!isCurrentFetchUser()) return;
       if (!user.globalUserData || !Array.isArray(user.globalUserData)) {
         return;
       }
@@ -3871,6 +3883,7 @@ const Portfolio = () => {
         },
       };
       console.log("[Portfolio] User:", computedUser);
+      if (!isCurrentFetchUser()) return;
       setUser(computedUser);
       console.log("[Portfolio] Network values:", networkValues);
     };
@@ -3884,6 +3897,7 @@ const Portfolio = () => {
       console.log("[Portfolio] API response:", apiResponse);
 
       if (apiResponse.success && apiResponse.data) {
+        if (!isCurrentFetchUser()) return;
         const user = apiResponse.data as Record<string, unknown>;
         console.log("[Portfolio] User data fetched from API:", user);
 
@@ -3906,7 +3920,7 @@ const Portfolio = () => {
         `[Portfolio] API failed; falling back to chain for ${userAddress}`
       );
       const chain = await fetchUserDataFromChain(userAddress);
-      if (chain) {
+      if (chain && isCurrentFetchUser()) {
         setUserProfileAvatar(null);
         applyPortfolioComputed({
           address: userAddress,
@@ -3918,7 +3932,7 @@ const Portfolio = () => {
     } catch (error) {
       console.error("Error fetching user global data:", error);
       const chain = await fetchUserDataFromChain(userAddress);
-      if (chain) {
+      if (chain && isCurrentFetchUser()) {
         setUserProfileAvatar(null);
         applyPortfolioComputed({
           address: userAddress,
@@ -3927,20 +3941,29 @@ const Portfolio = () => {
           userDataSource: "chain",
         });
       }
+    } finally {
+      // Only clear the in-flight flag if this call is still the current one
+      if (fetchUserAddressRef.current === userAddress) {
+        fetchUserInFlight.current = false;
+      }
     }
   };
 
   useEffect(() => {
-    if (displayAddress) {
-      fetchUser(displayAddress);
-    }
+    if (!displayAddress) return;
+    // Reset in-flight state when address changes so new address always fetches
+    fetchUserInFlight.current = false;
+    fetchUserAddressRef.current = null;
+    fetchUser(displayAddress);
   }, [displayAddress]);
 
-  // Fetch market data for all enabled networks when user data is available
+  // Fetch market data for all enabled networks when user data is available.
+  // Also fires after a 6s timeout so markets load even if fetchUser stalls (xChain race).
   useEffect(() => {
     const fetchMarketDataForAllNetworks = async () => {
-      if (!user?.computed) {
-        return; // Wait for user data to be available
+      // Proceed if user data is ready OR address is present (markets don't require user data)
+      if (!displayAddress && !user?.computed) {
+        return;
       }
 
       try {
@@ -3975,7 +3998,12 @@ const Portfolio = () => {
     };
 
     fetchMarketDataForAllNetworks();
-  }, [user?.computed, activeAccount?.address]);
+    // Fallback: if user data hasn't resolved in 6s (xChain wallet init race), load markets anyway
+    const fallbackTimer = setTimeout(() => {
+      if (displayAddress) void fetchMarketDataForAllNetworks();
+    }, 6000);
+    return () => clearTimeout(fallbackTimer);
+  }, [user?.computed, activeAccount?.address, displayAddress]);
 
   // Fetch user global data and market data when wallet connects
   // useEffect(() => {

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -75,6 +75,12 @@ import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
+import {
+  createDebouncedPrefetch,
+  warmBorrowModalMaxAndPool,
+  warmRepayModalRpc,
+  type MarketActionTokenParams,
+} from "@/utils/modalPrefetch";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
 import { shouldShowConfigSymbolUnderDisplayAsset } from "@/utils/portfolioAssetSubline";
 import {
@@ -494,6 +500,7 @@ const Portfolio = () => {
   const [isLoadingWalletBalance, setIsLoadingWalletBalance] = useState(false);
   const [userBorrowBalance, setUserBorrowBalance] = useState<number>(0);
   const [isLoadingBorrowData, setIsLoadingBorrowData] = useState(false);
+  const [isLoadingRepayData, setIsLoadingRepayData] = useState(false);
   const [user, setUser] = useState<Record<string, unknown> | null>(null);
   const [userProfileAvatar, setUserProfileAvatar] = useState<string | null>(
     null
@@ -4212,80 +4219,69 @@ const Portfolio = () => {
       }
     }
 
+    setDepositModal({
+      isOpen: true,
+      asset,
+      poolId,
+      network: networkId,
+      configSymbol,
+      marketId,
+    });
+
     setIsLoadingWalletBalance(true);
-
-    try {
-      // Fetch wallet balance before opening modal using the deposit's network
-      const balanceResult = await fetchWalletBalance(asset, networkId, true, {
-        poolId,
-        marketId,
-        configSymbol,
-      });
-
-      // In the background, prefetch wallet balances for other deposit assets
-      if (deposits.length > 0) {
-        const otherDeposits = deposits.filter((d) => {
-          const dn = d as ItemWithNetwork;
-          if (marketId != null && dn.marketId != null) {
-            return (
-              String(dn.marketId) !== String(marketId) ||
-              String(d.poolId ?? "") !== String(poolId ?? "")
-            );
-          }
-          return d.asset !== asset || d.poolId !== poolId;
+    void (async () => {
+      try {
+        await fetchWalletBalance(asset, networkId, true, {
+          poolId,
+          marketId,
+          configSymbol,
         });
-        if (otherDeposits.length > 0) {
-          Promise.all(
-            otherDeposits.map((d) =>
-              fetchWalletBalance(
-                d.asset,
-                (d as ItemWithNetwork).network || networkId,
-                true,
-                {
-                  poolId: d.poolId,
-                  marketId: (d as ItemWithNetwork).marketId,
-                  configSymbol: (d as ItemWithNetwork).configSymbol,
-                }
-              ).catch((error) =>
-                console.error(
-                  "[Portfolio] Error prefetching wallet balance for deposit asset",
+
+        if (deposits.length > 0) {
+          const otherDeposits = deposits.filter((d) => {
+            const dn = d as ItemWithNetwork;
+            if (marketId != null && dn.marketId != null) {
+              return (
+                String(dn.marketId) !== String(marketId) ||
+                String(d.poolId ?? "") !== String(poolId ?? "")
+              );
+            }
+            return d.asset !== asset || d.poolId !== poolId;
+          });
+          if (otherDeposits.length > 0) {
+            Promise.all(
+              otherDeposits.map((d) =>
+                fetchWalletBalance(
                   d.asset,
-                  error
+                  (d as ItemWithNetwork).network || networkId,
+                  true,
+                  {
+                    poolId: d.poolId,
+                    marketId: (d as ItemWithNetwork).marketId,
+                    configSymbol: (d as ItemWithNetwork).configSymbol,
+                  }
+                ).catch((error) =>
+                  console.error(
+                    "[Portfolio] Error prefetching wallet balance for deposit asset",
+                    d.asset,
+                    error
+                  )
                 )
               )
-            )
-          ).catch((error) =>
-            console.error(
-              "[Portfolio] Error in prefetch wallet balances Promise.all",
-              error
-            )
-          );
+            ).catch((error) =>
+              console.error(
+                "[Portfolio] Error in prefetch wallet balances Promise.all",
+                error
+              )
+            );
+          }
         }
+      } catch (error) {
+        console.error("Error fetching wallet balance for deposit:", error);
+      } finally {
+        setIsLoadingWalletBalance(false);
       }
-
-      // Open modal after balance is fetched
-      setDepositModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkId,
-        configSymbol,
-        marketId,
-      });
-    } catch (error) {
-      console.error("Error fetching wallet balance for deposit:", error);
-      // Still open modal even if balance fetch fails
-      setDepositModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkId,
-        configSymbol,
-        marketId,
-      });
-    } finally {
-      setIsLoadingWalletBalance(false);
-    }
+    })();
   };
 
   const prefetchWithdrawIndicesRef = useRef<
@@ -4293,10 +4289,110 @@ const Portfolio = () => {
         asset: string,
         poolId?: string,
         marketId?: string,
-        networkIdOverride?: string
+        networkIdOverride?: string,
+        configSymbol?: string
       ) => Promise<void>)
     | null
   >(null);
+
+  const debouncedPortfolioPrefetch = useMemo(() => createDebouncedPrefetch(), []);
+
+  const prefetchWithdrawModalData = (
+    asset: string,
+    poolId?: string,
+    networkId?: string,
+    marketId?: string,
+    configSymbol?: string
+  ) => {
+    void prefetchWithdrawIndicesRef.current?.(
+      asset,
+      poolId,
+      marketId,
+      networkId,
+      configSymbol
+    );
+  };
+
+  const prefetchDepositOnHover = useCallback(
+    (
+      asset: string,
+      poolId?: string,
+      networkId?: string,
+      configSymbol?: string,
+      marketId?: string
+    ) => {
+      if (!activeAccount?.address) return;
+      const networkToUse = (networkId || currentNetwork) as NetworkId;
+      const key = `deposit:${networkToUse}:${asset}:${poolId ?? ""}:${configSymbol ?? ""}:${marketId ?? ""}`;
+      debouncedPortfolioPrefetch(key, () => {
+        void fetchWalletBalance(asset, networkToUse, true, {
+          poolId,
+          marketId,
+          configSymbol,
+        });
+      });
+    },
+    [activeAccount?.address, currentNetwork, debouncedPortfolioPrefetch]
+  );
+
+  const prefetchBorrowOnHover = useCallback(
+    (
+      asset: string,
+      poolId?: string,
+      networkId?: string,
+      configSymbol?: string,
+      marketId?: string
+    ) => {
+      if (!activeAccount?.address) return;
+      const networkToUse = (networkId || currentNetwork) as NetworkId;
+      const params: MarketActionTokenParams = {
+        userAddress: activeAccount.address,
+        networkId: networkToUse,
+        asset,
+        poolId,
+        configSymbol,
+        marketId,
+      };
+      debouncedPortfolioPrefetch(
+        `borrow:${networkToUse}:${asset}:${poolId ?? ""}:${configSymbol ?? ""}:${marketId ?? ""}`,
+        () => warmBorrowModalMaxAndPool(params)
+      );
+    },
+    [activeAccount?.address, currentNetwork, debouncedPortfolioPrefetch]
+  );
+
+  const prefetchRepayOnHover = useCallback(
+    (
+      asset: string,
+      poolId?: string,
+      networkId?: string,
+      configSymbol?: string,
+      marketId?: string
+    ) => {
+      if (!activeAccount?.address) return;
+      const networkToUse = (networkId || currentNetwork) as NetworkId;
+      const params: MarketActionTokenParams = {
+        userAddress: activeAccount.address,
+        networkId: networkToUse,
+        asset,
+        poolId,
+        configSymbol,
+        marketId,
+      };
+      debouncedPortfolioPrefetch(
+        `repay:${networkToUse}:${asset}:${poolId ?? ""}:${configSymbol ?? ""}:${marketId ?? ""}`,
+        () => {
+          warmRepayModalRpc(params);
+          void fetchWalletBalance(asset, networkToUse, true, {
+            poolId,
+            marketId,
+            configSymbol,
+          });
+        }
+      );
+    },
+    [activeAccount?.address, currentNetwork, debouncedPortfolioPrefetch]
+  );
 
   const handleWithdrawClick = (
     asset: string,
@@ -4353,80 +4449,57 @@ const Portfolio = () => {
       }
     }
 
+    const networkToUse = (networkId || currentNetwork) as NetworkId;
+
+    setBorrowModal({
+      isOpen: true,
+      asset,
+      poolId,
+      network: networkToUse,
+      configSymbol,
+      marketId,
+    });
+
     setIsLoadingBorrowData(true);
-
-    try {
-      // Use the asset's network if provided, otherwise fall back to currentNetwork
-      const networkToUse = (networkId || currentNetwork) as NetworkId;
-
-      // Fetch user global data before opening modal (only if wallet is connected)
-      if (activeAccount?.address) {
-        // fetch markets from node api for accurate healthFactorIndex calculation
-        // Fetch markets to pass for healthFactorIndex calculation
-        const markets = await fetchAllMarkets(networkToUse);
-        // const marketDataResponse =
-        //   await dorkfiAPIService.getAllMarketDataByNetwork(networkToUse);
-        // const markets = marketDataResponse.success
-        //   ? marketDataResponse.data
-        //   : [];
-        const globalData = await fetchUserGlobalData(
-          activeAccount.address,
-          networkToUse,
-          markets
-        );
-        setUserGlobalData(globalData);
-
-        // Fetch user's current borrow balance for this specific asset
-        const tokens = getAllTokensWithDisplayInfo(networkToUse);
-        const token = resolveSupplyBorrowToken(
-          tokens,
-          asset,
-          poolId,
-          configSymbol,
-          marketId
-        );
-
-        if (token && token.poolId && token.underlyingContractId) {
-          const borrowData = await fetchUserBorrowBalance(
+    void (async () => {
+      try {
+        if (activeAccount?.address) {
+          const globalData = await fetchUserGlobalData(
             activeAccount.address,
-            token.poolId,
-            token.underlyingContractId,
             networkToUse
           );
-          const borrowBalance = borrowData?.balance || 0;
-          setUserBorrowBalance(borrowBalance || 0);
+          setUserGlobalData(globalData);
+
+          const tokens = getAllTokensWithDisplayInfo(networkToUse);
+          const token = resolveSupplyBorrowToken(
+            tokens,
+            asset,
+            poolId,
+            configSymbol,
+            marketId
+          );
+
+          if (token && token.poolId && token.underlyingContractId) {
+            const borrowData = await fetchUserBorrowBalance(
+              activeAccount.address,
+              token.poolId,
+              token.underlyingContractId,
+              networkToUse
+            );
+            setUserBorrowBalance(borrowData?.balance || 0);
+          } else {
+            setUserBorrowBalance(0);
+          }
         } else {
+          setUserGlobalData(null);
           setUserBorrowBalance(0);
         }
-      } else {
-        // Not connected, set empty data
-        setUserGlobalData(null);
-        setUserBorrowBalance(0);
+      } catch (error) {
+        console.error("Error fetching user data for borrow:", error);
+      } finally {
+        setIsLoadingBorrowData(false);
       }
-
-      // Open modal regardless of connection status
-      setBorrowModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkToUse,
-        configSymbol,
-        marketId,
-      });
-    } catch (error) {
-      console.error("Error fetching user data for borrow:", error);
-      // Still open modal even if data fetch fails
-      setBorrowModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkId || currentNetwork,
-        configSymbol,
-        marketId,
-      });
-    } finally {
-      setIsLoadingBorrowData(false);
-    }
+    })();
   };
 
   const borrowModalMarketPickerRows = useMemo(() => {
@@ -4542,53 +4615,36 @@ const Portfolio = () => {
       return;
     }
 
-    try {
-      // Use the asset's network if provided, otherwise fall back to currentNetwork
-      const networkToUse = (networkId || currentNetwork) as NetworkId;
+    const networkToUse = (networkId || currentNetwork) as NetworkId;
 
-      // Fetch user global data from contract before opening modal (for accurate health factor)
-      if (activeAccount?.address) {
-        // Fetch markets from node api for accurate healthFactorIndex calculation
-        const markets = await fetchAllMarkets(networkToUse);
+    setRepayModal({
+      isOpen: true,
+      asset,
+      poolId,
+      network: networkToUse,
+      configSymbol,
+      marketId,
+    });
+
+    setIsLoadingRepayData(true);
+    void (async () => {
+      try {
         const globalData = await fetchUserGlobalData(
           activeAccount.address,
-          networkToUse,
-          markets
+          networkToUse
         );
         setUserGlobalData(globalData);
-      } else {
-        // Not connected, set empty data
-        setUserGlobalData(null);
+        await refreshWalletBalance(asset, networkToUse, {
+          poolId,
+          marketId,
+          configSymbol,
+        });
+      } catch (error) {
+        console.error("Error fetching data for repay:", error);
+      } finally {
+        setIsLoadingRepayData(false);
       }
-
-      // Fetch wallet balance for the asset before opening modal using the asset's network
-      await refreshWalletBalance(asset, networkToUse, {
-        poolId,
-        marketId,
-        configSymbol,
-      });
-
-      // Open modal after data is fetched
-      setRepayModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkToUse,
-        configSymbol,
-        marketId,
-      });
-    } catch (error) {
-      console.error("Error fetching data for repay:", error);
-      // Still open modal even if data fetch fails
-      setRepayModal({
-        isOpen: true,
-        asset,
-        poolId,
-        network: networkId,
-        configSymbol,
-        marketId,
-      });
-    }
+    })();
   };
 
   const handleAddCollateral = () => {
@@ -6711,10 +6767,34 @@ const Portfolio = () => {
                                         )
                                       : undefined
                                   }
+                                  onDepositMouseEnter={
+                                    !isViewOnly
+                                      ? () =>
+                                        prefetchDepositOnHover(
+                                          deposit.asset,
+                                          deposit.poolId,
+                                          (deposit as ItemWithNetwork).network,
+                                          (deposit as ItemWithNetwork).configSymbol,
+                                          (deposit as ItemWithNetwork).marketId
+                                        )
+                                      : undefined
+                                  }
                                   onWithdrawClick={
                                     !isViewOnly
                                       ? () =>
                                         handleWithdrawClick(
+                                          deposit.asset,
+                                          deposit.poolId,
+                                          (deposit as ItemWithNetwork).network,
+                                          (deposit as ItemWithNetwork).marketId,
+                                          (deposit as ItemWithNetwork).configSymbol
+                                        )
+                                      : undefined
+                                  }
+                                  onWithdrawMouseEnter={
+                                    !isViewOnly
+                                      ? () =>
+                                        prefetchWithdrawModalData(
                                           deposit.asset,
                                           deposit.poolId,
                                           (deposit as ItemWithNetwork).network,
@@ -7429,6 +7509,15 @@ const Portfolio = () => {
                                             <DorkFiButton
                                               size="sm"
                                               variant="secondary"
+                                              onMouseEnter={() =>
+                                                prefetchDepositOnHover(
+                                                  deposit.asset,
+                                                  deposit.poolId,
+                                                  (deposit as ItemWithNetwork).network,
+                                                  (deposit as ItemWithNetwork).configSymbol,
+                                                  (deposit as ItemWithNetwork).marketId
+                                                )
+                                              }
                                               onClick={(e) => {
                                                 e.stopPropagation();
                                                 if (depositCapReached) return;
@@ -7456,6 +7545,15 @@ const Portfolio = () => {
                                           <DorkFiButton
                                             size="sm"
                                             variant="withdraw"
+                                            onMouseEnter={() =>
+                                              prefetchWithdrawModalData(
+                                                deposit.asset,
+                                                deposit.poolId,
+                                                (deposit as ItemWithNetwork).network,
+                                                (deposit as ItemWithNetwork).marketId,
+                                                (deposit as ItemWithNetwork).configSymbol
+                                              )
+                                            }
                                             onClick={(e) => {
                                               e.stopPropagation();
                                               handleWithdrawClick(
@@ -8539,10 +8637,34 @@ const Portfolio = () => {
                                         )
                                       : undefined
                                   }
+                                  onDepositMouseEnter={
+                                    !isViewOnly
+                                      ? () =>
+                                        prefetchBorrowOnHover(
+                                          borrow.asset,
+                                          borrow.poolId,
+                                          (borrow as ItemWithNetwork).network,
+                                          (borrow as ItemWithNetwork).configSymbol,
+                                          (borrow as ItemWithNetwork).marketId
+                                        )
+                                      : undefined
+                                  }
                                   onWithdrawClick={
                                     !isViewOnly
                                       ? () =>
                                         handleRepayClick(
+                                          borrow.asset,
+                                          borrow.poolId,
+                                          (borrow as ItemWithNetwork).network,
+                                          (borrow as ItemWithNetwork).configSymbol,
+                                          (borrow as ItemWithNetwork).marketId
+                                        )
+                                      : undefined
+                                  }
+                                  onWithdrawMouseEnter={
+                                    !isViewOnly
+                                      ? () =>
+                                        prefetchRepayOnHover(
                                           borrow.asset,
                                           borrow.poolId,
                                           (borrow as ItemWithNetwork).network,
@@ -9126,6 +9248,15 @@ const Portfolio = () => {
                                             <DorkFiButton
                                               size="sm"
                                               variant="borrow-outline"
+                                              onMouseEnter={() =>
+                                                prefetchBorrowOnHover(
+                                                  borrow.asset,
+                                                  borrow.poolId,
+                                                  (borrow as ItemWithNetwork).network,
+                                                  (borrow as ItemWithNetwork).configSymbol,
+                                                  (borrow as ItemWithNetwork).marketId
+                                                )
+                                              }
                                               onClick={(e) => {
                                                 e.stopPropagation();
                                                 if (borrowCapReached) return;
@@ -9153,6 +9284,15 @@ const Portfolio = () => {
                                           <DorkFiButton
                                             size="sm"
                                             variant="danger-outline"
+                                            onMouseEnter={() =>
+                                              prefetchRepayOnHover(
+                                                borrow.asset,
+                                                borrow.poolId,
+                                                (borrow as ItemWithNetwork).network,
+                                                (borrow as ItemWithNetwork).configSymbol,
+                                                (borrow as ItemWithNetwork).marketId
+                                              )
+                                            }
                                             onClick={(e) => {
                                               e.stopPropagation();
                                               handleRepayClick(
@@ -10112,6 +10252,8 @@ const Portfolio = () => {
         userBorrowBalance={userBorrowBalance}
         folksMintedOneUnderlyingByKey={folksMintedOneUnderlyingByKey}
         prefetchWithdrawIndicesRef={prefetchWithdrawIndicesRef}
+        isLoadingWalletBalance={isLoadingWalletBalance}
+        isLoadingBorrowGlobalData={isLoadingBorrowData}
         onCloseDepositModal={() =>
           setDepositModal({
             isOpen: false,

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/utils/poolCollateralMarketRows";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
+import { warmWithdrawModalRpc } from "@/utils/modalPrefetch";
 import { withRainbowkitHostDialogDismissed } from "@/wallet/xchainSignUi";
 
 /**
@@ -188,12 +189,15 @@ interface PortfolioModalsProps {
         asset: string,
         poolId?: string,
         marketId?: string,
-        networkIdOverride?: string
+        networkIdOverride?: string,
+        configSymbol?: string
       ) => Promise<void>)
     | null
   >;
   /** Same Folks mint ratio as supplied table (`network|configSymbol|poolId` → minted f for 1 underlying atomic). */
   folksMintedOneUnderlyingByKey?: Record<string, string>;
+  isLoadingWalletBalance?: boolean;
+  isLoadingBorrowGlobalData?: boolean;
 }
 
 const PortfolioModals = ({
@@ -220,6 +224,8 @@ const PortfolioModals = ({
   onRefreshMarket,
   prefetchWithdrawIndicesRef,
   folksMintedOneUnderlyingByKey,
+  isLoadingWalletBalance = false,
+  isLoadingBorrowGlobalData = false,
 }: PortfolioModalsProps) => {
   const { activeAccount, signTransactions, activeWallet } = useWallet();
   const { currentNetwork } = useNetwork();
@@ -408,12 +414,49 @@ const PortfolioModals = ({
     [currentNetwork, activeAccount?.address]
   );
 
-  // Expose prefetch function via ref
+  // Expose prefetch (indices + max withdraw RPC cache) via ref for hover
   useEffect(() => {
-    if (prefetchWithdrawIndicesRef) {
-      prefetchWithdrawIndicesRef.current = fetchIndices;
-    }
-  }, [prefetchWithdrawIndicesRef, fetchIndices]);
+    if (!prefetchWithdrawIndicesRef) return;
+    prefetchWithdrawIndicesRef.current = async (
+      asset,
+      poolId,
+      marketId,
+      networkIdOverride,
+      configSymbol
+    ) => {
+      await fetchIndices(asset, poolId, marketId, networkIdOverride);
+      if (!activeAccount?.address) return;
+      const networkToUse = (networkIdOverride || currentNetwork) as NetworkId;
+      const withdrawalDeposit =
+        deposits.find(
+          (d) =>
+            d.asset === asset &&
+            String(d.poolId ?? "") === String(poolId ?? "") &&
+            (marketId == null ||
+              marketId === "" ||
+              String((d as Deposit).marketId ?? "") === String(marketId)) &&
+            (configSymbol == null ||
+              configSymbol === "" ||
+              String((d as Deposit).configSymbol ?? "") === String(configSymbol))
+        ) ?? deposits.find((d) => d.asset === asset);
+      warmWithdrawModalRpc({
+        userAddress: activeAccount.address,
+        networkId: networkToUse,
+        asset,
+        poolId,
+        configSymbol:
+          configSymbol ??
+          (withdrawalDeposit as Deposit | undefined)?.configSymbol,
+        marketId,
+      });
+    };
+  }, [
+    prefetchWithdrawIndicesRef,
+    fetchIndices,
+    activeAccount?.address,
+    currentNetwork,
+    deposits,
+  ]);
 
   // Fetch indices when withdraw modal opens (fallback)
   useEffect(() => {
@@ -2163,6 +2206,7 @@ const PortfolioModals = ({
                   walletBalances[depositModal.asset]?.lastUpdated
                 : walletBalances[depositModal.asset]?.lastUpdated
             }
+            isLoadingWalletBalance={isLoadingWalletBalance}
             onRefreshWalletBalance={
               depositModal.asset && onRefreshWalletBalance
                 ? () =>
@@ -2508,6 +2552,7 @@ const PortfolioModals = ({
             )}
             userGlobalData={userGlobalData}
             userBorrowBalance={userBorrowBalance || 0}
+            isLoadingBorrowGlobalData={isLoadingBorrowGlobalData}
             onTransactionSuccess={() => {
               if (onRefreshMarket) {
                 setTimeout(() => {
@@ -2538,6 +2583,7 @@ const PortfolioModals = ({
             onSelectAsset={onSelectBorrowMarket}
             userGlobalData={userGlobalData}
             userBorrowBalance={userBorrowBalance || 0}
+            isLoadingBorrowGlobalData={isLoadingBorrowGlobalData}
             poolCollateralMarkets={borrowPoolCollateralMarkets}
             onTransactionSuccess={() => {
               if (onRefreshMarket) {

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -381,6 +381,10 @@ interface SupplyBorrowModalProps {
    * (e.g. f-ASA units). Omit when only underlying routes exist.
    */
   walletBalanceMarketToken?: number;
+  /** Parent is refreshing wallet balance after optimistic modal open. */
+  isLoadingWalletBalance?: boolean;
+  /** Parent is loading borrow global data after optimistic modal open. */
+  isLoadingBorrowGlobalData?: boolean;
 }
 
 const SupplyBorrowModal = ({
@@ -406,6 +410,8 @@ const SupplyBorrowModal = ({
   walletBalanceLastUpdated,
   poolCollateralMarkets,
   walletBalanceMarketToken,
+  isLoadingWalletBalance = false,
+  isLoadingBorrowGlobalData = false,
 }: SupplyBorrowModalProps) => {
   const [amount, setAmount] = useState("");
   const [fiatValue, setFiatValue] = useState(0);
@@ -1482,6 +1488,7 @@ const SupplyBorrowModal = ({
   const borrowMaxLineLoading = useMemo(() => {
     if (mode !== "borrow") return false;
     return (
+      isLoadingBorrowGlobalData ||
       isLoadingMaxBorrow ||
       (borrowInputReceiveBasis === "underlying" &&
         folksMintRatioStatus === "loading") ||
@@ -1489,6 +1496,7 @@ const SupplyBorrowModal = ({
     );
   }, [
     mode,
+    isLoadingBorrowGlobalData,
     isLoadingMaxBorrow,
     borrowInputReceiveBasis,
     folksMintRatioStatus,
@@ -3670,8 +3678,9 @@ const SupplyBorrowModal = ({
                 walletBalanceLastUpdated={walletBalanceLastUpdated}
                 onRefreshWalletBalance={onRefreshWalletBalance}
                 depositWalletBalancePending={
-                  isNativeAlgoConsensusDepositRoute &&
-                  nativeAlgoSpendableHuman == null
+                  isLoadingWalletBalance ||
+                  (isNativeAlgoConsensusDepositRoute &&
+                    nativeAlgoSpendableHuman == null)
                 }
                 amountFieldEndAdornment={
                   depositMultiRoute ? (

--- a/src/components/market-modal/PremiumMarketModal.tsx
+++ b/src/components/market-modal/PremiumMarketModal.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { getAllTokensWithDisplayInfo, getMarketLabel, type NetworkId } from '@/config';
 import { useMimirTokenPrice24h } from '@/hooks/useMimirTokenPrice24h';
-import { MarketData, UserPosition } from './types';
+import { MarketData, UserPosition, UserPositionLoadState } from './types';
 import { MarketHeader } from './MarketHeader';
 import { UserPositionBar } from './UserPositionBar';
 import { MarketOverview } from './MarketOverview';
@@ -36,6 +36,7 @@ export interface PremiumMarketModalProps {
   networkId?: string | null;
   marketData: MarketData;
   userPosition?: UserPosition;
+  userPositionLoadState?: UserPositionLoadState;
   onDeposit?: () => void;
   onWithdraw?: () => void;
   onBorrow?: () => void;
@@ -51,6 +52,7 @@ export const PremiumMarketModal = ({
   networkId,
   marketData,
   userPosition,
+  userPositionLoadState = 'idle',
   onDeposit,
   onWithdraw,
   onBorrow,
@@ -113,7 +115,10 @@ export const PremiumMarketModal = ({
               chainId={chainId}
               marketLabel={marketLabel}
             />
-            <UserPositionBar userPosition={userPosition} />
+            <UserPositionBar
+              userPosition={userPosition}
+              loadState={userPositionLoadState}
+            />
 
             <section className={SECTION}>
               <MarketOverview marketData={marketData} />

--- a/src/components/market-modal/PremiumMarketModal.tsx
+++ b/src/components/market-modal/PremiumMarketModal.tsx
@@ -64,10 +64,23 @@ export const PremiumMarketModal = ({
     return getMarketLabel(networkId, poolId);
   }, [rawMarket, networkId]);
 
+  const mimirPriceSymbol = useMemo(() => {
+    const cs = rawMarket?.configSymbol;
+    return typeof cs === "string" && cs.trim() !== ""
+      ? cs.trim()
+      : marketData.symbol;
+  }, [rawMarket, marketData.symbol]);
+
   const {
     priceChange24h: mimirChange24h,
     priceHistory: mimirHistory,
-  } = useMimirTokenPrice24h(marketData.symbol, isOpen);
+  } = useMimirTokenPrice24h(mimirPriceSymbol, isOpen, {
+    networkId,
+    configSymbol:
+      typeof rawMarket?.configSymbol === "string"
+        ? rawMarket.configSymbol
+        : undefined,
+  });
 
   const headerMarketData = useMemo((): MarketData => {
     const mergedHistory =

--- a/src/components/market-modal/UserPositionBar.tsx
+++ b/src/components/market-modal/UserPositionBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
+import { Loader2 } from 'lucide-react';
 import { formatUsdAmount } from '@/lib/utils';
-import { UserPosition } from './types';
+import { UserPosition, UserPositionLoadState } from './types';
 
 const StatCard = ({
   label,
@@ -21,9 +22,21 @@ const StatCard = ({
   </div>
 );
 
-export const UserPositionBar = ({ userPosition }: { userPosition?: UserPosition }) => {
+export const UserPositionBar = ({
+  userPosition,
+  loadState = 'idle',
+}: {
+  userPosition?: UserPosition;
+  loadState?: UserPositionLoadState;
+}) => {
   const [open, setOpen] = useState(true);
-  if (!userPosition) return null;
+
+  if (loadState === 'idle') return null;
+
+  const showBody =
+    loadState === 'loading' || loadState === 'error' || userPosition != null;
+  if (!showBody) return null;
+
   return (
     <div className="px-0 mb-2 min-w-0 w-full max-w-full overflow-x-hidden">
       <button
@@ -63,16 +76,31 @@ export const UserPositionBar = ({ userPosition }: { userPosition?: UserPosition 
         </svg>
       </button>
       {open && (
-        <div className="rounded-b-xl border border-t-0 border-border bg-muted/20 dark:bg-muted/15 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 px-2 py-3 items-stretch w-full min-w-0">
-          <StatCard label="Supplied" value={formatUsdAmount(userPosition.supplied)} color="text-green-600 dark:text-green-400" />
-          <StatCard label="Borrowed" value={formatUsdAmount(userPosition.borrowed)} color="text-orange-600 dark:text-orange-400" />
-          <StatCard label="Withdrawable" value={formatUsdAmount(userPosition.withdrawable)} color="text-cyan-600 dark:text-cyan-400" />
-          <StatCard label="Borrowable" value={formatUsdAmount(userPosition.borrowable)} color="text-blue-600 dark:text-blue-400" />
-          <StatCard
-            label="Health factor"
-            value={userPosition.healthFactor.toFixed(2)}
-            color="text-emerald-600 dark:text-emerald-400"
-          />
+        <div className="rounded-b-xl border border-t-0 border-border bg-muted/20 dark:bg-muted/15 px-2 py-3 w-full min-w-0">
+          {loadState === 'loading' && (
+            <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin shrink-0" aria-hidden />
+              Loading your position…
+            </div>
+          )}
+          {loadState === 'error' && (
+            <p className="py-4 text-center text-sm text-destructive">
+              Could not load your position. Try closing and reopening this market.
+            </p>
+          )}
+          {loadState === 'ready' && userPosition && (
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 items-stretch w-full min-w-0">
+              <StatCard label="Supplied" value={formatUsdAmount(userPosition.supplied)} color="text-green-600 dark:text-green-400" />
+              <StatCard label="Borrowed" value={formatUsdAmount(userPosition.borrowed)} color="text-orange-600 dark:text-orange-400" />
+              <StatCard label="Withdrawable" value={formatUsdAmount(userPosition.withdrawable)} color="text-cyan-600 dark:text-cyan-400" />
+              <StatCard label="Borrowable" value={formatUsdAmount(userPosition.borrowable)} color="text-blue-600 dark:text-blue-400" />
+              <StatCard
+                label="Health"
+                value={userPosition.healthFactor.toFixed(2)}
+                color="text-emerald-600 dark:text-emerald-400"
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/market-modal/UserPositionBar.tsx
+++ b/src/components/market-modal/UserPositionBar.tsx
@@ -89,16 +89,9 @@ export const UserPositionBar = ({
             </p>
           )}
           {loadState === 'ready' && userPosition && (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 items-stretch w-full min-w-0">
+            <div className="grid grid-cols-2 gap-2 items-stretch w-full min-w-0">
               <StatCard label="Supplied" value={formatUsdAmount(userPosition.supplied)} color="text-green-600 dark:text-green-400" />
               <StatCard label="Borrowed" value={formatUsdAmount(userPosition.borrowed)} color="text-orange-600 dark:text-orange-400" />
-              <StatCard label="Withdrawable" value={formatUsdAmount(userPosition.withdrawable)} color="text-cyan-600 dark:text-cyan-400" />
-              <StatCard label="Borrowable" value={formatUsdAmount(userPosition.borrowable)} color="text-blue-600 dark:text-blue-400" />
-              <StatCard
-                label="Health"
-                value={userPosition.healthFactor.toFixed(2)}
-                color="text-emerald-600 dark:text-emerald-400"
-              />
             </div>
           )}
         </div>

--- a/src/components/market-modal/types.ts
+++ b/src/components/market-modal/types.ts
@@ -36,3 +36,5 @@ export interface UserPosition {
   earnings: number;
 }
 
+export type UserPositionLoadState = 'idle' | 'loading' | 'ready' | 'error';
+

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -2,7 +2,10 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { OnDemandMarketData } from "@/hooks/useOnDemandMarketData";
+import {
+  OnDemandMarketData,
+  marketRowPoolIdForFilter,
+} from "@/hooks/useOnDemandMarketData";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import DorkFiButton from "@/components/ui/DorkFiButton";
 import APYDisplay from "@/components/APYDisplay";
@@ -135,7 +138,7 @@ const MarketCardView = ({
   const deduplicatedMarkets = useMemo(() => {
     const marketMap = new Map<string, OnDemandMarketData>();
     markets.forEach((market) => {
-      const poolId = market.marketInfo?.poolId || market.poolId || "default";
+      const poolId = marketRowPoolIdForFilter(market) || "default";
       const key =
         (market as { _sortKey?: string })._sortKey ??
         `${market.asset}-${poolId}`;
@@ -159,14 +162,13 @@ const MarketCardView = ({
   return (
     <div className="space-y-4">
       {deduplicatedMarkets.map((market) => {
-        const poolIdForLabel =
-          market.marketInfo?.poolId || market.poolId || undefined;
+        const poolIdForLabel = marketRowPoolIdForFilter(market) || undefined;
         const marketLabel = getMarketLabel(currentNetwork, poolIdForLabel);
 
         // Render special card for s-tokens
         if (market.isSToken) {
           // Use poolId in key to ensure uniqueness even if multiple markets exist
-          const marketKey = `${market.asset}-${market.marketInfo?.poolId || market.poolId || 'stoken'}`;
+          const marketKey = `${market.asset}-${marketRowPoolIdForFilter(market) || "stoken"}`;
           return (
             <STokenCard
               key={marketKey}
@@ -183,7 +185,7 @@ const MarketCardView = ({
 
         // Render regular card for non-s-tokens
         // Use poolId in key to ensure uniqueness even if multiple markets exist
-        const marketKey = `${market.asset}-${market.marketInfo?.poolId || market.poolId || 'default'}`;
+        const marketKey = `${market.asset}-${marketRowPoolIdForFilter(market) || "default"}`;
         return (
           <DorkFiCard
             key={marketKey}

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -36,6 +36,16 @@ interface MarketCardViewProps {
   onBorrowClick: (asset: string, poolId?: string, marketRowKey?: string) => void;
   onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   onMigrateClick?: (asset: string) => void;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const MarketCardView = ({ 
@@ -45,7 +55,9 @@ const MarketCardView = ({
   onDepositClick, 
   onBorrowClick,
   onMintClick,
-  onMigrateClick
+  onMigrateClick,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: MarketCardViewProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -191,6 +203,7 @@ const MarketCardView = ({
             key={marketKey}
             className="flex flex-col md:flex-row md:items-stretch gap-4 md:gap-6"
             onClick={() => onRowClick(market)}
+            onMouseEnter={() => onRowMouseEnter?.(market)}
           >
             {/* Header with logo, asset info, and info button */}
             <div className="flex flex-col items-center text-center md:flex-col-reverse md:items-start md:text-left md:justify-normal">
@@ -279,6 +292,13 @@ const MarketCardView = ({
               <div className="flex gap-2 justify-center md:justify-start">
                 <DorkFiButton
                   variant="secondary"
+                  onMouseEnter={
+                    getMarketActionHoverHandlers?.(
+                      market.asset,
+                      market.marketInfo?.poolId || market.poolId,
+                      (market as { _sortKey?: string })._sortKey
+                    )?.onDepositMouseEnter
+                  }
                   onClick={e => {
                     e.stopPropagation();
                     onDepositClick(
@@ -296,6 +316,13 @@ const MarketCardView = ({
                 >Supply</DorkFiButton>
                 <DorkFiButton
                   variant="borrow-outline"
+                  onMouseEnter={
+                    getMarketActionHoverHandlers?.(
+                      market.asset,
+                      market.marketInfo?.poolId || market.poolId,
+                      (market as { _sortKey?: string })._sortKey
+                    )?.onBorrowMouseEnter
+                  }
                   onClick={e => {
                     e.stopPropagation();
                     if (isAtBorrowCap(Number(market.totalBorrow ?? 0), Number(market.borrowCap ?? 0))) return;

--- a/src/components/markets/MarketsDesktopTable.tsx
+++ b/src/components/markets/MarketsDesktopTable.tsx
@@ -50,6 +50,16 @@ interface MarketsDesktopTableProps {
   onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   onMigrateClick?: (asset: string) => void;
   isLoadingBalance?: boolean;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const headerTooltips = {
@@ -86,6 +96,8 @@ const MarketsDesktopTable = ({
   onMintClick,
   onMigrateClick,
   isLoadingBalance = false,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: MarketsDesktopTableProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -376,6 +388,8 @@ const MarketsDesktopTable = ({
           isLoadingBalance={isLoadingBalance}
           isNested={isNested}
           marketIndex={marketIndex}
+          getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+          onRowMouseEnter={onRowMouseEnter}
         />
       );
     }
@@ -388,6 +402,7 @@ const MarketsDesktopTable = ({
           isNested ? "bg-gray-50/50 dark:bg-slate-700/50" : ""
         }`}
         onClick={() => onRowClick(market)}
+        onMouseEnter={() => onRowMouseEnter?.(market)}
       >
         <TableCell className="text-left align-top">
           <div className="flex items-center gap-3 w-full justify-between">
@@ -621,6 +636,11 @@ const MarketsDesktopTable = ({
             const borrowCap = Number(market.borrowCap ?? 0);
             const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
+            const hoverHandlers = getMarketActionHoverHandlers?.(
+              market.asset,
+              finalPoolId,
+              (market as { _sortKey?: string })._sortKey
+            );
             return (
               <MarketsTableActions
                 asset={market.asset}
@@ -641,6 +661,9 @@ const MarketsDesktopTable = ({
                 isSToken={market.isSToken}
                 depositDisabled={depositCapReached}
                 borrowDisabled={borrowCapReached}
+                onDepositMouseEnter={hoverHandlers?.onDepositMouseEnter}
+                onBorrowMouseEnter={hoverHandlers?.onBorrowMouseEnter}
+                onMintMouseEnter={hoverHandlers?.onMintMouseEnter}
               />
             );
           })()}
@@ -800,6 +823,7 @@ const MarketsDesktopTable = ({
                   {/* Main collapsible row */}
                 <TableRow
                     className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-teal-400 hover:shadow-[0_0_16px_4px_rgba(13,255,190,0.15)] hover:z-20"
+                    onMouseEnter={() => onRowMouseEnter?.(mainMarket)}
                 >
                   <TableCell className="text-left align-top">
                       <div className="flex items-center gap-3 w-full justify-between">
@@ -1058,6 +1082,12 @@ const MarketsDesktopTable = ({
                       const borrowCap = Number(mainMarket.borrowCap ?? 0);
                       const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
+                      const groupedHoverHandlers =
+                        getMarketActionHoverHandlers?.(
+                          mainMarket.asset,
+                          finalPoolId,
+                          (mainMarket as { _sortKey?: string })._sortKey
+                        );
                       return (
                         <MarketsTableActions
                           asset={mainMarket.asset}
@@ -1080,6 +1110,15 @@ const MarketsDesktopTable = ({
                           isSToken={mainMarket.isSToken}
                           depositDisabled={depositCapReached}
                           borrowDisabled={borrowCapReached}
+                          onDepositMouseEnter={
+                            groupedHoverHandlers?.onDepositMouseEnter
+                          }
+                          onBorrowMouseEnter={
+                            groupedHoverHandlers?.onBorrowMouseEnter
+                          }
+                          onMintMouseEnter={
+                            groupedHoverHandlers?.onMintMouseEnter
+                          }
                         />
                       );
                     })()}

--- a/src/components/markets/MarketsTableActions.tsx
+++ b/src/components/markets/MarketsTableActions.tsx
@@ -18,6 +18,9 @@ interface MarketsTableActionsProps {
   depositDisabled?: boolean;
   /** When true, borrow is disabled (e.g. market at or over borrow cap). */
   borrowDisabled?: boolean;
+  onDepositMouseEnter?: (e: React.MouseEvent) => void;
+  onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+  onMintMouseEnter?: (e: React.MouseEvent) => void;
 }
 
 /**
@@ -37,6 +40,9 @@ const MarketsTableActions = ({
   isSToken = false,
   depositDisabled = false,
   borrowDisabled = false,
+  onDepositMouseEnter,
+  onBorrowMouseEnter,
+  onMintMouseEnter,
 }: MarketsTableActionsProps) => {
   return (
     <div className="flex flex-col space-y-2">
@@ -44,6 +50,7 @@ const MarketsTableActions = ({
         {!isSToken && (
           <DorkFiButton
             variant="secondary"
+            onMouseEnter={onDepositMouseEnter}
             onClick={(e) => {
               e.stopPropagation();
               onDepositClick(asset, poolId, marketRowKey);
@@ -56,6 +63,7 @@ const MarketsTableActions = ({
         )}
         <DorkFiButton
           variant={isSToken ? "mint" : "borrow-outline"}
+          onMouseEnter={isSToken ? onMintMouseEnter : onBorrowMouseEnter}
           onClick={(e) => {
             e.stopPropagation();
             if (isSToken && onMintClick) {

--- a/src/components/markets/MarketsTableContent.tsx
+++ b/src/components/markets/MarketsTableContent.tsx
@@ -24,6 +24,16 @@ interface MarketsTableContentProps {
   onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   onMigrateClick?: (asset: string) => void;
   isLoadingBalance?: boolean;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const MarketsTableContent = ({
@@ -39,7 +49,9 @@ const MarketsTableContent = ({
   onBorrowClick,
   onMintClick,
   onMigrateClick,
-  isLoadingBalance = false 
+  isLoadingBalance = false,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: MarketsTableContentProps) => {
   const breakpoint = useBreakpoint();
 
@@ -54,6 +66,8 @@ const MarketsTableContent = ({
         onBorrowClick={onBorrowClick}
         onMintClick={onMintClick}
         onMigrateClick={onMigrateClick}
+        getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+        onRowMouseEnter={onRowMouseEnter}
       />
     );
   }
@@ -71,6 +85,8 @@ const MarketsTableContent = ({
         onMintClick={onMintClick}
         onMigrateClick={onMigrateClick}
         isLoadingBalance={isLoadingBalance}
+        getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+        onRowMouseEnter={onRowMouseEnter}
       />
     );
   }
@@ -88,6 +104,8 @@ const MarketsTableContent = ({
       onMintClick={onMintClick}
       onMigrateClick={onMigrateClick}
       isLoadingBalance={isLoadingBalance}
+      getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+      onRowMouseEnter={onRowMouseEnter}
     />
   );
 };

--- a/src/components/markets/MarketsTableContent.tsx
+++ b/src/components/markets/MarketsTableContent.tsx
@@ -1,11 +1,17 @@
 
 import { useBreakpoint } from "@/hooks/useBreakpoint";
-import { OnDemandMarketData, SortField, SortOrder } from "@/hooks/useOnDemandMarketData";
+import {
+  OnDemandMarketData,
+  SortField,
+  SortOrder,
+  type MarketFilter,
+} from "@/hooks/useOnDemandMarketData";
 import MarketsDesktopTable from "./MarketsDesktopTable";
 import MarketsTabletTable from "./MarketsTabletTable";
 import MarketCardView from "./MarketCardView";
 
 interface MarketsTableContentProps {
+  marketFilter?: MarketFilter;
   markets: OnDemandMarketData[];
   sortField?: SortField;
   sortOrder?: SortOrder;
@@ -20,8 +26,9 @@ interface MarketsTableContentProps {
   isLoadingBalance?: boolean;
 }
 
-const MarketsTableContent = ({ 
-  markets, 
+const MarketsTableContent = ({
+  marketFilter = "all",
+  markets,
   sortField,
   sortOrder,
   userDeposits,
@@ -39,6 +46,7 @@ const MarketsTableContent = ({
   if (breakpoint === "mobile") {
     return (
       <MarketCardView
+        key={marketFilter}
         markets={markets}
         onRowClick={onRowClick}
         onInfoClick={onInfoClick}

--- a/src/components/markets/MarketsTabletTable.tsx
+++ b/src/components/markets/MarketsTabletTable.tsx
@@ -41,6 +41,16 @@ interface MarketsTabletTableProps {
   onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   onMigrateClick?: (asset: string) => void;
   isLoadingBalance?: boolean;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const MarketsTabletTable = ({
@@ -54,6 +64,8 @@ const MarketsTabletTable = ({
   onMintClick,
   onMigrateClick,
   isLoadingBalance = false,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: MarketsTabletTableProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -354,6 +366,7 @@ const MarketsTabletTable = ({
           isNested ? "bg-gray-50/50 dark:bg-slate-700/50" : ""
         }`}
         onClick={() => onRowClick(market)}
+        onMouseEnter={() => onRowMouseEnter?.(market)}
       >
         <TableCell className="text-center">
           <div className="flex items-center justify-center gap-2">
@@ -529,6 +542,11 @@ const MarketsTabletTable = ({
             // Use poolId from market object (most reliable - set when market data is loaded)
             // Fallback to token poolId, then marketInfo poolId
             const finalPoolId = market.poolId || token?.poolId || poolId || market.marketInfo?.poolId;
+            const hoverHandlers = getMarketActionHoverHandlers?.(
+              market.asset,
+              finalPoolId,
+              (market as { _sortKey?: string })._sortKey
+            );
 
             return (
               <MarketsTableActions
@@ -538,6 +556,9 @@ const MarketsTabletTable = ({
                 onDepositClick={onDepositClick}
                 onBorrowClick={onBorrowClick}
                 onMintClick={onMintClick}
+                onDepositMouseEnter={hoverHandlers?.onDepositMouseEnter}
+                onBorrowMouseEnter={hoverHandlers?.onBorrowMouseEnter}
+                onMintMouseEnter={hoverHandlers?.onMintMouseEnter}
                 onMigrateClick={
                   onMigrateClick &&
                   hasMigration &&
@@ -781,6 +802,12 @@ const MarketsTabletTable = ({
                       const borrowCap = Number(mainMarket.borrowCap ?? 0);
                       const borrowCapReached = isAtBorrowCap(totalBorrow, borrowCap);
 
+                      const groupedHoverHandlers =
+                        getMarketActionHoverHandlers?.(
+                          mainMarket.asset,
+                          mainMarket.marketInfo?.poolId || mainMarket.poolId,
+                          (mainMarket as { _sortKey?: string })._sortKey
+                        );
                       return (
                         <MarketsTableActions
                           asset={mainMarket.asset}
@@ -791,6 +818,15 @@ const MarketsTabletTable = ({
                           onDepositClick={onDepositClick}
                           onBorrowClick={onBorrowClick}
                           onMintClick={onMintClick}
+                          onDepositMouseEnter={
+                            groupedHoverHandlers?.onDepositMouseEnter
+                          }
+                          onBorrowMouseEnter={
+                            groupedHoverHandlers?.onBorrowMouseEnter
+                          }
+                          onMintMouseEnter={
+                            groupedHoverHandlers?.onMintMouseEnter
+                          }
                           onMigrateClick={
                             onMigrateClick &&
                             hasMigration &&

--- a/src/components/markets/STokenRow.tsx
+++ b/src/components/markets/STokenRow.tsx
@@ -29,6 +29,16 @@ interface STokenRowProps {
   isLoadingBalance?: boolean;
   isNested?: boolean;
   marketIndex?: number;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const LoadingCell = () => (
@@ -54,6 +64,8 @@ const STokenRow = ({
   isLoadingBalance = false,
   isNested = false,
   marketIndex,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: STokenRowProps) => {
   const { formatNumber, formatCurrency } = useNumberI18n();
   const { currentNetwork } = useNetwork();
@@ -63,6 +75,7 @@ const STokenRow = ({
       key={market.asset}
       className="hover:bg-gradient-to-r hover:from-purple-50 hover:to-pink-50 dark:hover:from-purple-900/20 dark:hover:to-pink-900/20 cursor-pointer transition-all duration-300 border-l-4 border-l-purple-500 bg-gradient-to-r from-purple-50/30 to-pink-50/30 dark:from-purple-900/10 dark:to-pink-900/10"
       onClick={() => onRowClick(market)}
+      onMouseEnter={() => onRowMouseEnter?.(market)}
     >
       <TableCell className="text-center">
         <div className="flex items-center justify-center gap-3">
@@ -169,11 +182,33 @@ const STokenRow = ({
         <MarketsTableActions
           asset={market.asset}
           poolId={market.marketInfo?.poolId}
+          marketRowKey={(market as { _sortKey?: string })._sortKey}
           onDepositClick={onDepositClick}
           onBorrowClick={onBorrowClick}
           onMintClick={onMintClick}
           isLoadingBalance={isLoadingBalance}
           isSToken={true}
+          onDepositMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              market.marketInfo?.poolId,
+              (market as { _sortKey?: string })._sortKey
+            )?.onDepositMouseEnter
+          }
+          onBorrowMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              market.marketInfo?.poolId,
+              (market as { _sortKey?: string })._sortKey
+            )?.onBorrowMouseEnter
+          }
+          onMintMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              market.marketInfo?.poolId,
+              (market as { _sortKey?: string })._sortKey
+            )?.onMintMouseEnter
+          }
         />
       </TableCell>
     </TableRow>

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -29,6 +29,8 @@ interface PortfolioTableMobileCardProps {
   poolId?: string;
   onDepositClick?: () => void;
   onWithdrawClick?: () => void;
+  onDepositMouseEnter?: () => void;
+  onWithdrawMouseEnter?: () => void;
   onRefreshClick?: () => void;
   isRefreshing?: boolean;
   type?: "deposit" | "borrow";
@@ -55,6 +57,8 @@ const PortfolioTableMobileCard = ({
   poolId,
   onDepositClick,
   onWithdrawClick,
+  onDepositMouseEnter,
+  onWithdrawMouseEnter,
   onRefreshClick,
   isRefreshing,
   type = "deposit",
@@ -247,6 +251,7 @@ const PortfolioTableMobileCard = ({
             <DorkFiButton
               variant={isDeposit ? "secondary" : "borrow-outline"}
               size="sm"
+              onMouseEnter={onDepositMouseEnter}
               onClick={onDepositClick}
               className="flex-1 min-w-0"
               disabled={isDeposit ? depositDisabled : borrowDisabled}
@@ -266,6 +271,7 @@ const PortfolioTableMobileCard = ({
             <DorkFiButton
               variant={isDeposit ? "withdraw" : "danger-outline"}
               size="sm"
+              onMouseEnter={onWithdrawMouseEnter}
               onClick={onWithdrawClick}
               className="flex-1 min-w-0"
             >

--- a/src/config/__tests__/resolveTokenForMarketPosition.test.ts
+++ b/src/config/__tests__/resolveTokenForMarketPosition.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveTokenForMarketPosition } from "@/config";
+
+describe("resolveTokenForMarketPosition", () => {
+  it("resolves UNIT on prod primary pool", () => {
+    const t = resolveTokenForMarketPosition("voi-mainnet", {
+      asset: "UNIT",
+      poolId: "47139778",
+    });
+    expect(t).not.toBeNull();
+    expect(t?.poolId).toBe("47139778");
+    expect(t?.underlyingContractId).toBe("420069");
+  });
+
+  it("resolves UNIT on legacy migration pool A", () => {
+    const t = resolveTokenForMarketPosition("voi-mainnet", {
+      asset: "UNIT",
+      poolId: "41760711",
+    });
+    expect(t).not.toBeNull();
+    expect(t?.poolId).toBe("41760711");
+    expect(t?.underlyingContractId).toBe("420069");
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3864,6 +3864,95 @@ export const getAllTokensWithDisplayInfo = (networkId: NetworkId) => {
   return result;
 };
 
+export type DisplayTokenInfo = ReturnType<typeof getAllTokensWithDisplayInfo>[number];
+
+function tokenConfigRowMatchesPool(tc: TokenConfig, poolId: string): boolean {
+  if (String(tc.poolId ?? "") === poolId) return true;
+  if (tc.migration && String(tc.migration.poolId) === poolId) return true;
+  return false;
+}
+
+/**
+ * Resolve pool + market contract for on-chain position reads (deposit/borrow balances).
+ * Matches primary `poolId` on display tokens and legacy {@link TokenConfig.migration} pools.
+ */
+export function resolveTokenForMarketPosition(
+  networkId: NetworkId,
+  params: {
+    asset: string;
+    poolId?: string;
+    configSymbol?: string;
+  }
+): DisplayTokenInfo | null {
+  const poolStr =
+    params.poolId != null && String(params.poolId).trim() !== ""
+      ? String(params.poolId).trim()
+      : "";
+  const tokens = getAllTokensWithDisplayInfo(networkId);
+  const asset = params.asset.trim();
+  const configSymbol = params.configSymbol?.trim();
+
+  const matchesSymbol = (t: DisplayTokenInfo): boolean => {
+    if (configSymbol) {
+      return (
+        (t.originalSymbol ?? t.symbol) === configSymbol ||
+        t.configKey === configSymbol ||
+        t.symbol === configSymbol
+      );
+    }
+    return t.symbol === asset;
+  };
+
+  if (poolStr !== "") {
+    const direct = tokens.find(
+      (t) => matchesSymbol(t) && String(t.poolId ?? "") === poolStr
+    );
+    if (direct?.poolId && direct.underlyingContractId) return direct;
+
+    const book = config.networks[networkId]?.tokens;
+    if (book) {
+      for (const [configKey, raw] of Object.entries(book)) {
+        const rows: { config: TokenConfig; index: number }[] = Array.isArray(raw)
+          ? raw.map((config, index) => ({ config, index }))
+          : [{ config: raw, index: 0 }];
+        for (const { config: tc, index } of rows) {
+          if (!tokenConfigRowMatchesPool(tc, poolStr)) continue;
+          const keyMatches = configSymbol
+            ? configSymbol === configKey || configSymbol === tc.symbol
+            : false;
+          const assetMatches = configKey === asset || tc.symbol === asset;
+          if (!keyMatches && !assetMatches) continue;
+
+          const usesMigration =
+            tc.migration && String(tc.migration.poolId) === poolStr;
+          const rpcPoolId = usesMigration ? tc.migration!.poolId : String(tc.poolId ?? "");
+          const rpcContractId = usesMigration
+            ? tc.migration!.contractId
+            : String(tc.contractId ?? "").trim();
+          if (!rpcPoolId || !rpcContractId) continue;
+
+          const displayInfo = getTokenDisplayInfo(networkId, configKey, index);
+          if (!displayInfo) continue;
+
+          return {
+            configKey,
+            symbol: configKey,
+            ...displayInfo,
+            poolId: rpcPoolId,
+            underlyingContractId: rpcContractId,
+            decimals: tc.decimals,
+            logoPath: tc.logoPath,
+            isNew: isNewMarketByDataAddedAt(tc.dataAddedAt),
+          };
+        }
+      }
+    }
+  }
+
+  const fallback = tokens.find(matchesSymbol);
+  return fallback?.poolId && fallback.underlyingContractId ? fallback : null;
+}
+
 /**
  * Check if a token has market override configured
  * For tokens with multiple markets, checks the first market

--- a/src/hooks/useMimirTokenPrice24h.ts
+++ b/src/hooks/useMimirTokenPrice24h.ts
@@ -32,21 +32,30 @@ export interface UseMimirTokenPrice24hResult {
   error: string | null;
 }
 
+/** Mimir price API is Voi-mainnet only; other networks should use on-chain/market data. */
+export function isMimirPriceNetwork(networkId?: string | null): boolean {
+  return networkId == null || networkId === "voi-mainnet";
+}
+
 /**
  * 24h USD-ish price series from Mimir (token vs USDC) for sparkline + % change.
- * Fetches only when `enabled` (e.g. modal open).
+ * Fetches only when `enabled` (e.g. modal open on Voi).
  */
 export function useMimirTokenPrice24h(
   symbol: string,
-  enabled: boolean
+  enabled: boolean,
+  options?: { networkId?: string | null; configSymbol?: string }
 ): UseMimirTokenPrice24hResult {
+  const priceSymbol = (options?.configSymbol?.trim() || symbol.trim()).trim();
+  const mimirEnabled =
+    enabled && isMimirPriceNetwork(options?.networkId ?? null);
   const [priceChange24h, setPriceChange24h] = useState(0);
   const [priceHistory, setPriceHistory] = useState<TokenPrice24hPoint[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetch24h = useCallback(async () => {
-    if (!enabled || !symbol?.trim()) {
+    if (!mimirEnabled || !priceSymbol) {
       setPriceChange24h(0);
       setPriceHistory([]);
       setIsLoading(false);
@@ -54,7 +63,7 @@ export function useMimirTokenPrice24h(
       return;
     }
 
-    const upper = symbol.trim().toUpperCase();
+    const upper = priceSymbol.toUpperCase();
     if (STABLE_ASSET_SYMBOLS.has(upper)) {
       setPriceChange24h(0);
       setPriceHistory([]);
@@ -68,7 +77,7 @@ export function useMimirTokenPrice24h(
 
     try {
       const points = await MimirApiService.getPriceHistory(
-        symbol.trim(),
+        priceSymbol,
         "USDC",
         "1h",
         "24h"
@@ -89,7 +98,7 @@ export function useMimirTokenPrice24h(
     } finally {
       setIsLoading(false);
     }
-  }, [symbol, enabled]);
+  }, [priceSymbol, mimirEnabled]);
 
   useEffect(() => {
     void fetch24h();

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -878,28 +878,15 @@ export const useOnDemandMarketData = ({
         multiPoolAssetKeys.has(market.asset.toLowerCase())
       );
     }
-    // Filter by market (All / A / B / D — D uses {@link getMarketLabel} === "D", not only `lendingPools[2]`)
+    // Filter by market letter (A / B / D) via {@link getMarketLabel}, not raw `lendingPools` index —
+    // prod has pools [A, B, D] and token/API pool ids must match the label map, not only [0]/[1].
     if (marketFilter !== "all") {
       const nid = currentNetwork as NetworkId;
-      if (
-        (marketFilter === "A" || marketFilter === "B") &&
-        lendingPools.length >= 2
-      ) {
-        const poolIdA = lendingPools[0];
-        const poolIdB = lendingPools[1];
-        filtered = filtered.filter((market) => {
-          const pid = marketRowPoolIdForFilter(market);
-          if (marketFilter === "A") return pid === String(poolIdA);
-          if (marketFilter === "B") return pid === String(poolIdB);
-          return true;
-        });
-      } else if (marketFilter === "D") {
-        filtered = filtered.filter(
-          (market) =>
-            getMarketLabel(nid, marketRowPoolIdForFilter(market) || undefined) ===
-            "D"
-        );
-      }
+      filtered = filtered.filter(
+        (market) =>
+          getMarketLabel(nid, marketRowPoolIdForFilter(market) || undefined) ===
+          marketFilter
+      );
     }
     // Filter data based on search term
     const q = searchTerm.toLowerCase();

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -3,12 +3,70 @@ import { fetchMarketInfo } from '@/services/lendingService';
 import { getAllTokensWithDisplayInfo } from '@/config';
 import { useNetwork } from '@/contexts/NetworkContext';
 import { usdPerTokenFromMarketInfoPrice } from '@/utils/assetDecimals';
+import { withRpcReadCache } from '@/utils/rpcReadCache';
 
 interface UseTokenPriceResult {
   price: number;
   isLoading: boolean;
   error: string | null;
   refetch: () => void;
+}
+
+const TOKEN_PRICE_CACHE_TTL_MS = 60_000;
+
+async function fetchTokenPriceUsd(
+  tokenSymbol: string,
+  networkToUse: string
+): Promise<number> {
+  const tokens = getAllTokensWithDisplayInfo(networkToUse as any);
+  const token = tokens.find(t => t.symbol === tokenSymbol);
+
+  if (!token || !token.poolId || !token.underlyingContractId) {
+    const { getEnabledNetworks } = await import('@/config');
+    const enabledNetworks = getEnabledNetworks();
+
+    for (const network of enabledNetworks) {
+      if (network === networkToUse) continue;
+
+      const otherTokens = getAllTokensWithDisplayInfo(network as any);
+      const otherToken = otherTokens.find(t => t.symbol === tokenSymbol);
+
+      if (otherToken && otherToken.poolId && otherToken.underlyingContractId) {
+        const marketInfo = await fetchMarketInfo(
+          otherToken.poolId,
+          otherToken.underlyingContractId,
+          network
+        );
+        const decimals = otherToken.decimals ?? 6;
+        if (marketInfo) {
+          const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
+          const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
+          if (marketPrice != null && marketPrice > 0) {
+            return marketPrice;
+          }
+        }
+      }
+    }
+
+    throw new Error(`Token ${tokenSymbol} not found or missing configuration`);
+  }
+
+  const marketInfo = await fetchMarketInfo(
+    token.poolId,
+    token.underlyingContractId,
+    networkToUse
+  );
+
+  const decimals = token.decimals ?? 6;
+  if (marketInfo) {
+    const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
+    const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
+    if (marketPrice != null && marketPrice > 0) {
+      return marketPrice;
+    }
+  }
+
+  throw new Error(`No market price data available for ${tokenSymbol}`);
 }
 
 export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseTokenPriceResult => {
@@ -23,84 +81,28 @@ export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseToken
       return;
     }
 
+    const networkToUse = networkId || currentNetwork;
+    if (!networkToUse) {
+      setError('No network specified');
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
+    const cacheKey = `tokenPrice:${networkToUse}:${tokenSymbol}`;
+
     try {
-      // Use provided networkId or fallback to currentNetwork
-      const networkToUse = networkId || currentNetwork;
-      
-      if (!networkToUse) {
-        throw new Error('No network specified');
-      }
-
-      // Get token configuration to find pool and market IDs
-      const tokens = getAllTokensWithDisplayInfo(networkToUse as any);
-      const token = tokens.find(t => t.symbol === tokenSymbol);
-      
-      if (!token || !token.poolId || !token.underlyingContractId) {
-        // If token not found in specified network, try other enabled networks
-        if (!networkId) {
-          // Only try other networks if networkId wasn't explicitly provided
-          const { getEnabledNetworks } = await import('@/config');
-          const enabledNetworks = getEnabledNetworks();
-          
-          for (const network of enabledNetworks) {
-            if (network === networkToUse) continue; // Skip the one we already tried
-            
-            const otherTokens = getAllTokensWithDisplayInfo(network as any);
-            const otherToken = otherTokens.find(t => t.symbol === tokenSymbol);
-            
-            if (otherToken && otherToken.poolId && otherToken.underlyingContractId) {
-              // Found token in another network, use that network
-              const marketInfo = await fetchMarketInfo(
-                otherToken.poolId,
-                otherToken.underlyingContractId,
-                network
-              );
-              const decimals = otherToken.decimals ?? 6;
-              if (marketInfo) {
-                const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
-                const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
-                if (marketPrice != null && marketPrice > 0) {
-                  console.log(`Market price for ${tokenSymbol} on ${network}: $${marketPrice}`);
-                  setPrice(marketPrice);
-                  setIsLoading(false);
-                  return;
-                }
-              }
-            }
-          }
-        }
-        
-        throw new Error(`Token ${tokenSymbol} not found or missing configuration`);
-      }
-
-      // Fetch market info to get the real market price
-      const marketInfo = await fetchMarketInfo(
-        token.poolId,
-        token.underlyingContractId,
-        networkToUse
+      const marketPrice = await withRpcReadCache(
+        cacheKey,
+        () => fetchTokenPriceUsd(tokenSymbol, networkToUse),
+        TOKEN_PRICE_CACHE_TTL_MS
       );
-
-      const decimals = token.decimals ?? 6;
-      if (marketInfo) {
-        const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
-        const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
-        if (marketPrice != null && marketPrice > 0) {
-          console.log(`Market price for ${tokenSymbol}: $${marketPrice} (decimals=${decimals})`);
-          setPrice(marketPrice);
-        } else {
-          throw new Error(`No market price data available for ${tokenSymbol}`);
-        }
-      } else {
-        throw new Error(`No market price data available for ${tokenSymbol}`);
-      }
+      setPrice(marketPrice);
     } catch (err) {
       console.error(`Error fetching market price for ${tokenSymbol}:`, err);
       setError(err instanceof Error ? err.message : 'Failed to fetch market price');
-      
-      // Fallback to mock prices
+
       const mockPrices: Record<string, number> = {
         'VOI': 0.05,
         'UNIT': 0.1,
@@ -113,7 +115,7 @@ export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseToken
         'USDT': 1.0,
         'DAI': 1.0
       };
-      
+
       setPrice(mockPrices[tokenSymbol] || 1.0);
     } finally {
       setIsLoading(false);

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -25,6 +25,7 @@ import { APP_SPEC as STokenAppSpec } from "@/clients/STokenClient";
 import { abi, CONTRACT } from "ulujs";
 import algorandService, { AlgorandNetwork } from "./algorandService";
 import algosdk, { TransactionSigner } from "algosdk";
+import { withRpcReadCache } from "@/utils/rpcReadCache";
 
 export interface PausedState {
   isPaused: boolean;
@@ -1067,6 +1068,26 @@ export const updateMarketMaxBorrows = async (
  * @returns The maximum borrow amount as a bigint, or null if the call fails
  */
 export const calculateMaxBorrowAmount = async (
+  poolId: number | string,
+  userId: string,
+  marketId: number | string,
+  storageContractAppId?: number | string
+): Promise<bigint | null> => {
+  const storageKey = storageContractAppId ?? poolId;
+  return withRpcReadCache(
+    `maxBorrow:${poolId}:${userId}:${marketId}:${storageKey}`,
+    () =>
+      calculateMaxBorrowAmountUncached(
+        poolId,
+        userId,
+        marketId,
+        storageContractAppId
+      ),
+    15_000
+  );
+};
+
+const calculateMaxBorrowAmountUncached = async (
   poolId: number | string,
   userId: string,
   marketId: number | string,

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -45,6 +45,7 @@ import {
 } from "@/clients/DorkFiLendingPoolClient";
 import algosdk from "algosdk";
 import BigNumber from "bignumber.js";
+import { withRpcReadCache } from "@/utils/rpcReadCache";
 import { calcDepositReturn } from "@folks-finance/algorand-sdk";
 import {
   calculateDepositAPY,
@@ -1145,6 +1146,21 @@ export const fetchUserGlobalData = async (
   lastUpdateTime: number;
   healthFactorIndex?: number;
 } | null> => {
+  return withRpcReadCache(
+    `userGlobal:${networkId}:${userAddress}`,
+    () => fetchUserGlobalDataUncached(userAddress, networkId)
+  );
+};
+
+const fetchUserGlobalDataUncached = async (
+  userAddress: string,
+  networkId: NetworkId
+): Promise<{
+  totalCollateralValue: number;
+  totalBorrowValue: number;
+  lastUpdateTime: number;
+  healthFactorIndex?: number;
+} | null> => {
   try {
     const networkConfig = getNetworkConfig(networkId);
 
@@ -1153,75 +1169,61 @@ export const fetchUserGlobalData = async (
         networkConfig.walletNetworkId as AlgorandNetwork
       );
 
-      // Initialize aggregate values
       let totalCollateralValueUSD = 0;
       let totalBorrowValueUSD = 0;
       let lastUpdateTime = 0;
 
-      const lendingPools = networkConfig.contracts?.lendingPools ?? [];
-      for (const poolId of lendingPools) {
-        const poolIdNum = Number(poolId);
-        if (!Number.isFinite(poolIdNum) || poolIdNum <= 0) {
-          console.warn(
-            `fetchUserGlobalData: skipping invalid lending pool id: ${String(poolId)}`
-          );
-          continue;
-        }
-        try {
-          const ci = new CONTRACT(
-            poolIdNum,
-            clients.algod,
-            undefined,
-            { ...LendingPoolAppSpec.contract, events: [] },
-            {
-              addr: algosdk.encodeAddress(
-                algosdk.getApplicationAddress(poolIdNum).publicKey
-              ),
-              sk: new Uint8Array(),
-            }
-          );
-          ci.setFee(2000);
+      const lendingPools = (networkConfig.contracts?.lendingPools ?? [])
+        .map((poolId) => Number(poolId))
+        .filter((poolIdNum) => Number.isFinite(poolIdNum) && poolIdNum > 0);
 
-          const globalUserR = await ci.get_global_user(userAddress);
-          if (globalUserR.success) {
-            const globalUser = GlobalUserData(globalUserR.returnValue);
-            console.log(`Global user data for pool ${poolId}:`, globalUser);
-
-            // Contract stores totalCollateralValue with scaling: (deposit_amount * price) // SCALE
-            // Where SCALE = 1e18, so we need to divide by 1e18 to get USD value
-            const poolCollateralValueUSD = new BigNumber(
-              globalUser.totalCollateralValue.toString()
-            )
-              .div(1e12) // Correct scaling factor for collateral value
-              .toNumber();
-            const poolBorrowValueUSD = new BigNumber(
-              globalUser.totalBorrowValue.toString()
-            )
-              .div(1e12) // Correct scaling factor for borrow value
-              .toNumber();
-
-            console.log(`Pool ${poolId} values:`, {
-              collateralValueUSD: poolCollateralValueUSD,
-              borrowValueUSD: poolBorrowValueUSD,
-            });
-
-            // Aggregate values from all pools
-            totalCollateralValueUSD += poolCollateralValueUSD;
-            totalBorrowValueUSD += poolBorrowValueUSD;
-            // Use the latest update time from all pools
-            lastUpdateTime = Math.max(
-              lastUpdateTime,
-              Number(globalUser.lastUpdateTime)
+      const poolResults = await Promise.all(
+        lendingPools.map(async (poolIdNum) => {
+          try {
+            const ci = new CONTRACT(
+              poolIdNum,
+              clients.algod,
+              undefined,
+              { ...LendingPoolAppSpec.contract, events: [] },
+              {
+                addr: algosdk.encodeAddress(
+                  algosdk.getApplicationAddress(poolIdNum).publicKey
+                ),
+                sk: new Uint8Array(),
+              }
             );
-          } else {
-            console.warn(`Failed to get global user data for pool ${poolId}`);
+            ci.setFee(2000);
+            const globalUserR = await ci.get_global_user(userAddress);
+            if (!globalUserR.success) return null;
+            const globalUser = GlobalUserData(globalUserR.returnValue);
+            return {
+              poolCollateralValueUSD: new BigNumber(
+                globalUser.totalCollateralValue.toString()
+              )
+                .div(1e12)
+                .toNumber(),
+              poolBorrowValueUSD: new BigNumber(
+                globalUser.totalBorrowValue.toString()
+              )
+                .div(1e12)
+                .toNumber(),
+              lastUpdateTime: Number(globalUser.lastUpdateTime),
+            };
+          } catch (poolError) {
+            console.warn(
+              `fetchUserGlobalData: pool ${poolIdNum} read failed:`,
+              poolError
+            );
+            return null;
           }
-        } catch (poolError) {
-          console.warn(
-            `fetchUserGlobalData: pool ${poolId} read failed (continuing other pools):`,
-            poolError
-          );
-        }
+        })
+      );
+
+      for (const row of poolResults) {
+        if (!row) continue;
+        totalCollateralValueUSD += row.poolCollateralValueUSD;
+        totalBorrowValueUSD += row.poolBorrowValueUSD;
+        lastUpdateTime = Math.max(lastUpdateTime, row.lastUpdateTime);
       }
 
       // Same ratio as on-chain _calculate_user_health(collateral, borrow, liquidation_threshold);
@@ -1287,6 +1289,21 @@ export const fetchUserGlobalData = async (
  * Use this when computing max borrow for a specific pool so borrowing power is based on collateral in that pool only.
  */
 export const fetchUserGlobalDataForPool = async (
+  userAddress: string,
+  networkId: NetworkId,
+  poolId: string | number
+): Promise<{
+  totalCollateralValue: number;
+  totalBorrowValue: number;
+  lastUpdateTime: number;
+} | null> => {
+  return withRpcReadCache(
+    `userGlobalPool:${networkId}:${poolId}:${userAddress}`,
+    () => fetchUserGlobalDataForPoolUncached(userAddress, networkId, poolId)
+  );
+};
+
+const fetchUserGlobalDataForPoolUncached = async (
   userAddress: string,
   networkId: NetworkId,
   poolId: string | number
@@ -2552,6 +2569,30 @@ export function getMaxWithdrawable(
  * Returns human-readable underlying amount and scaled amount for contract call.
  */
 export const getMaxWithdrawableForMarket = async (
+  poolId: string,
+  marketId: string,
+  userAddress: string,
+  networkId: NetworkId,
+  tokenDecimals: number,
+  options?: GetMaxWithdrawableOptions
+): Promise<{ maxWithdrawUnderlying: number; maxWithdrawScaled: bigint } | null> => {
+  const optionsKey = options?.minLiquidationThresholdBps?.toString() ?? "";
+  return withRpcReadCache(
+    `maxWithdraw:${networkId}:${poolId}:${marketId}:${userAddress}:${tokenDecimals}:${optionsKey}`,
+    () =>
+      getMaxWithdrawableForMarketUncached(
+        poolId,
+        marketId,
+        userAddress,
+        networkId,
+        tokenDecimals,
+        options
+      ),
+    15_000
+  );
+};
+
+const getMaxWithdrawableForMarketUncached = async (
   poolId: string,
   marketId: string,
   userAddress: string,

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1372,6 +1372,67 @@ export type ChainGlobalUserRow = {
 };
 
 /**
+ * Per-pool `get_global_user` for all enabled networks (~few RPC calls).
+ * Use for portfolio health factor; avoids scanning every market via {@link fetchUserDataFromChain}.
+ */
+export const fetchGlobalUserRowsFromChain = async (
+  userAddress: string
+): Promise<ChainGlobalUserRow[]> => {
+  const tasks: Array<Promise<ChainGlobalUserRow | null>> = [];
+
+  for (const networkId of getEnabledNetworks()) {
+    if (!isAlgorandCompatibleNetwork(networkId)) continue;
+
+    const networkConfig = getNetworkConfig(networkId);
+    const clientsPromise = algorandService.initializeClientsForReads(
+      networkConfig.walletNetworkId as AlgorandNetwork
+    );
+
+    for (const poolId of networkConfig.contracts.lendingPools) {
+      tasks.push(
+        (async () => {
+          try {
+            const clients = await clientsPromise;
+            const poolIdNum = Number(poolId);
+            const ci = new CONTRACT(
+              poolIdNum,
+              clients.algod,
+              undefined,
+              { ...LendingPoolAppSpec.contract, events: [] },
+              {
+                addr: algosdk.encodeAddress(
+                  algosdk.getApplicationAddress(poolIdNum).publicKey
+                ),
+                sk: new Uint8Array(),
+              }
+            );
+            ci.setFee(2000);
+            const globalUserR = await ci.get_global_user(userAddress);
+            if (!globalUserR.success) return null;
+            const globalUser = GlobalUserData(globalUserR.returnValue);
+            return {
+              network: networkId,
+              poolId: String(poolId),
+              totalCollateralValue: globalUser.totalCollateralValue.toString(),
+              totalBorrowValue: globalUser.totalBorrowValue.toString(),
+            };
+          } catch (e) {
+            console.warn(
+              `[fetchGlobalUserRowsFromChain] pool ${poolId} on ${networkId}:`,
+              e
+            );
+            return null;
+          }
+        })()
+      );
+    }
+  }
+
+  const settled = await Promise.all(tasks);
+  return settled.filter((r): r is ChainGlobalUserRow => r != null);
+};
+
+/**
  * Fetch global user rows and per-market user rows from chain for all enabled networks.
  * Mirrors the shape expected by Portfolio when building `user.computed` from API data.
  */

--- a/src/services/mimirApi/priceService.ts
+++ b/src/services/mimirApi/priceService.ts
@@ -1,6 +1,39 @@
-import { OHLCDataPoint, PriceDataPoint, MimirOHLCResponse, MimirPriceResponse, MIMIR_BASE_URL, TOKEN_MAP } from '@/types/mimirTypes';
+import {
+  OHLCDataPoint,
+  PriceDataPoint,
+  MimirOHLCResponse,
+  MimirPriceResponse,
+  MIMIR_BASE_URL,
+  TOKEN_MAP,
+  type Token,
+} from '@/types/mimirTypes';
 import { TokenService } from './tokenService';
 import { MockDataService } from './mockDataService';
+
+function resolveMimirTokenId(symbol: string, tokens: Token[]): string | null {
+  const trimmed = symbol.trim();
+  if (!trimmed) return null;
+  const upper = trimmed.toUpperCase();
+
+  const bySymbol = tokens.find(
+    (t) =>
+      t.symbol.toUpperCase() === upper ||
+      t.id.toUpperCase() === upper
+  );
+  if (bySymbol) return bySymbol.id;
+
+  const mapped = TOKEN_MAP[trimmed] ?? TOKEN_MAP[upper];
+  if (mapped) {
+    const byMapped = tokens.find(
+      (t) =>
+        t.symbol.toUpperCase() === mapped.toUpperCase() ||
+        t.id === mapped
+    );
+    return byMapped?.id ?? mapped;
+  }
+
+  return null;
+}
 
 interface SwapSimulationResult {
   expectedOutput: string;
@@ -136,26 +169,36 @@ export class PriceService {
     interval: '1m' | '5m' | '1h' = '5m',
     range: '1h' | '24h' | '7d' = '24h'
   ): Promise<PriceDataPoint[]> {
-    try {
-      const tokens = await TokenService.getTokens();
-      const tokenAId = tokens.find(t => t.symbol === tokenA)?.id || TOKEN_MAP[tokenA] || tokenA;
-      const tokenBId = tokens.find(t => t.symbol === tokenB)?.id || TOKEN_MAP[tokenB] || tokenB;
+    const tokens = await TokenService.getTokens();
+    const tokenAId = resolveMimirTokenId(tokenA, tokens);
+    const tokenBId = resolveMimirTokenId(tokenB, tokens);
 
-      const url = `${MIMIR_BASE_URL}/prices/history?tokenA=${tokenAId}&tokenB=${tokenBId}&interval=${interval}&range=${range}`;
+    if (!tokenAId || !tokenBId) {
+      return MockDataService.generateMockData(tokenA, tokenB, range);
+    }
+
+    try {
+      const url = `${MIMIR_BASE_URL}/prices/history?tokenA=${encodeURIComponent(tokenAId)}&tokenB=${encodeURIComponent(tokenBId)}&interval=${interval}&range=${range}`;
       const response = await fetch(url);
-      
+
+      if (response.status === 404) {
+        return MockDataService.generateMockData(tokenA, tokenB, range);
+      }
+
       if (!response.ok) {
         throw new Error(`Failed to fetch price history: ${response.status}`);
       }
-      
+
       const data: MimirPriceResponse[] = await response.json();
-      
-      return data.map(item => ({
+
+      return data.map((item) => ({
         timestamp: item.timestamp,
-        price: item.price
+        price: item.price,
       }));
     } catch (error) {
-      console.error('Error fetching price history:', error);
+      if (import.meta.env.DEV) {
+        console.debug('Mimir price history unavailable, using fallback:', error);
+      }
       return MockDataService.generateMockData(tokenA, tokenB, range);
     }
   }

--- a/src/utils/__tests__/portfolioDisplayHealthFactor.test.ts
+++ b/src/utils/__tests__/portfolioDisplayHealthFactor.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePortfolioDisplayHealthFactor,
+  depositsForHealthFromChainUserData,
+  sumGlobalUserTotals,
+} from "@/utils/portfolioDisplayHealthFactor";
+
+describe("portfolioDisplayHealthFactor", () => {
+  it("uses worst pool HF across globalUserData rows", () => {
+    const scale = (usd: number) => String(BigInt(Math.round(usd * 1e12)));
+    const deposits = [
+      { poolId: "100", marketId: "1", value: 1 },
+      { poolId: "200", marketId: "2", value: 1 },
+    ];
+    const marketData = [
+      {
+        poolId: "100",
+        marketId: "1",
+        liquidationThreshold: 0.85,
+      },
+      {
+        poolId: "200",
+        marketId: "2",
+        liquidationThreshold: 0.85,
+      },
+    ];
+    const hf = computePortfolioDisplayHealthFactor({
+      globalUserData: [
+        {
+          network: "voi-mainnet",
+          poolId: "100",
+          totalCollateralValue: scale(10_000),
+          totalBorrowValue: scale(5_000),
+        },
+        {
+          network: "voi-mainnet",
+          poolId: "200",
+          totalCollateralValue: scale(10_000),
+          totalBorrowValue: scale(8_000),
+        },
+      ],
+      deposits,
+      marketData,
+    });
+    // Pool 100: 10000*0.85/5000 = 1.7; pool 200: 10000*0.85/8000 ≈ 1.0625
+    expect(hf).toBeCloseTo(1.0625, 3);
+  });
+
+  it("builds deposit rows from chain user data with scaled deposits", () => {
+    const deps = depositsForHealthFromChainUserData([
+      {
+        network: "voi-mainnet",
+        marketId: "420069",
+        underlyingContractId: "420069",
+        appId: "47139778",
+        poolId: "47139778",
+        scaledDeposits: "1000",
+        scaledBorrows: "0",
+        depositIndex: "0",
+        borrowIndex: "0",
+      },
+      {
+        network: "voi-mainnet",
+        marketId: "2",
+        underlyingContractId: "2",
+        appId: "47139778",
+        poolId: "47139778",
+        scaledDeposits: "0",
+        scaledBorrows: "0",
+        depositIndex: "0",
+        borrowIndex: "0",
+      },
+    ]);
+    expect(deps).toHaveLength(1);
+    expect(deps[0].marketId).toBe("420069");
+  });
+
+  it("sums global user totals across pools", () => {
+    const scale = (usd: number) => String(BigInt(Math.round(usd * 1e12)));
+    const { totalCollateral, totalBorrowed } = sumGlobalUserTotals([
+      {
+        network: "voi-mainnet",
+        poolId: "1",
+        totalCollateralValue: scale(100),
+        totalBorrowValue: scale(40),
+      },
+      {
+        network: "voi-mainnet",
+        poolId: "2",
+        totalCollateralValue: scale(50),
+        totalBorrowValue: scale(10),
+      },
+    ]);
+    expect(totalCollateral).toBe(150);
+    expect(totalBorrowed).toBe(50);
+  });
+});

--- a/src/utils/modalHoverHandlers.ts
+++ b/src/utils/modalHoverHandlers.ts
@@ -1,0 +1,134 @@
+import type { MouseEvent } from "react";
+import type { NetworkId } from "@/config";
+import {
+  configSymbolFromMarketRowKey,
+  createDebouncedPrefetch,
+  warmBorrowModalMaxAndPool,
+  warmMintModalRpc,
+  warmRepayModalRpc,
+  type MarketActionTokenParams,
+} from "@/utils/modalPrefetch";
+
+export type ModalHoverPrefetchBundle = {
+  debounced: ReturnType<typeof createDebouncedPrefetch>;
+  userAddress?: string;
+  networkId: NetworkId;
+  /** Portfolio / Markets: warm wallet balance via parent fetcher. */
+  warmWalletBalance?: (params: MarketActionTokenParams) => void;
+};
+
+export function buildMarketHoverHandlers(
+  bundle: ModalHoverPrefetchBundle,
+  asset: string,
+  poolId?: string,
+  marketRowKey?: string,
+  configSymbol?: string,
+  marketId?: string
+) {
+  const resolvedConfig =
+    configSymbol ?? configSymbolFromMarketRowKey(marketRowKey);
+  const params: MarketActionTokenParams = {
+    userAddress: bundle.userAddress ?? "",
+    networkId: bundle.networkId,
+    asset,
+    poolId,
+    configSymbol: resolvedConfig,
+    marketId,
+  };
+  const keyBase = [
+    bundle.networkId,
+    asset,
+    poolId ?? "",
+    resolvedConfig ?? "",
+    marketId ?? "",
+  ].join(":");
+
+  const stop = (e: MouseEvent) => e.stopPropagation();
+
+  return {
+    onDepositMouseEnter: bundle.userAddress
+      ? (e: MouseEvent) => {
+          stop(e);
+          bundle.debounced(`deposit:${keyBase}`, () => {
+            bundle.warmWalletBalance?.(params);
+          });
+        }
+      : undefined,
+    onBorrowMouseEnter: bundle.userAddress
+      ? (e: MouseEvent) => {
+          stop(e);
+          bundle.debounced(`borrow:${keyBase}`, () => {
+            warmBorrowModalMaxAndPool(params);
+          });
+        }
+      : undefined,
+    onMintMouseEnter: bundle.userAddress
+      ? (e: MouseEvent) => {
+          stop(e);
+          bundle.debounced(`mint:${keyBase}`, () => {
+            warmMintModalRpc(params);
+          });
+        }
+      : undefined,
+  };
+}
+
+export function buildRepayHoverHandler(
+  bundle: ModalHoverPrefetchBundle,
+  asset: string,
+  poolId?: string,
+  configSymbol?: string,
+  marketId?: string,
+  networkIdOverride?: string
+) {
+  if (!bundle.userAddress) return undefined;
+  const networkId = (networkIdOverride ?? bundle.networkId) as NetworkId;
+  const params: MarketActionTokenParams = {
+    userAddress: bundle.userAddress,
+    networkId,
+    asset,
+    poolId,
+    configSymbol,
+    marketId,
+  };
+  const keyBase = [networkId, asset, poolId ?? "", configSymbol ?? "", marketId ?? ""].join(
+    ":"
+  );
+  return (e: MouseEvent) => {
+    e.stopPropagation();
+    bundle.debounced(`repay:${keyBase}`, () => {
+      warmRepayModalRpc(params);
+      bundle.warmWalletBalance?.(params);
+    });
+  };
+}
+
+export function buildWithdrawHoverHandler(
+  bundle: ModalHoverPrefetchBundle,
+  asset: string,
+  poolId?: string,
+  configSymbol?: string,
+  marketId?: string,
+  networkIdOverride?: string,
+  onWithdrawWarm?: (params: MarketActionTokenParams) => void
+) {
+  if (!bundle.userAddress) return undefined;
+  const networkId = (networkIdOverride ?? bundle.networkId) as NetworkId;
+  const params: MarketActionTokenParams = {
+    userAddress: bundle.userAddress,
+    networkId,
+    asset,
+    poolId,
+    configSymbol,
+    marketId,
+  };
+  const keyBase = [networkId, asset, poolId ?? "", configSymbol ?? "", marketId ?? ""].join(
+    ":"
+  );
+  return (e: MouseEvent) => {
+    e.stopPropagation();
+    bundle.debounced(`withdraw:${keyBase}`, () => {
+      onWithdrawWarm?.(params);
+    });
+  };
+}

--- a/src/utils/modalPrefetch.ts
+++ b/src/utils/modalPrefetch.ts
@@ -1,0 +1,309 @@
+/**
+ * Debounced hover prefetch for supply / borrow / withdraw / repay modals.
+ * Warms RPC read cache (see rpcReadCache) before the user clicks.
+ */
+
+import {
+  getAllTokensWithDisplayInfo,
+  getNetworkConfig,
+  getAlgorandNetworkFromNetworkId,
+  getFolksAdapterForPhase,
+  getTokenConfig,
+  type NetworkId,
+} from "@/config";
+import { calculateMaxBorrowAmount } from "@/services/adminService";
+import {
+  fetchUserBorrowBalance,
+  fetchUserDepositBalance,
+  fetchUserGlobalData,
+  fetchUserGlobalDataForPool,
+  fetchMarketInfoFromContract,
+  getMaxWithdrawableForMarket,
+} from "@/services/lendingService";
+import { estimateFolksDepositMintedFAssetAmount } from "@/services/folksDepositAdapter";
+import { fetchPoolCollateralMarketRowsForDeposit } from "@/utils/poolCollateralMarketRows";
+import { resolveSupplyBorrowToken } from "@/components/SupplyBorrowModal";
+import algorandService, { type AlgorandNetwork } from "@/services/algorandService";
+import { CONTRACT } from "ulujs";
+import {
+  APP_SPEC as LendingPoolAppSpec,
+  UserData,
+} from "@/clients/DorkFiLendingPoolClient";
+import algosdk from "algosdk";
+import BigNumber from "bignumber.js";
+
+export type MarketActionTokenParams = {
+  userAddress: string;
+  networkId: NetworkId;
+  asset: string;
+  poolId?: string;
+  configSymbol?: string;
+  marketId?: string;
+};
+
+function resolveActionToken(params: MarketActionTokenParams) {
+  const tokens = getAllTokensWithDisplayInfo(params.networkId);
+  return resolveSupplyBorrowToken(
+    tokens,
+    params.asset,
+    params.poolId,
+    params.configSymbol,
+    params.marketId ?? ""
+  );
+}
+
+/** Debounce + cooldown per cache key to avoid RPC spam on row hover. */
+export function createDebouncedPrefetch(cooldownMs = 2_500) {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const lastRun = new Map<string, number>();
+
+  return (key: string, run: () => void, delayMs = 80) => {
+    const pending = timers.get(key);
+    if (pending) clearTimeout(pending);
+    timers.set(
+      key,
+      setTimeout(() => {
+        timers.delete(key);
+        const now = Date.now();
+        if (now - (lastRun.get(key) ?? 0) < cooldownMs) return;
+        lastRun.set(key, now);
+        void run();
+      }, delayMs)
+    );
+  };
+}
+
+function prefetchKey(prefix: string, params: MarketActionTokenParams): string {
+  return [
+    prefix,
+    params.networkId,
+    params.userAddress,
+    params.asset,
+    params.poolId ?? "",
+    params.configSymbol ?? "",
+    params.marketId ?? "",
+  ].join(":");
+}
+
+/** Global user + per-asset borrow + pool collateral rows. */
+export function warmBorrowModalRpc(params: MarketActionTokenParams): void {
+  if (!params.userAddress) return;
+  const key = prefetchKey("borrow", params);
+  void Promise.all([
+    fetchUserGlobalData(params.userAddress, params.networkId),
+    (async () => {
+      const token = resolveActionToken(params);
+      if (!token?.poolId || !token.underlyingContractId) return;
+      await fetchUserBorrowBalance(
+        params.userAddress,
+        token.poolId,
+        token.underlyingContractId,
+        params.networkId
+      );
+      if (params.poolId) {
+        await fetchPoolCollateralMarketRowsForDeposit(
+          params.userAddress,
+          params.networkId,
+          params.poolId
+        );
+      }
+    })(),
+  ]).catch(() => undefined);
+}
+
+/** Same reads as borrow; used for sToken mint modal. */
+export const warmMintModalRpc = warmBorrowModalRpc;
+
+/** Per-pool global data + max borrow (SupplyBorrowModal mount). */
+export function warmBorrowModalMaxAndPool(params: MarketActionTokenParams): void {
+  warmBorrowModalRpc(params);
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId || !params.userAddress) {
+    return;
+  }
+  void fetchUserGlobalDataForPool(
+    params.userAddress,
+    params.networkId,
+    token.poolId
+  ).catch(() => undefined);
+  const storageAppId = getNetworkConfig(params.networkId)?.contracts
+    ?.appStorageId;
+  void calculateMaxBorrowAmount(
+    token.poolId,
+    params.userAddress,
+    token.underlyingContractId,
+    storageAppId ? Number(storageAppId) : undefined
+  ).catch(() => undefined);
+}
+
+/** Repay modal: global user data + current borrow balance. */
+export function warmRepayModalRpc(params: MarketActionTokenParams): void {
+  if (!params.userAddress) return;
+  void fetchUserGlobalData(params.userAddress, params.networkId).catch(
+    () => undefined
+  );
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+  void fetchUserBorrowBalance(
+    params.userAddress,
+    token.poolId,
+    token.underlyingContractId,
+    params.networkId
+  ).catch(() => undefined);
+}
+
+/** Withdraw indices (market + user deposit index). */
+export async function warmWithdrawIndicesRpc(
+  params: MarketActionTokenParams
+): Promise<void> {
+  if (!params.userAddress) return;
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+
+  try {
+    await fetchMarketInfoFromContract(
+      token.poolId,
+      token.underlyingContractId,
+      params.networkId
+    );
+  } catch {
+    /* ignore */
+  }
+
+  const networkConfig = getNetworkConfig(params.networkId);
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (!algodNet) return;
+
+  try {
+    const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
+    const ci = new CONTRACT(
+      Number(token.poolId),
+      clients.algod,
+      undefined,
+      { ...LendingPoolAppSpec.contract, events: [] },
+      {
+        addr: algosdk.encodeAddress(
+          algosdk.getApplicationAddress(Number(token.poolId)).publicKey
+        ),
+        sk: new Uint8Array(),
+      }
+    );
+    ci.setFee(2000);
+    await ci.get_user(
+      params.userAddress,
+      Number(token.underlyingContractId)
+    );
+  } catch {
+    /* ignore */
+  }
+  void networkConfig;
+}
+
+/** Max withdraw + optional Folks mint ratio (RPC cache). */
+export function warmMaxWithdrawRpc(params: MarketActionTokenParams): void {
+  if (!params.userAddress) return;
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+
+  void getMaxWithdrawableForMarket(
+    token.poolId,
+    token.underlyingContractId,
+    params.userAddress,
+    params.networkId,
+    token.decimals
+  ).catch(() => undefined);
+
+  const cfgSym = token.configKey ?? token.originalSymbol ?? token.symbol;
+  const rawTc = getTokenConfig(params.networkId, cfgSym);
+  const tc = Array.isArray(rawTc)
+    ? rawTc.find((c) => String(c.poolId) === String(token.poolId)) ?? rawTc[0]
+    : rawTc;
+  const folksSide = tc
+    ? getFolksAdapterForPhase(tc, "withdraw") ??
+      getFolksAdapterForPhase(tc, "deposit")
+    : undefined;
+  if (!folksSide || params.networkId !== "algorand-mainnet") return;
+
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (!algodNet) return;
+  void (async () => {
+    try {
+      const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
+      const oneUnderlyingAtomic = BigInt(
+        new BigNumber(1).shiftedBy(token.decimals).toFixed(0)
+      );
+      await estimateFolksDepositMintedFAssetAmount({
+        poolName: folksSide.folksParams.pool,
+        underlyingAmount: oneUnderlyingAtomic,
+        algod: clients.algod,
+      });
+    } catch {
+      /* ignore */
+    }
+  })();
+}
+
+export function warmWithdrawModalRpc(params: MarketActionTokenParams): void {
+  void warmWithdrawIndicesRpc(params);
+  warmMaxWithdrawRpc(params);
+}
+
+/** Markets detail sheet user position strip. */
+export function warmMarketDetailUserPositionRpc(
+  params: MarketActionTokenParams
+): void {
+  if (!params.userAddress) return;
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+  void Promise.all([
+    fetchUserDepositBalance(
+      params.userAddress,
+      token.poolId,
+      token.underlyingContractId,
+      params.networkId
+    ),
+    fetchUserBorrowBalance(
+      params.userAddress,
+      token.poolId,
+      token.underlyingContractId,
+      params.networkId
+    ),
+    fetchUserGlobalData(params.userAddress, params.networkId),
+    getMaxWithdrawableForMarket(
+      token.poolId,
+      token.underlyingContractId,
+      params.userAddress,
+      params.networkId,
+      token.decimals
+    ),
+  ]).catch(() => undefined);
+}
+
+export function configSymbolFromMarketRowKey(
+  marketRowKey?: string
+): string | undefined {
+  if (!marketRowKey) return undefined;
+  const parts = marketRowKey.split("|");
+  if (parts.length >= 2 && parts[1]) return parts[1];
+  return undefined;
+}
+
+export function marketRowKeyFromMarket(market: {
+  asset?: string;
+  poolId?: string;
+  configSymbol?: string;
+  _sortKey?: string;
+}): string | undefined {
+  if (market._sortKey) return market._sortKey;
+  if (market.configSymbol) {
+    return `${market.asset ?? ""}|${market.configSymbol}|${market.poolId ?? ""}`;
+  }
+  return undefined;
+}
+
+export function poolIdFromMarketRow(market: {
+  marketInfo?: { poolId?: string };
+  poolId?: string;
+}): string | undefined {
+  return market.marketInfo?.poolId ?? market.poolId;
+}

--- a/src/utils/portfolioDisplayHealthFactor.ts
+++ b/src/utils/portfolioDisplayHealthFactor.ts
@@ -1,0 +1,278 @@
+/**
+ * Portfolio headline health factor (worst pool HF, then aggregate fallback).
+ * Mirrors {@link Portfolio} `displayHealthFactor` logic for reuse in Markets modal, etc.
+ */
+
+import type { ChainGlobalUserRow, ChainUserDataRow } from "@/services/lendingService";
+import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
+import {
+  calculateUserHealthFactor,
+  normalizeLiquidationThresholdToDecimal,
+} from "@/utils/userHealth";
+
+export type PortfolioHealthDeposit = {
+  poolId?: string;
+  value?: number;
+  asset?: string;
+  marketId?: string;
+};
+
+export type MarketRowForHealth = {
+  symbol?: string;
+  asset?: string;
+  poolId?: string;
+  marketId?: string | number;
+  liquidationThreshold?: unknown;
+  marketInfo?: {
+    poolId?: string | number;
+    marketId?: string | number;
+    liquidationThreshold?: unknown;
+  };
+};
+
+export function saturateHealthFactorForDisplay(
+  healthFactor: number | null
+): number | null {
+  if (healthFactor === null) return null;
+  return Math.min(healthFactor, 3.0);
+}
+
+function marketRowForHealth(
+  rows: unknown[],
+  pos: {
+    marketId?: string | null;
+    poolId?: string | null;
+    displaySymbol?: string | null;
+  }
+): MarketRowForHealth | undefined {
+  const mid = pos.marketId != null ? String(pos.marketId) : "";
+  const pid = pos.poolId != null ? String(pos.poolId) : "";
+  if (mid !== "" && pid !== "") {
+    const hit = rows.find((raw) => {
+      const m = raw as MarketRowForHealth;
+      const mi = m.marketInfo;
+      const rowMid = String(m.marketId ?? mi?.marketId ?? "");
+      const rowPid = String(m.poolId ?? mi?.poolId ?? "");
+      return rowMid === mid && rowPid === pid;
+    });
+    if (hit) return hit as MarketRowForHealth;
+  }
+  const sym = pos.displaySymbol ?? "";
+  if (sym !== "" && pid !== "") {
+    const hit = rows.find((raw) => {
+      const m = raw as MarketRowForHealth;
+      return (
+        (m.symbol === sym || m.asset === sym) &&
+        String(m.poolId ?? m.marketInfo?.poolId ?? "") === pid
+      );
+    });
+    if (hit) return hit as MarketRowForHealth;
+  }
+  return marketRowForPortfolioPosition(rows, pos) as
+    | MarketRowForHealth
+    | undefined;
+}
+
+function liquidationThresholdFromMarketRow(
+  market: MarketRowForHealth | undefined
+): unknown {
+  if (!market) return undefined;
+  return market.liquidationThreshold ?? market.marketInfo?.liquidationThreshold;
+}
+
+export function minLiquidationThresholdForDeposits(
+  deposits: PortfolioHealthDeposit[],
+  marketData: unknown[]
+): number {
+  if (!deposits.length || !marketData.length) {
+    return normalizeLiquidationThresholdToDecimal(undefined);
+  }
+  const thresholds: number[] = [];
+  for (const deposit of deposits) {
+    if (!deposit.value || deposit.value <= 0) continue;
+    const market = marketRowForHealth(marketData, {
+      marketId: deposit.marketId,
+      poolId: deposit.poolId,
+      displaySymbol: deposit.asset,
+    });
+    const raw = liquidationThresholdFromMarketRow(market);
+    if (raw !== undefined && raw !== null) {
+      thresholds.push(normalizeLiquidationThresholdToDecimal(raw));
+    }
+  }
+  return thresholds.length > 0
+    ? Math.min(...thresholds)
+    : normalizeLiquidationThresholdToDecimal(undefined);
+}
+
+/** Min LT among listed market rows in a pool (fast path when deposit scan is too heavy). */
+export function minLtForPoolFromMarketRows(
+  poolId: string,
+  marketData: unknown[]
+): number {
+  const thresholds: number[] = [];
+  const pid = String(poolId);
+  for (const raw of marketData) {
+    const m = raw as MarketRowForHealth;
+    const rowPid = String(m.poolId ?? m.marketInfo?.poolId ?? "");
+    if (rowPid !== pid) continue;
+    const lt = liquidationThresholdFromMarketRow(m);
+    if (lt !== undefined && lt !== null) {
+      thresholds.push(normalizeLiquidationThresholdToDecimal(lt));
+    }
+  }
+  return thresholds.length > 0
+    ? Math.min(...thresholds)
+    : normalizeLiquidationThresholdToDecimal(undefined);
+}
+
+export function minLiquidationThresholdFromMarketRows(
+  marketData: unknown[]
+): number {
+  const thresholds: number[] = [];
+  for (const raw of marketData) {
+    const m = raw as MarketRowForHealth;
+    const lt = liquidationThresholdFromMarketRow(m);
+    if (lt !== undefined && lt !== null) {
+      thresholds.push(normalizeLiquidationThresholdToDecimal(lt));
+    }
+  }
+  return thresholds.length > 0
+    ? Math.min(...thresholds)
+    : normalizeLiquidationThresholdToDecimal(undefined);
+}
+
+function minLtForPool(
+  poolId: string,
+  deposits: PortfolioHealthDeposit[],
+  marketData: unknown[]
+): number {
+  const thresholds: number[] = [];
+  for (const deposit of deposits) {
+    if (String(deposit.poolId ?? "") !== poolId) continue;
+    if (!deposit.value || deposit.value <= 0) continue;
+    const market = marketRowForHealth(marketData, {
+      marketId: deposit.marketId,
+      poolId: deposit.poolId,
+      displaySymbol: deposit.asset,
+    });
+    const raw = liquidationThresholdFromMarketRow(market);
+    if (raw !== undefined && raw !== null) {
+      thresholds.push(normalizeLiquidationThresholdToDecimal(raw));
+    }
+  }
+  return thresholds.length > 0
+    ? Math.min(...thresholds)
+    : normalizeLiquidationThresholdToDecimal(undefined);
+}
+
+function parsePoolGlobalUsd(value: unknown): number {
+  try {
+    return Number(BigInt(String(value ?? 0)) / BigInt(1e12));
+  } catch {
+    return 0;
+  }
+}
+
+/** Deposits with `value > 0` from chain user rows (for LT lookup). */
+export function depositsForHealthFromChainUserData(
+  userData: ChainUserDataRow[]
+): PortfolioHealthDeposit[] {
+  const out: PortfolioHealthDeposit[] = [];
+  for (const row of userData) {
+    try {
+      if (BigInt(row.scaledDeposits) === 0n) continue;
+    } catch {
+      continue;
+    }
+    out.push({
+      poolId: row.poolId,
+      marketId: row.marketId ?? row.underlyingContractId,
+      value: 1,
+    });
+  }
+  return out;
+}
+
+export function sumGlobalUserTotals(globalUserData: ChainGlobalUserRow[]): {
+  totalCollateral: number;
+  totalBorrowed: number;
+} {
+  let totalCollateral = 0;
+  let totalBorrowed = 0;
+  for (const rec of globalUserData) {
+    totalCollateral += parsePoolGlobalUsd(rec.totalCollateralValue);
+    totalBorrowed += parsePoolGlobalUsd(rec.totalBorrowValue);
+  }
+  return { totalCollateral, totalBorrowed };
+}
+
+/**
+ * Same metric as Portfolio headline HF: minimum HF across pools with borrows,
+ * using per-pool `get_global_user` totals and min LT from user deposits in that pool.
+ */
+export function computePortfolioDisplayHealthFactor(args: {
+  globalUserData: ChainGlobalUserRow[] | Array<Record<string, unknown>>;
+  deposits: PortfolioHealthDeposit[];
+  marketData: unknown[];
+  totalCollateral?: number;
+  totalBorrowed?: number;
+  /**
+   * When true, derive pool LT from `marketData` rows (no per-market `get_user` deposit scan).
+   * Slightly conservative vs Portfolio but much faster for Markets modal.
+   */
+  useMarketRowsForPoolLt?: boolean;
+}): number | null {
+  const { globalUserData, deposits, marketData, useMarketRowsForPoolLt } = args;
+
+  const minLiquidationThresholdForHealth = useMarketRowsForPoolLt
+    ? minLiquidationThresholdFromMarketRows(marketData)
+    : minLiquidationThresholdForDeposits(deposits, marketData);
+
+  const summed =
+    args.totalCollateral !== undefined && args.totalBorrowed !== undefined
+      ? {
+          totalCollateral: args.totalCollateral,
+          totalBorrowed: args.totalBorrowed,
+        }
+      : sumGlobalUserTotals(globalUserData as ChainGlobalUserRow[]);
+
+  let worst: number | null = null;
+
+  if (Array.isArray(globalUserData) && globalUserData.length > 0) {
+    for (const item of globalUserData) {
+      const rec = item as Record<string, unknown>;
+      const poolId = String(rec.appId ?? rec.poolId ?? "");
+      if (!poolId) continue;
+
+      const collateral = parsePoolGlobalUsd(rec.totalCollateralValue);
+      const borrow = parsePoolGlobalUsd(rec.totalBorrowValue);
+      if (borrow <= 0) continue;
+
+      const lt = useMarketRowsForPoolLt
+        ? minLtForPoolFromMarketRows(poolId, marketData)
+        : minLtForPool(poolId, deposits, marketData);
+      const hf = calculateUserHealthFactor(
+        collateral,
+        borrow,
+        lt,
+        `pool:${poolId}`
+      );
+      if (hf != null && Number.isFinite(hf)) {
+        if (worst === null || hf < worst) {
+          worst = hf;
+        }
+      }
+    }
+  }
+
+  const aggregateFallback = calculateUserHealthFactor(
+    summed.totalCollateral,
+    summed.totalBorrowed,
+    minLiquidationThresholdForHealth,
+    "portfolio-aggregate-fallback"
+  );
+
+  const healthFactorValue = worst !== null ? worst : aggregateFallback;
+  return saturateHealthFactorForDisplay(healthFactorValue);
+}

--- a/src/utils/rpcReadCache.ts
+++ b/src/utils/rpcReadCache.ts
@@ -1,0 +1,68 @@
+/**
+ * Short-lived in-memory cache for expensive RPC / contract reads.
+ * Reduces duplicate calls when modals open and child effects mount together.
+ */
+
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+const DEFAULT_TTL_MS = 30_000;
+
+export function getRpcReadCache<T>(key: string): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value as T;
+}
+
+export function setRpcReadCache<T>(
+  key: string,
+  value: T,
+  ttlMs: number = DEFAULT_TTL_MS
+): void {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+export function invalidateRpcReadCache(prefix?: string): void {
+  if (!prefix) {
+    cache.clear();
+    return;
+  }
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+/** Deduplicate concurrent in-flight requests for the same key. */
+const inflight = new Map<string, Promise<unknown>>();
+
+export async function withRpcReadCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttlMs: number = DEFAULT_TTL_MS
+): Promise<T> {
+  const cached = getRpcReadCache<T>(key);
+  if (cached !== undefined) return cached;
+
+  const pending = inflight.get(key) as Promise<T> | undefined;
+  if (pending) return pending;
+
+  const promise = fetcher()
+    .then((value) => {
+      setRpcReadCache(key, value, ttlMs);
+      return value;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}


### PR DESCRIPTION
## Summary

Merges `beta` into `next` with markets UI fixes, faster modals, and more reliable portfolio loading for xChain wallets.

### Markets & market detail modal
- **Mobile filter tabs** (#338, #342): Fix A/B/D tabs overlapping market cards; use a single-row grid, short labels on mobile, `Select` on small screens, and correct pool badges from config `poolId`.
- **Your Position in market modal** (#340, #341): Load per-market supplied/borrowed with portfolio-level health (worst-pool HF), loading/error states, migration-aware token resolution, and cached RPC reads via `rpcReadCache`.
- **Position bar**: Hide withdrawable, borrowable, and health in the market modal position bar.

### Portfolio & xChain
- **xChain loading races** (#322, #334): Deduplicate `fetchUser`, cancel stale address updates, reset in-flight state on wallet switch, and add a 6s market-data fallback when user API is slow or empty.

### Modals & performance
- **Supply/Borrow latency** (#317, #339): Open modals immediately with background loading, RPC read cache, parallel pool fetches, hover prefetch (`modalPrefetch`), and fixes for detail-modal re-fetch loops and position ref crashes.

## Test plan
- [ ] **Markets (mobile)**: Filter by A/B/D; confirm tabs do not overlap cards and pool badges match the selected pool.
- [ ] **Market detail modal**: Open from Markets; confirm Your Position loads (supplied/borrowed) and position bar omits withdrawable/borrowable/health.
- [ ] **xChain wallet**: Connect via RainbowKit/EVM; switch accounts and reconnect; confirm portfolio and markets load without stale or empty state.
- [ ] **Supply/Borrow/Repay/Mint**: Open from Markets and Portfolio; confirm modals open quickly; hover prefetch feels responsive; no infinite loading on detail modal.
- [ ] **Regression**: Desktop/tablet market tables and portfolio views behave as before.