### PR TITLE
Release beta: NFT manual claim network fix and borrow modal supply stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.711",
+  "version": "0.1.713",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -564,9 +564,11 @@ const Portfolio = () => {
         duration: 10000,
       });
       const stxns = await signTransactions(unsignedTxns);
-      const algorandNetwork = getAlgorandNetworkFromNetworkId(currentNetwork as NetworkId);
+      // NFT holder claims are built for Voi mainnet; do not use the wallet network selector.
+      const NFT_HOLDER_CLAIM_NETWORK_ID = "voi-mainnet" as const;
+      const algorandNetwork = getAlgorandNetworkFromNetworkId(NFT_HOLDER_CLAIM_NETWORK_ID);
       if (!algorandNetwork) {
-        throw new Error(`Invalid network: ${currentNetwork}`);
+        throw new Error(`Invalid network: ${NFT_HOLDER_CLAIM_NETWORK_ID}`);
       }
       const algorandClients =
         await algorandService.initializeClientsForTransactions(algorandNetwork);
@@ -580,14 +582,7 @@ const Portfolio = () => {
         description: `Transaction confirmed: ${res.txid}`,
       });
     },
-    [
-      signTransactions,
-      displayAddress,
-      activeWallet,
-      toast,
-      currentNetwork,
-      queryClient,
-    ]
+    [signTransactions, displayAddress, activeWallet, toast, queryClient]
   );
 
   const nftHolderClaimableDisplayAmount = nftHolderClaimAgent

--- a/src/components/SupplyBorrowStats.tsx
+++ b/src/components/SupplyBorrowStats.tsx
@@ -1076,12 +1076,29 @@ const SupplyBorrowStats = ({
                     <InfoIcon className="h-3 w-3 text-slate-400 dark:text-slate-500" />
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Total amount borrowed (minted) from this market</p>
+                    <p>Total amount supplied to this market</p>
                   </TooltipContent>
                 </Tooltip>
               </div>
               <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
-                {Math.abs(assetData.totalBorrow || 0).toLocaleString()} {asset}
+                {(assetData.totalSupply ?? 0).toLocaleString()} {asset}
+              </span>
+            </div>
+
+            <div className="flex justify-between items-center">
+              <div className="flex items-center gap-1.5 md:gap-2">
+                <span className="text-[10px] md:text-sm text-slate-500 dark:text-slate-400">Total Borrows</span>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <InfoIcon className="h-3 w-3 text-slate-400 dark:text-slate-500" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Total amount currently borrowed from this market</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
+                {Math.abs(assetData.totalBorrow ?? 0).toLocaleString()} {asset}
               </span>
             </div>
           </>


### PR DESCRIPTION
## Summary

Merges `beta` into `next` with two targeted fixes (version **0.1.713**).

### Portfolio — NFT holder manual claim (#357, fixes #336)
- **Voi mainnet override**: Manual NFT holder claim submit/confirm always uses `voi-mainnet` (`voimain`) algod clients instead of the wallet network selector.
- **Symptom fixed**: Manual claim worked on **Voi Network** but failed when **Algorand** was selected, because broadcast/confirmation followed Algorand status while unsigned txns from the claim agent are Voi-scoped.

### Borrow modal — market stats (#346, fixes #335)
- **Total Supply**: Show `totalSupply` with copy describing supplied liquidity (was incorrectly showing `totalBorrow` with a borrow tooltip).
- **Total Borrows**: New row under Total Supply for `totalBorrow` with correct tooltip.

## Test plan
- [ ] **NFT manual claim (Algorand selected)**: Portfolio → NFT holder rewards → Manual claim → sign → confirm tx lands on Voi; claim agent/portfolio refresh.
- [ ] **NFT manual claim (Voi selected)**: Same flow still succeeds (regression).
- [ ] **Borrow modal**: Open borrow for a market; Total Supply matches supplied liquidity; Total Borrows matches borrowed amount; tooltips read correctly.
- [ ] **Regression**: Paid agent claim path, markets/portfolio modals, and xChain flows unchanged.