### PR TITLE
fix(portfolio): broadcast manual NFT claims on Voi mainnet

### DIFF
--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -564,9 +564,11 @@ const Portfolio = () => {
         duration: 10000,
       });
       const stxns = await signTransactions(unsignedTxns);
-      const algorandNetwork = getAlgorandNetworkFromNetworkId(currentNetwork as NetworkId);
+      // NFT holder claims are built for Voi mainnet; do not use the wallet network selector.
+      const NFT_HOLDER_CLAIM_NETWORK_ID = "voi-mainnet" as const;
+      const algorandNetwork = getAlgorandNetworkFromNetworkId(NFT_HOLDER_CLAIM_NETWORK_ID);
       if (!algorandNetwork) {
-        throw new Error(`Invalid network: ${currentNetwork}`);
+        throw new Error(`Invalid network: ${NFT_HOLDER_CLAIM_NETWORK_ID}`);
       }
       const algorandClients =
         await algorandService.initializeClientsForTransactions(algorandNetwork);
@@ -580,14 +582,7 @@ const Portfolio = () => {
         description: `Transaction confirmed: ${res.txid}`,
       });
     },
-    [
-      signTransactions,
-      displayAddress,
-      activeWallet,
-      toast,
-      currentNetwork,
-      queryClient,
-    ]
+    [signTransactions, displayAddress, activeWallet, toast, queryClient]
   );
 
   const nftHolderClaimableDisplayAmount = nftHolderClaimAgent


### PR DESCRIPTION
## Summary
- Manual NFT holder claim submit/confirm now always uses **Voi mainnet** (`voi-mainnet` → `voimain`) algod clients, instead of `currentNetwork` from the wallet selector.
- Fixes manual claim failing when the UI is set to Algorand while unsigned txns from the claim agent are Voi-scoped.

## Test plan
- [ ] Connect wallet, open Portfolio → NFT holder rewards → Manual claim
- [ ] With network set to **Algorand**, load unsigned claim, sign, and confirm tx lands on Voi
- [ ] With network set to **Voi Network**, same flow still succeeds

Closes #336 (network bug); batch/multi-NFT UX can follow separately.

Made with [Cursor](https://cursor.com)