### PR TITLE
feat(nft): on-chain UNIT drip manual claim in portfolio modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.713",
+  "version": "0.1.726",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ import MarketsTable from "./components/MarketsTable";
 import Dashboard from "./components/Dashboard";
 import Portfolio from "./components/Portfolio";
 import PortfolioPage from "./pages/PortfolioPage";
-
 //const LAUNCH_TIMESTAMP = Date.UTC(2025, 10, 21, 2, 0, 0); // Nov 20, 2025 6:00 PM PST (Nov 21, 2025 2:00 AM UTC)
 const LAUNCH_TIMESTAMP = Date.now();
 

--- a/src/components/LocaleNumberSettings.tsx
+++ b/src/components/LocaleNumberSettings.tsx
@@ -163,7 +163,7 @@ export function LocaleNumberSettings() {
                 )}
               </Button>
               <p className="text-xs text-muted-foreground mt-1.5">
-                Writes preferred locale to your Envoi name on Voi Mainnet.
+                Writes preferred locale to your Envoi name on Voi Network.
               </p>
             </div>
           )}

--- a/src/components/MintModal.tsx
+++ b/src/components/MintModal.tsx
@@ -384,7 +384,7 @@ const MintModal = ({
 
         if (!isSupported) {
           const networkName =
-            networkId === "voi-mainnet" ? "VOI Mainnet" : "Algorand Mainnet";
+            networkId === "voi-mainnet" ? "VOI Network" : "Algorand Mainnet";
           throw new Error(
             `Your wallet (${activeWallet.metadata?.name || walletId
             }) does not support ${networkName}. Please switch to a compatible wallet or network.`

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -552,39 +552,6 @@ const Portfolio = () => {
     [nftHolderClaimAgent]
   );
 
-  const submitManualNftHolderClaim = useCallback(
-    async (unsignedTxns: Uint8Array[]) => {
-      if (!signTransactions || !displayAddress) {
-        throw new Error("Connect a wallet to sign this claim.");
-      }
-      const walletName = activeWallet?.metadata?.name || "your wallet";
-      toast({
-        title: "Sign in your wallet",
-        description: `Approve the manual NFT reward claim in ${walletName}.`,
-        duration: 10000,
-      });
-      const stxns = await signTransactions(unsignedTxns);
-      // NFT holder claims are built for Voi mainnet; do not use the wallet network selector.
-      const NFT_HOLDER_CLAIM_NETWORK_ID = "voi-mainnet" as const;
-      const algorandNetwork = getAlgorandNetworkFromNetworkId(NFT_HOLDER_CLAIM_NETWORK_ID);
-      if (!algorandNetwork) {
-        throw new Error(`Invalid network: ${NFT_HOLDER_CLAIM_NETWORK_ID}`);
-      }
-      const algorandClients =
-        await algorandService.initializeClientsForTransactions(algorandNetwork);
-      const res = await algorandClients.algod.sendRawTransaction(stxns).do();
-      await waitForConfirmation(algorandClients.algod, res.txid, 4);
-      void queryClient.invalidateQueries({
-        queryKey: ["nft-holder-claim-agent", displayAddress],
-      });
-      toast({
-        title: "Manual claim submitted",
-        description: `Transaction confirmed: ${res.txid}`,
-      });
-    },
-    [signTransactions, displayAddress, activeWallet, toast, queryClient]
-  );
-
   const nftHolderClaimableDisplayAmount = nftHolderClaimAgent
     ? Number.parseFloat(nftHolderClaimAgent.totalClaimableDisplay)
     : NaN;
@@ -10444,11 +10411,6 @@ const Portfolio = () => {
         open={nftClaimManualModalOpen}
         onOpenChange={setNftClaimManualModalOpen}
         beneficiaryAddress={displayAddress ?? ""}
-        submitManualNftClaim={
-          !isViewOnly && displayAddress && signTransactions
-            ? submitManualNftHolderClaim
-            : undefined
-        }
       />
 
       <NftHolderClaimSuccessModal
@@ -10480,7 +10442,7 @@ const Portfolio = () => {
           try {
             // Only supported on voi-mainnet
             if (currentNetwork !== "voi-mainnet") {
-              throw new Error("Profile NFTs are only supported on Voi Mainnet");
+              throw new Error("Profile NFTs are only supported on Voi Network");
             }
 
             const resolverNetwork = "mainnet";

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -2246,7 +2246,7 @@ const SupplyBorrowModal = ({
 
         if (!isSupported) {
           const networkName =
-            networkId === "voi-mainnet" ? "VOI Mainnet" : "Algorand Mainnet";
+            networkId === "voi-mainnet" ? "VOI Network" : "Algorand Mainnet";
           throw new Error(
             `Your wallet (${activeWallet.metadata?.name || walletId
             }) does not support ${networkName}. Please switch to a compatible wallet or network.`
@@ -2373,7 +2373,7 @@ const SupplyBorrowModal = ({
           (!isVOIWallet && !isAlgorandWallet && !isWalletConnect);
         if (!isSupported) {
           const networkName =
-            networkId === "voi-mainnet" ? "VOI Mainnet" : "Algorand Mainnet";
+            networkId === "voi-mainnet" ? "VOI Network" : "Algorand Mainnet";
           throw new Error(
             `Your wallet (${activeWallet.metadata?.name || walletId
             }) does not support ${networkName}. Please switch to a compatible wallet or network.`
@@ -3091,7 +3091,7 @@ const SupplyBorrowModal = ({
 
         if (!isSupported) {
           const networkName =
-            networkId === "voi-mainnet" ? "VOI Mainnet" : "Algorand Mainnet";
+            networkId === "voi-mainnet" ? "VOI Network" : "Algorand Mainnet";
           throw new Error(
             `Your wallet (${activeWallet.metadata?.name || walletId
             }) does not support ${networkName}. Please switch to a compatible wallet or network.`

--- a/src/components/WithdrawModal.tsx
+++ b/src/components/WithdrawModal.tsx
@@ -1124,7 +1124,7 @@ const WithdrawModal = ({
 
         if (!isSupported) {
           const networkName =
-            networkId === "voi-mainnet" ? "VOI Mainnet" : "Algorand Mainnet";
+            networkId === "voi-mainnet" ? "VOI Network" : "Algorand Mainnet";
           throw new Error(
             `Your wallet (${
               activeWallet.metadata?.name || walletId

--- a/src/components/portfolio/NftHolderClaimManualModal.tsx
+++ b/src/components/portfolio/NftHolderClaimManualModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -8,165 +8,41 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useToast } from "@/hooks/use-toast";
-import {
-  fetchNftHolderUnsignedClaim,
-  resolveNftHolderClaimRelayerAddress,
-  type NftHolderUnsignedClaimResponse,
-} from "@/services/paidWorkflowGateway";
-import { fetchArc72NftImageUrl } from "@/services/nftService";
-import { Loader2, RefreshCw } from "lucide-react";
+import { DORK_DRIP_CONFIG, DORK_V2_DRIP_CONFIG } from "@/config/nftDrips";
+import { NFT_DRIP_CLAIMS_PER_GROUP } from "@/services/nftDripClaimService";
+import { UnitNftDripTool } from "@/components/tools/UnitNftDripTool";
 import { cn } from "@/lib/utils";
 
-function formatUnsignedClaimErrors(errors: unknown[] | undefined): string | null {
-  if (!errors?.length) return null;
-  const bits: string[] = [];
-  for (const e of errors) {
-    if (typeof e === "string") {
-      bits.push(e);
-      continue;
-    }
-    if (e && typeof e === "object" && "message" in e) {
-      const m = (e as { message?: unknown }).message;
-      if (typeof m === "string") {
-        bits.push(m);
-        continue;
-      }
-    }
-    try {
-      bits.push(JSON.stringify(e));
-    } catch {
-      bits.push(String(e));
-    }
-  }
-  return bits.length ? bits.join(" — ") : null;
-}
-
-function txnBase64ToUint8(txnBase64: string): Uint8Array {
-  return Uint8Array.from(atob(txnBase64.trim()), (c) => c.charCodeAt(0));
-}
+type DripTab = "dork" | "dork-v2";
 
 type NftHolderClaimManualModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Portfolio / claim beneficiary (58-char AVM). */
   beneficiaryAddress: string;
-  /** Sign unsigned bytes then broadcast (Portfolio wires algod + network). */
-  submitManualNftClaim?: (unsignedTxns: Uint8Array[]) => Promise<void>;
 };
 
 export function NftHolderClaimManualModal({
   open,
   onOpenChange,
   beneficiaryAddress,
-  submitManualNftClaim,
 }: NftHolderClaimManualModalProps) {
-  const { toast } = useToast();
-  const [data, setData] = useState<NftHolderUnsignedClaimResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [nftImageUrl, setNftImageUrl] = useState<string | null>(null);
-  const [nftImageLoading, setNftImageLoading] = useState(false);
-
-  const loadUnsigned = useCallback(async () => {
-    const addr = beneficiaryAddress.trim();
-    if (!addr) {
-      setData(null);
-      setError("No portfolio address.");
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetchNftHolderUnsignedClaim({
-        beneficiaryAddress: addr,
-        relayerAddress: resolveNftHolderClaimRelayerAddress(addr),
-      });
-      setData(res);
-    } catch (e) {
-      setData(null);
-      setError(e instanceof Error ? e.message : "Failed to load unsigned claim");
-    } finally {
-      setLoading(false);
-    }
-  }, [beneficiaryAddress]);
+  const [tab, setTab] = useState<DripTab>("dork");
 
   useEffect(() => {
-    if (!open) return;
-    void loadUnsigned();
-  }, [open, loadUnsigned]);
+    if (!open) setTab("dork");
+  }, [open]);
 
-  useEffect(() => {
-    if (!open) {
-      setNftImageUrl(null);
-      setNftImageLoading(false);
-      return;
-    }
-    const cid = data?.slot?.collectionId;
-    const tid = data?.slot?.tokenId?.trim();
-    if (typeof cid !== "number" || !tid) {
-      setNftImageUrl(null);
-      setNftImageLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setNftImageLoading(true);
-    setNftImageUrl(null);
-    void fetchArc72NftImageUrl(cid, tid)
-      .then((url) => {
-        if (!cancelled) setNftImageUrl(url);
-      })
-      .catch(() => {
-        if (!cancelled) setNftImageUrl(null);
-      })
-      .finally(() => {
-        if (!cancelled) setNftImageLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, data?.slot?.collectionId, data?.slot?.tokenId]);
-
-  const sortedTxns = useMemo(() => {
-    if (!data?.transactions?.length) return [];
-    return [...data.transactions].sort((a, b) => a.groupIndex - b.groupIndex);
-  }, [data]);
-
-  const errDetail = formatUnsignedClaimErrors(data?.errors);
-  const canSubmit =
-    Boolean(submitManualNftClaim) &&
-    data?.claimable === true &&
-    sortedTxns.length > 0 &&
-    !loading &&
-    !submitting;
-
-  const handleSubmit = async () => {
-    if (!submitManualNftClaim || !sortedTxns.length) return;
-    setSubmitting(true);
-    try {
-      const unsigned = sortedTxns.map((t) => txnBase64ToUint8(t.txnBase64));
-      await submitManualNftClaim(unsigned);
-      onOpenChange(false);
-    } catch (e) {
-      toast({
-        title: "Manual claim failed",
-        description: e instanceof Error ? e.message : "Unknown error while signing or sending.",
-        variant: "destructive",
-      });
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const config = tab === "dork" ? DORK_DRIP_CONFIG : DORK_V2_DRIP_CONFIG;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[min(90vh,880px)] w-full max-w-[min(100vw-1.5rem,42rem)] overflow-y-auto overflow-x-hidden border-slate-800 bg-slate-950 p-0 pt-12 text-slate-100 shadow-2xl sm:max-w-3xl sm:pt-14 z-[110]">
+      <DialogContent className="max-h-[min(92vh,920px)] w-full max-w-[min(100vw-1.5rem,44rem)] overflow-y-auto overflow-x-hidden border-slate-800 bg-slate-950 p-0 pt-12 text-slate-100 shadow-2xl sm:max-w-4xl sm:pt-14 z-[110]">
         <div className="border-b border-slate-800">
           <div className="relative w-full overflow-hidden bg-slate-950">
             <img
               src="/nft-reward-agent-hero.png"
-              alt="Manual claim ready — whale AI agent illustration; review rewards and sign when you choose"
+              alt="Manual UNIT drip claim — review NFT rewards and sign with your wallet"
               className="block h-auto w-full max-w-none align-middle"
               loading="eager"
               decoding="async"
@@ -174,130 +50,53 @@ export function NftHolderClaimManualModal({
           </div>
         </div>
 
-        <div className="space-y-3 px-8 py-5 sm:px-10 sm:py-6">
+        <div className="space-y-3 px-6 py-5 sm:px-8 sm:py-6">
           <DialogHeader className="space-y-2 pr-6 text-left sm:pr-8">
             <DialogTitle className="text-left text-lg font-semibold tracking-tight text-white">
               Manual claim{" "}
-              <span className="text-emerald-400">ready</span>
+              <span className="text-emerald-400">on-chain</span>
             </DialogTitle>
             <DialogDescription className="text-left text-xs leading-relaxed text-slate-400">
-              Your rewards are ready to be claimed. Review the details below and sign with your
-              connected AVM wallet when you are ready.
+              Load your NFTs and claim up to {NFT_DRIP_CLAIMS_PER_GROUP} rewards at a time.
             </DialogDescription>
           </DialogHeader>
-        <div className="space-y-3 pt-1">
-          {loading ? (
-            <div className="flex items-center justify-center gap-2 py-8 text-sm text-slate-400">
-              <Loader2 className="h-5 w-5 animate-spin shrink-0" aria-hidden />
-              Loading claim info
-            </div>
-          ) : error ? (
-            <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-red-200">
-              {error}
-            </p>
-          ) : data ? (
-            <div className="space-y-3 text-xs">
-              <p>
-                <span className="text-slate-500">Claimable:</span>{" "}
-                <span className={data.claimable ? "text-emerald-400" : "text-amber-300"}>
-                  {data.claimable ? "yes" : "no"}
-                </span>
-                {sortedTxns.length ? (
-                  <span className="tabular-nums text-slate-500">
-                    {" "}
-                    · {sortedTxns.length} transaction{sortedTxns.length === 1 ? "" : "s"}
-                  </span>
-                ) : null}
-              </p>
-              {data.slot ? (
-                <div className="flex gap-3 rounded-lg border border-slate-800 bg-slate-900/40 p-3 text-[11px] text-slate-400">
-                  <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg border border-slate-700/80 bg-slate-950">
-                    {nftImageLoading ? (
-                      <div className="flex h-full w-full items-center justify-center">
-                        <Loader2 className="h-6 w-6 animate-spin text-slate-500" aria-hidden />
-                      </div>
-                    ) : nftImageUrl ? (
-                      <img
-                        src={nftImageUrl}
-                        alt={`NFT #${data.slot.tokenId ?? ""}`.trim() || "Reward NFT"}
-                        className="h-full w-full object-cover"
-                        loading="lazy"
-                        decoding="async"
-                        onError={() => setNftImageUrl(null)}
-                      />
-                    ) : (
-                      <div
-                        className="flex h-full w-full items-center justify-center text-[9px] uppercase tracking-wide text-slate-600"
-                        aria-hidden
-                      >
-                        NFT
-                      </div>
-                    )}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="font-semibold text-slate-300">
-                      {data.slot.campaignName ?? data.slot.campaignId ?? "Reward slot"}
-                    </p>
-                    {data.slot.rewardSymbol != null || data.slot.claimableDisplay != null ? (
-                      <p className="mt-1">
-                        {data.slot.claimableDisplay != null ? (
-                          <span className="tabular-nums text-white">{data.slot.claimableDisplay}</span>
-                        ) : null}{" "}
-                        {data.slot.rewardSymbol != null ? (
-                          <span className="text-slate-300">{data.slot.rewardSymbol}</span>
-                        ) : null}
-                      </p>
-                    ) : null}
-                    {data.slot.tokenId != null ? (
-                      <p className="mt-1 text-slate-500">
-                        Token <span className="font-mono text-slate-400">{data.slot.tokenId}</span>
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              ) : null}
-              {errDetail ? <p className="text-red-300/90">{errDetail}</p> : null}
-            </div>
-          ) : null}
 
           <div className="flex flex-wrap gap-2">
             <Button
               type="button"
-              variant="outline"
               size="sm"
-              className="border-slate-600 text-slate-200"
-              disabled={loading || !beneficiaryAddress.trim()}
-              onClick={() => void loadUnsigned()}
+              variant={tab === "dork" ? "default" : "outline"}
+              className={cn(
+                tab === "dork" && "bg-emerald-800 hover:bg-emerald-700",
+                tab !== "dork" && "border-slate-600 text-slate-200"
+              )}
+              onClick={() => setTab("dork")}
             >
-              <RefreshCw className={cn("mr-1.5 h-3.5 w-3.5", loading && "animate-spin")} aria-hidden />
-              Refresh
+              Dorks
             </Button>
             <Button
               type="button"
-              variant="default"
               size="sm"
-              className="bg-emerald-700 text-white hover:bg-emerald-600 disabled:opacity-50"
-              disabled={!canSubmit}
-              onClick={() => void handleSubmit()}
-            >
-              {submitting ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 shrink-0 animate-spin" aria-hidden />
-                  Signing…
-                </>
-              ) : (
-                "Claim"
+              variant={tab === "dork-v2" ? "default" : "outline"}
+              className={cn(
+                tab === "dork-v2" && "bg-emerald-800 hover:bg-emerald-700",
+                tab !== "dork-v2" && "border-slate-600 text-slate-200"
               )}
+              onClick={() => setTab("dork-v2")}
+            >
+              Dorks V2
             </Button>
           </div>
-          {!submitManualNftClaim ? (
-            <p className="text-[10px] text-amber-200/90">
-              Connect a wallet with signing enabled to submit this group from the app.
-            </p>
-          ) : null}
+
+          <UnitNftDripTool
+            key={tab}
+            config={config}
+            requiredAddress={beneficiaryAddress.trim()}
+            compact
+          />
         </div>
-        </div>
-        <DialogFooter className="border-t border-slate-800/80 px-8 py-5 sm:justify-center sm:px-10 sm:py-5">
+
+        <DialogFooter className="border-t border-slate-800/80 px-6 py-4 sm:justify-center sm:px-8">
           <Button
             type="button"
             variant="ghost"

--- a/src/components/portfolio/NftHolderRewardsModalBody.tsx
+++ b/src/components/portfolio/NftHolderRewardsModalBody.tsx
@@ -14,9 +14,12 @@ import {
   X,
 } from "lucide-react";
 import type { QueryClient } from "@tanstack/react-query";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { useNetwork } from "@/contexts/NetworkContext";
+import { getNetworkConfig } from "@/config";
 import type { NftHolderClaimSuccessDetails } from "@/components/portfolio/NftHolderClaimSuccessModal";
 import { NftHolderRewardsGatewayPaySection } from "./NftHolderRewardsGatewayPaySection";
 
@@ -127,6 +130,32 @@ export function NftHolderRewardsModalBody({
   onRequestOpenManualClaim,
   eligibilitySnapshot,
 }: NftHolderRewardsModalBodyProps) {
+  const { toast } = useToast();
+  const { currentNetwork, switchNetwork, isSwitchingNetwork } = useNetwork();
+  const [switchingToVoi, setSwitchingToVoi] = useState(false);
+  const isVoiNetwork = currentNetwork === "voi-mainnet";
+  const voiNetworkLabel = getNetworkConfig("voi-mainnet").name;
+
+  const handleSwitchToVoi = async () => {
+    if (isVoiNetwork || isSwitchingNetwork || switchingToVoi) return;
+    setSwitchingToVoi(true);
+    try {
+      await switchNetwork("voi-mainnet");
+      toast({
+        title: `Switched to ${voiNetworkLabel}`,
+        description: "You can open manual claim now.",
+      });
+    } catch (e) {
+      toast({
+        title: "Could not switch network",
+        description: e instanceof Error ? e.message : "Try again from the network menu.",
+        variant: "destructive",
+      });
+    } finally {
+      setSwitchingToVoi(false);
+    }
+  };
+
   const errText =
     claimAgentFetchError instanceof Error ? claimAgentFetchError.message : null;
   const agentOk = Boolean(claimAgent?.eligible ?? claimAgent?.claimable);
@@ -374,26 +403,55 @@ export function NftHolderRewardsModalBody({
 
         {displayAddress ? (
           <div className="space-y-4">
-            <div className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-sky-300/95">
-                Claim manually
-              </p>
-              <p className="mt-1.5 text-[11px] leading-relaxed text-slate-400">
-                Skip the in-app Base payer ({feeUsd} USDC x402). Opens the manual claim dialog so you
-                can review and sign on-chain yourself.
-              </p>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="mt-3 border-sky-500/40 text-sky-100 hover:bg-sky-950/60 hover:text-white"
-                disabled={!onRequestOpenManualClaim}
-                onClick={() => onRequestOpenManualClaim?.()}
-              >
-                <ExternalLink className="mr-2 h-3.5 w-3.5 shrink-0" aria-hidden />
-                Open manual claim
-              </Button>
-            </div>
+            {isVoiNetwork ? (
+              <div className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-sky-300/95">
+                  Claim manually
+                </p>
+                <p className="mt-1.5 text-[11px] leading-relaxed text-slate-400">
+                  Skip the in-app Base payer ({feeUsd} USDC x402). Opens the UNIT drip tool on{" "}
+                  {voiNetworkLabel} — up to 6 NFTs per wallet approval; claim again for more.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3 border-sky-500/40 text-sky-100 hover:bg-sky-950/60 hover:text-white"
+                  disabled={!onRequestOpenManualClaim}
+                  onClick={() => onRequestOpenManualClaim?.()}
+                >
+                  <ExternalLink className="mr-2 h-3.5 w-3.5 shrink-0" aria-hidden />
+                  Open manual claim
+                </Button>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-amber-500/30 bg-amber-950/20 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-amber-200/95">
+                  Claim manually
+                </p>
+                <p className="mt-1.5 text-[11px] leading-relaxed text-slate-400">
+                  On-chain UNIT drip claims run on {voiNetworkLabel}. Switch from{" "}
+                  {getNetworkConfig(currentNetwork).name} to use manual claim.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3 border-amber-500/40 text-amber-100 hover:bg-amber-950/50 hover:text-white"
+                  disabled={isSwitchingNetwork || switchingToVoi}
+                  onClick={() => void handleSwitchToVoi()}
+                >
+                  {isSwitchingNetwork || switchingToVoi ? (
+                    <>
+                      <Loader2 className="mr-2 h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
+                      Switching…
+                    </>
+                  ) : (
+                    `Switch to ${voiNetworkLabel}`
+                  )}
+                </Button>
+              </div>
+            )}
             <div className="rounded-2xl border border-slate-700/80 bg-slate-900/30 p-4">
               <NftHolderRewardsGatewayPaySection
                 algorandPortfolioAddress={displayAddress}

--- a/src/components/tools/UnitNftDripTool.tsx
+++ b/src/components/tools/UnitNftDripTool.tsx
@@ -1,0 +1,632 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useWallet } from "@txnlab/use-wallet-react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useToast } from "@/hooks/use-toast";
+import { getAlgorandNetworkFromNetworkId } from "@/config";
+import type { UnitNftDripCampaignConfig } from "@/config/nftDrips";
+import {
+  fetchUserNFTs,
+  normalizeNftMetadataImageUrl,
+  parseNFTMetadata,
+  type NFTToken,
+} from "@/services/nftService";
+import algorandService from "@/services/algorandService";
+import { createSigningBatchesFromEncoded } from "@/lib/algorand/grouping";
+import { signAllEncodedBatches } from "@/lib/algorand/signing";
+import { submitSignedGroups } from "@/lib/algorand/submission";
+import {
+  buildNftDripClaimSigningBundle,
+  formatDripRewardAmount,
+  NFT_DRIP_CLAIMS_PER_GROUP,
+  readNftDripInfo,
+  type NftDripClaimTarget,
+  type NftDripInfo,
+} from "@/services/nftDripClaimService";
+import { getTransactionErrorFeedback } from "@/utils/errorUtils";
+import { cn } from "@/lib/utils";
+
+const PAGE_SIZE = 12;
+const DRIP_READ_CONCURRENCY = 10;
+const VOI_DRIP_NETWORK = "voi-mainnet" as const;
+const MAX_CLAIMS_PER_ACTION = NFT_DRIP_CLAIMS_PER_GROUP;
+
+function tokenKey(contractId: number, tokenId: string): string {
+  return `${contractId}-${tokenId}`;
+}
+
+type ParsedNft = {
+  tokenId: string;
+  contractId: number;
+  name: string;
+  image: string;
+};
+
+export type UnitNftDripToolProps = {
+  config: UnitNftDripCampaignConfig;
+  /** When set, wallet must match this address (portfolio manual claim). */
+  requiredAddress?: string;
+  compact?: boolean;
+};
+
+export function UnitNftDripTool({ config, requiredAddress, compact }: UnitNftDripToolProps) {
+  const { activeAccount, signTransactions } = useWallet();
+  const { toast } = useToast();
+  const [tokens, setTokens] = useState<ParsedNft[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  /** Load failures only — must not hide the claim UI after a cancelled wallet prompt. */
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [claimingKey, setClaimingKey] = useState<string | null>(null);
+  const [dripInfoByKey, setDripInfoByKey] = useState<Record<string, NftDripInfo | null>>({});
+  const [dripLoadingByKey, setDripLoadingByKey] = useState<Record<string, boolean>>({});
+  const [dripRefreshTrigger, setDripRefreshTrigger] = useState(0);
+  const [dripScanning, setDripScanning] = useState(false);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
+  const ownerAddress = activeAccount?.address?.trim() ?? "";
+  const addressOk =
+    !requiredAddress ||
+    (ownerAddress.length > 0 &&
+      ownerAddress.toUpperCase() === requiredAddress.trim().toUpperCase());
+
+  const { rewardTokenDecimals: dec, rewardSymbol: sym } = config;
+
+  const totalPages = Math.max(1, Math.ceil(tokens.length / PAGE_SIZE));
+  const safePage = Math.min(Math.max(1, page), totalPages);
+  const paginatedTokens = tokens.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  const allClaimableTokens = useMemo(
+    () =>
+      tokens.filter((t) => {
+        const info = dripInfoByKey[tokenKey(t.contractId, t.tokenId)];
+        return info && info.claimableAmount > 0;
+      }),
+    [tokens, dripInfoByKey]
+  );
+
+  const totalClaimableAmount = useMemo(
+    () =>
+      allClaimableTokens.reduce((sum, t) => {
+        const info = dripInfoByKey[tokenKey(t.contractId, t.tokenId)];
+        return sum + (info?.claimableAmount ?? 0);
+      }, 0),
+    [allClaimableTokens, dripInfoByKey]
+  );
+
+  const selectedClaimableAmount = useMemo(() => {
+    let sum = 0;
+    for (const key of selectedKeys) {
+      const info = dripInfoByKey[key];
+      sum += info?.claimableAmount ?? 0;
+    }
+    return sum;
+  }, [selectedKeys, dripInfoByKey]);
+
+  const getAlgod = useCallback(async () => {
+    const net = getAlgorandNetworkFromNetworkId(VOI_DRIP_NETWORK);
+    if (!net) throw new Error("VOI mainnet not configured");
+    const clients = await algorandService.initializeClientsForTransactions(net);
+    return clients.algod;
+  }, []);
+
+  const toggleSelection = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+        return next;
+      }
+      if (next.size >= MAX_CLAIMS_PER_ACTION) {
+        toast({
+          title: "Selection limit",
+          description: `Select at most ${MAX_CLAIMS_PER_ACTION} NFTs per claim.`,
+          variant: "destructive",
+        });
+        return prev;
+      }
+      next.add(key);
+      return next;
+    });
+  };
+
+  const selectAllClaimable = () => {
+    const capped = allClaimableTokens.slice(0, MAX_CLAIMS_PER_ACTION);
+    setSelectedKeys(new Set(capped.map((t) => tokenKey(t.contractId, t.tokenId))));
+    if (allClaimableTokens.length > MAX_CLAIMS_PER_ACTION) {
+      toast({
+        title: "Selected first batch",
+        description: `${MAX_CLAIMS_PER_ACTION} of ${allClaimableTokens.length} claimable NFTs — claim, then repeat for more.`,
+      });
+    }
+  };
+
+  const clearSelection = () => setSelectedKeys(new Set());
+
+  const targetsFromTokens = (list: ParsedNft[]): NftDripClaimTarget[] => {
+    const out: NftDripClaimTarget[] = [];
+    for (const t of list) {
+      const info = dripInfoByKey[tokenKey(t.contractId, t.tokenId)];
+      if (info && info.claimableAmount > 0) {
+        out.push({
+          contractId: t.contractId,
+          tokenId: t.tokenId,
+          claimableAmount: info.claimableAmount,
+          config,
+        });
+      }
+    }
+    return out;
+  };
+
+  const notifyClaimError = (err: unknown) => {
+    const { userRejected, message } = getTransactionErrorFeedback(err);
+    if (userRejected) {
+      toast({
+        title: "Transaction cancelled",
+        description: message,
+      });
+      return;
+    }
+    toast({ title: "Claim failed", description: message, variant: "destructive" });
+  };
+
+  const prepareClaimTargets = (
+    targets: NftDripClaimTarget[],
+    opts: { truncateWithNotice: boolean }
+  ): NftDripClaimTarget[] => {
+    if (targets.length <= MAX_CLAIMS_PER_ACTION) return targets;
+    if (opts.truncateWithNotice) {
+      toast({
+        title: "Claiming first batch",
+        description: `Up to ${MAX_CLAIMS_PER_ACTION} NFTs per wallet approval. Claim again for any remaining rewards.`,
+      });
+      return targets.slice(0, MAX_CLAIMS_PER_ACTION);
+    }
+    toast({
+      title: "Too many NFTs selected",
+      description: `Select at most ${MAX_CLAIMS_PER_ACTION} NFTs per claim.`,
+      variant: "destructive",
+    });
+    return [];
+  };
+
+  const runClaimTargets = async (targets: NftDripClaimTarget[]) => {
+    if (!signTransactions || !ownerAddress) {
+      throw new Error("Connect a wallet to sign");
+    }
+
+    const algod = await getAlgod();
+    const { targetsForSign, preparedGroups } = await buildNftDripClaimSigningBundle(
+      config,
+      targets,
+      ownerAddress,
+      algod
+    );
+    if (preparedGroups.length === 0) {
+      throw new Error("Failed to build claim transactions");
+    }
+
+    const signingBatches = createSigningBatchesFromEncoded(preparedGroups);
+    const { signedGroups } = await signAllEncodedBatches(signingBatches, signTransactions);
+    const submission = await submitSignedGroups({ algod, signedGroups });
+
+    const claimCount = targetsForSign.length;
+    const totalClaimed = targetsForSign.reduce((s, t) => s + t.claimableAmount, 0);
+
+    if (submission.failedGroups.length > 0) {
+      toast({
+        title: "Claim failed",
+        description: "Transaction group could not be confirmed. Try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    toast({
+      title: "Claim submitted",
+      description: `Claimed ${formatDripRewardAmount(totalClaimed, dec)} ${sym} from ${claimCount} NFT(s).`,
+    });
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      targetsForSign.forEach((t) => next.delete(tokenKey(t.contractId, t.tokenId)));
+      return next;
+    });
+    setDripRefreshTrigger((r) => r + 1);
+  };
+
+  const handleClaimSelected = async () => {
+    const toClaim = tokens.filter((t) => selectedKeys.has(tokenKey(t.contractId, t.tokenId)));
+    const rawTargets = targetsFromTokens(toClaim);
+    if (rawTargets.length === 0) {
+      toast({ title: "Nothing to claim", description: "No selected NFTs with claimable amount.", variant: "destructive" });
+      return;
+    }
+    const targets = prepareClaimTargets(rawTargets, { truncateWithNotice: false });
+    if (targets.length === 0) return;
+    setIsClaiming(true);
+    try {
+      await runClaimTargets(targets);
+    } catch (err) {
+      notifyClaimError(err);
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
+  const handleClaimAll = async () => {
+    const targets = prepareClaimTargets(targetsFromTokens(allClaimableTokens), {
+      truncateWithNotice: true,
+    });
+    if (targets.length === 0) {
+      toast({
+        title: "Nothing to claim",
+        description: dripScanning ? "Still loading claimable amounts…" : "No claimable rewards found.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setIsClaiming(true);
+    try {
+      await runClaimTargets(targets);
+      clearSelection();
+    } catch (err) {
+      notifyClaimError(err);
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
+  const handleClaimOne = async (t: ParsedNft) => {
+    const key = tokenKey(t.contractId, t.tokenId);
+    const info = dripInfoByKey[key];
+    if (!info || info.claimableAmount <= 0) {
+      toast({ title: "Nothing to claim", variant: "destructive" });
+      return;
+    }
+    setClaimingKey(key);
+    try {
+      await runClaimTargets([
+        {
+          contractId: t.contractId,
+          tokenId: t.tokenId,
+          claimableAmount: info.claimableAmount,
+          config,
+        },
+      ]);
+    } catch (err) {
+      notifyClaimError(err);
+    } finally {
+      setClaimingKey(null);
+    }
+  };
+
+  useEffect(() => {
+    if (!ownerAddress || !addressOk) {
+      setTokens([]);
+      setDripInfoByKey({});
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    void fetchUserNFTs(ownerAddress, [config.nftContractId], 600)
+      .then((data) => {
+        if (cancelled) return;
+        const parsed: ParsedNft[] = (data.tokens ?? [])
+          .filter((t: NFTToken) => !t.isBurned)
+          .map((t: NFTToken) => {
+            const meta = parseNFTMetadata(t.metadata || "{}");
+            return {
+              tokenId: t.tokenId,
+              contractId: t.contractId,
+              name: meta.name ?? `${config.collectionLabel} #${t.tokenId}`,
+              image: normalizeNftMetadataImageUrl(meta.image) ?? "",
+            };
+          });
+        setTokens(parsed);
+        setPage(1);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : "Failed to load NFTs");
+          setTokens([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ownerAddress, addressOk, config.nftContractId, config.collectionLabel]);
+
+  useEffect(() => {
+    if (!ownerAddress || !addressOk || tokens.length === 0) return;
+    let cancelled = false;
+    setDripScanning(true);
+    void (async () => {
+      const algod = await getAlgod();
+      for (let i = 0; i < tokens.length; i += DRIP_READ_CONCURRENCY) {
+        if (cancelled) return;
+        const batch = tokens.slice(i, i + DRIP_READ_CONCURRENCY);
+        await Promise.all(
+          batch.map(async (t) => {
+            const key = tokenKey(t.contractId, t.tokenId);
+            setDripLoadingByKey((prev) => ({ ...prev, [key]: true }));
+            try {
+              const info = await readNftDripInfo(config, t.contractId, t.tokenId, ownerAddress, algod);
+              if (!cancelled) {
+                setDripInfoByKey((prev) => ({ ...prev, [key]: info }));
+                setDripLoadingByKey((prev) => ({ ...prev, [key]: false }));
+              }
+            } catch {
+              if (!cancelled) {
+                setDripInfoByKey((prev) => ({ ...prev, [key]: null }));
+                setDripLoadingByKey((prev) => ({ ...prev, [key]: false }));
+              }
+            }
+          })
+        );
+      }
+      if (!cancelled) setDripScanning(false);
+    })();
+    return () => {
+      cancelled = true;
+      setDripScanning(false);
+    };
+  }, [ownerAddress, addressOk, tokens, dripRefreshTrigger, config, getAlgod]);
+
+  const collectionUrl = `https://nautilus.sh/#/collection/${config.nftContractId}/trade`;
+
+  return (
+    <div className={cn(compact ? "px-0 py-0" : "mx-auto max-w-3xl px-4 py-8")}>
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-6 shadow-xl">
+        {!compact ? (
+          <div className="mb-6 text-center">
+            <h2 className="text-2xl font-semibold text-white">
+              <span className="mr-2" aria-hidden>
+                💧
+              </span>
+              {config.title}
+            </h2>
+            <p className="mx-auto mt-2 max-w-md text-sm text-slate-400">{config.subtitle}</p>
+            <a
+              href={collectionUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-block text-sm font-semibold text-violet-400 hover:underline"
+            >
+              View collection
+            </a>
+          </div>
+        ) : null}
+
+        {!ownerAddress && (
+          <p className="text-center text-sm text-slate-400">
+            Connect your wallet to see {config.collectionLabel} NFTs and claim {sym}.
+          </p>
+        )}
+
+        {ownerAddress && requiredAddress && !addressOk && (
+          <p className="rounded-lg border border-amber-500/30 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
+            Connected wallet must match portfolio address{" "}
+            <span className="font-mono text-amber-200/90">{requiredAddress.slice(0, 8)}…</span> to
+            claim on-chain.
+          </p>
+        )}
+
+        {ownerAddress && addressOk && loading && (
+          <div className="flex items-center justify-center gap-2 py-10 text-slate-400">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Loading your NFTs…
+          </div>
+        )}
+
+        {ownerAddress && addressOk && loadError && (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-red-200">
+            {loadError}
+          </p>
+        )}
+
+        {ownerAddress && addressOk && !loading && !loadError && tokens.length === 0 && (
+          <p className="py-8 text-center text-sm text-slate-400">
+            <span className="text-2xl">{config.emptyStateEmoji}</span>
+            <br />
+            You don&apos;t own any {config.collectionLabel} NFTs yet.
+          </p>
+        )}
+
+        {ownerAddress && addressOk && !loading && !loadError && tokens.length > 0 && (
+          <>
+            {(allClaimableTokens.length > 0 || dripScanning) && (
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-800 bg-slate-900/50 px-3 py-2 text-xs">
+                <div className="flex flex-wrap items-center gap-3">
+                  <label className="flex cursor-pointer items-center gap-2 text-slate-400">
+                    <Checkbox
+                      checked={
+                        allClaimableTokens.length > 0 &&
+                        allClaimableTokens
+                          .slice(0, MAX_CLAIMS_PER_ACTION)
+                          .every((t) => selectedKeys.has(tokenKey(t.contractId, t.tokenId)))
+                      }
+                      disabled={dripScanning || allClaimableTokens.length === 0}
+                      onCheckedChange={(v) => (v ? selectAllClaimable() : clearSelection())}
+                    />
+                    Select claimable (up to {MAX_CLAIMS_PER_ACTION})
+                    {allClaimableTokens.length > 0 ? (
+                      <span className="tabular-nums text-slate-500">({allClaimableTokens.length})</span>
+                    ) : null}
+                  </label>
+                  <span className="text-slate-600">
+                    Max {MAX_CLAIMS_PER_ACTION} per wallet approval
+                  </span>
+                  {dripScanning ? (
+                    <span className="flex items-center gap-1 text-slate-500">
+                      <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                      Scanning…
+                    </span>
+                  ) : allClaimableTokens.length > 0 ? (
+                    <span className="tabular-nums text-violet-300/90">
+                      {formatDripRewardAmount(totalClaimableAmount, dec)} {sym} total
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    size="sm"
+                    className="bg-emerald-700 hover:bg-emerald-600"
+                    disabled={
+                      isClaiming || dripScanning || !signTransactions || allClaimableTokens.length === 0
+                    }
+                    onClick={() => void handleClaimAll()}
+                  >
+                    {isClaiming
+                      ? "Claiming…"
+                      : (() => {
+                          const n = Math.min(allClaimableTokens.length, MAX_CLAIMS_PER_ACTION);
+                          const suffix =
+                            allClaimableTokens.length > MAX_CLAIMS_PER_ACTION
+                              ? ` (next ${n})`
+                              : allClaimableTokens.length > 0
+                                ? ` (${n})`
+                                : "";
+                          return `Claim batch${suffix}`;
+                        })()}
+                  </Button>
+                  {selectedKeys.size > 0 ? (
+                    <>
+                      <span className="tabular-nums text-slate-300">
+                        {selectedKeys.size} selected ·{" "}
+                        {formatDripRewardAmount(selectedClaimableAmount, dec)} {sym}
+                      </span>
+                      <Button
+                        size="sm"
+                        className="bg-violet-700 hover:bg-violet-600"
+                        disabled={isClaiming || !signTransactions}
+                        onClick={() => void handleClaimSelected()}
+                      >
+                        {isClaiming ? "Claiming…" : `Claim selected (${selectedKeys.size})`}
+                      </Button>
+                      <Button size="sm" variant="ghost" onClick={clearSelection}>
+                        Clear
+                      </Button>
+                    </>
+                  ) : null}
+                </div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+              {paginatedTokens.map((t) => {
+                const key = tokenKey(t.contractId, t.tokenId);
+                const dripLoading = dripLoadingByKey[key];
+                const dripInfo = dripInfoByKey[key];
+                const hasClaimable = !!(dripInfo && dripInfo.claimableAmount > 0);
+                const isSelected = selectedKeys.has(key);
+                return (
+                  <div
+                    key={key}
+                    role={hasClaimable ? "button" : undefined}
+                    tabIndex={hasClaimable ? 0 : undefined}
+                    className={cn(
+                      "overflow-hidden rounded-xl border bg-slate-900/60 transition",
+                      isSelected ? "border-violet-500/80 ring-1 ring-violet-500/50" : "border-slate-800",
+                      hasClaimable && "cursor-pointer hover:border-violet-500/40"
+                    )}
+                    onClick={() => hasClaimable && toggleSelection(key)}
+                    onKeyDown={(e) => {
+                      if (hasClaimable && (e.key === "Enter" || e.key === " ")) {
+                        e.preventDefault();
+                        toggleSelection(key);
+                      }
+                    }}
+                  >
+                    <div className="relative aspect-square bg-slate-950">
+                      {hasClaimable && (
+                        <div className="absolute left-2 top-2 z-10" onClick={(e) => e.stopPropagation()}>
+                          <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={() => toggleSelection(key)}
+                          />
+                        </div>
+                      )}
+                      {t.image ? (
+                        <img src={t.image} alt="" className="h-full w-full object-cover" />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-[10px] text-slate-600">
+                          NFT
+                        </div>
+                      )}
+                    </div>
+                    <div className="border-t border-slate-800 px-2 py-1.5 text-center text-[10px] font-medium text-slate-300 truncate">
+                      {t.name}
+                    </div>
+                    <div className="flex items-center justify-between gap-1 border-t border-slate-800 px-2 py-1.5 text-[10px] text-slate-500">
+                      {dripLoading ? (
+                        <span>…</span>
+                      ) : dripInfo ? (
+                        <>
+                          <span className={hasClaimable ? "font-semibold text-violet-300" : ""}>
+                            {formatDripRewardAmount(dripInfo.claimableAmount, dec)} {sym}
+                          </span>
+                          {hasClaimable ? (
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              className="h-6 px-2 text-[9px]"
+                              disabled={
+                                isClaiming ||
+                                (claimingKey !== null && claimingKey !== key) ||
+                                !signTransactions
+                              }
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                void handleClaimOne(t);
+                              }}
+                            >
+                              {claimingKey === key ? "…" : "Claim"}
+                            </Button>
+                          ) : null}
+                        </>
+                      ) : (
+                        <span>—</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="mt-4 flex items-center justify-center gap-3 text-sm text-slate-400">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={safePage <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <span>
+                  Page {safePage} of {totalPages}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={safePage >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -868,7 +868,7 @@ export interface GlobalConfig {
 const baseVoiMainnetConfig: BaseNetworkConfig = {
   networkId: "voi-mainnet",
   walletNetworkId: "voimain",
-  name: "VOI Mainnet",
+  name: "VOI Network",
   networkType: "avm",
   rpcUrl: "https://mainnet-api.voi.dork.fi",
   rpcPort: 443,

--- a/src/config/nftDrips.ts
+++ b/src/config/nftDrips.ts
@@ -1,0 +1,51 @@
+/** NFT drip app contract (Voi) — Dorks v1 */
+export const nftDripDorkAppId = 49016540;
+/** NFT drip app contract (Voi) — Dorks v2 */
+export const nftDripDorkV2AppId = 49016557;
+
+export type UnitNftDripCampaignConfig = {
+  id: string;
+  nftContractId: number;
+  dripContractId: number;
+  rewardTokenContractId: number;
+  rewardTokenDecimals: number;
+  /** Accrual rate in smallest token units per week (on-chain math). */
+  dripPerWeekRaw: number;
+  rewardSymbol: string;
+  title: string;
+  subtitle: string;
+  collectionLabel: string;
+  emptyStateEmoji: string;
+};
+
+export const DORK_DRIP_CONFIG: UnitNftDripCampaignConfig = {
+  id: "dork",
+  nftContractId: 313597,
+  dripContractId: nftDripDorkAppId,
+  rewardTokenContractId: 420069,
+  rewardTokenDecimals: 8,
+  dripPerWeekRaw: 400_000_000,
+  rewardSymbol: "UNIT",
+  title: "Dorks Drip",
+  subtitle:
+    "Your Dorks NFTs earn UNIT over time. Claim up to 6 NFTs per wallet approval (~1 VOI per batch).",
+  collectionLabel: "Dorks",
+  emptyStateEmoji: "🤓",
+};
+
+export const DORK_V2_DRIP_CONFIG: UnitNftDripCampaignConfig = {
+  id: "dork-v2",
+  nftContractId: 894888,
+  dripContractId: nftDripDorkV2AppId,
+  rewardTokenContractId: 420069,
+  rewardTokenDecimals: 8,
+  dripPerWeekRaw: 80_000_000,
+  rewardSymbol: "UNIT",
+  title: "Dorks V2 Drip",
+  subtitle:
+    "Your Dorks V2 NFTs earn UNIT over time. Claim up to 6 NFTs per wallet approval (~1 VOI per batch).",
+  collectionLabel: "Dorks V2",
+  emptyStateEmoji: "🤓",
+};
+
+export const NFT_UNIT_DRIP_CAMPAIGNS = [DORK_DRIP_CONFIG, DORK_V2_DRIP_CONFIG] as const;

--- a/src/hooks/useSavePreferredLocaleToEnvoi.ts
+++ b/src/hooks/useSavePreferredLocaleToEnvoi.ts
@@ -45,7 +45,7 @@ export function useSavePreferredLocaleToEnvoi() {
 
   const savePreferredLocaleToEnvoi = useCallback(async () => {
     if (!canSave || !activeAccount?.address || !addressName || !signTransactions) {
-      setError(new Error("Save to Envoi profile is only available on Voi Mainnet with an Envoi name."));
+      setError(new Error("Save to Envoi profile is only available on Voi Network with an Envoi name."));
       return;
     }
 

--- a/src/lib/algorand/grouping.test.ts
+++ b/src/lib/algorand/grouping.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import algosdk from "algosdk";
+import {
+  chunk,
+  createSigningBatches,
+  createSigningBatchesFromEncoded,
+  groupTransactions,
+} from "@/lib/algorand/grouping";
+import { reconstructSignedGroups } from "@/lib/algorand/signing";
+
+describe("chunk", () => {
+  it("splits items into fixed-size chunks", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+});
+
+describe("groupTransactions", () => {
+  it("creates groups of at most 16 with shared group id", () => {
+    const addr = algosdk.encodeAddress(new Uint8Array(32).fill(7));
+    const suggestedParams = {
+      fee: 1000,
+      firstValid: 1,
+      lastValid: 1000,
+      genesisHash: new Uint8Array(32).fill(1),
+      genesisID: "test",
+      minFee: 1000,
+    };
+    const txns = Array.from({ length: 20 }, (_, i) =>
+      algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: addr,
+        receiver: addr,
+        amount: i,
+        suggestedParams,
+      })
+    );
+    const groups = groupTransactions(txns);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toHaveLength(16);
+    expect(groups[1]).toHaveLength(4);
+    const g0 = groups[0]![0]!.group!;
+    expect(groups[0]!.every((t) => Buffer.compare(t.group!, g0) === 0)).toBe(true);
+  });
+});
+
+describe("createSigningBatches", () => {
+  it("flattens up to 16 atomic groups per signing batch", () => {
+    const groups = Array.from({ length: 20 }, () => [] as algosdk.Transaction[]);
+    const batches = createSigningBatches(groups);
+    expect(batches).toHaveLength(2);
+    expect(batches[0]!.groups).toHaveLength(16);
+    expect(batches[1]!.groups).toHaveLength(4);
+  });
+});
+
+describe("createSigningBatchesFromEncoded", () => {
+  it("preserves encoded bytes without re-encoding", () => {
+    const encoded = [
+      [new Uint8Array([1, 2])],
+      [new Uint8Array([3]), new Uint8Array([4])],
+    ];
+    const batches = createSigningBatchesFromEncoded(encoded);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]!.flat).toHaveLength(3);
+    expect(batches[0]!.flat[0]).toEqual(new Uint8Array([1, 2]));
+  });
+});
+
+describe("reconstructSignedGroups", () => {
+  it("splits flat signed bytes by group sizes", () => {
+    const flat = [new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])];
+    const groups = reconstructSignedGroups(flat, [1, 2]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toHaveLength(1);
+    expect(groups[1]).toHaveLength(2);
+  });
+});

--- a/src/lib/algorand/grouping.ts
+++ b/src/lib/algorand/grouping.ts
@@ -1,0 +1,158 @@
+/**
+ * Algorand transaction grouping for Claim All.
+ *
+ * ## Atomic groups (execution)
+ * On-chain, up to {@link MAX_TXNS_PER_GROUP} transactions share one group ID and succeed or fail
+ * together. A single ARC-200 claim path may expand to several txns (opt-in, app call, transfer).
+ *
+ * ## Signing batches (wallet)
+ * Wallets sign bytes, not "logical claims". We may flatten up to {@link MAX_GROUPS_PER_SIGNING}
+ * atomic groups into one `signTransactions` call to reduce popups. That batch is NOT one atomic
+ * group — each subgroup keeps its own group ID and is submitted separately after signing.
+ */
+
+import algosdk from "algosdk";
+import { MAX_GROUPS_PER_SIGNING, MAX_TXNS_PER_GROUP } from "@/lib/dorkfi/types";
+import type { SigningBatchPlan, SigningBatchPlanEncoded } from "@/lib/dorkfi/types";
+
+/** Split an array into fixed-size chunks (last chunk may be smaller). */
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size < 1) throw new Error("chunk size must be at least 1");
+  if (items.length === 0) return [];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Partition flat transactions into atomic groups (≤ {@link MAX_TXNS_PER_GROUP} each)
+ * and assign a fresh group ID per chunk.
+ */
+export function groupTransactions(txns: algosdk.Transaction[]): algosdk.Transaction[][] {
+  if (txns.length === 0) return [];
+  const chunks = chunk(txns, MAX_TXNS_PER_GROUP);
+  return chunks.map((group) => {
+    const copy = group.map((t) =>
+      algosdk.decodeUnsignedTransaction(algosdk.encodeUnsignedTransaction(t))
+    );
+    algosdk.assignGroupID(copy);
+    return copy;
+  });
+}
+
+/** Decode encoded groups produced by external builders (e.g. ulujs `custom()`). */
+export function decodeTransactionGroups(encodedGroups: Uint8Array[][]): algosdk.Transaction[][] {
+  return encodedGroups.map((groupBytes) =>
+    groupBytes.map((b) => algosdk.decodeUnsignedTransaction(b))
+  );
+}
+
+/** Encode atomic groups for wallet / algod submission. */
+export function encodeTransactionGroups(groups: algosdk.Transaction[][]): Uint8Array[][] {
+  return groups.map((group) =>
+    group.map((txn) => algosdk.encodeUnsignedTransaction(txn))
+  );
+}
+
+/**
+ * Assign group IDs only when needed (ulujs `custom()` groups are often already valid).
+ */
+export function ensureAtomicGroups(groups: algosdk.Transaction[][]): algosdk.Transaction[][] {
+  return groups.map((group) => {
+    if (group.length > MAX_TXNS_PER_GROUP) {
+      throw new Error(
+        `Atomic group has ${group.length} transactions (max ${MAX_TXNS_PER_GROUP})`
+      );
+    }
+    if (group.length <= 1) return group;
+    const expected = algosdk.computeGroupID(group);
+    const valid =
+      !isZeroGroup(expected) &&
+      group.every((t) => t.group && Buffer.compare(t.group, expected) === 0);
+    if (valid) return group;
+    const copy = group.map((t) =>
+      algosdk.decodeUnsignedTransaction(algosdk.encodeUnsignedTransaction(t))
+    );
+    algosdk.assignGroupID(copy);
+    return copy;
+  });
+}
+
+function isZeroGroup(group: Uint8Array): boolean {
+  return group.every((b) => b === 0);
+}
+
+/**
+ * Build wallet signing batches: up to {@link MAX_GROUPS_PER_SIGNING} atomic groups flattened
+ * per batch. Returns one flat array per batch (what you pass to `signTransactions`).
+ */
+export function createSigningBatches(
+  groups: algosdk.Transaction[][]
+): SigningBatchPlan[] {
+  if (groups.length === 0) return [];
+
+  const groupBatches = chunk(groups, MAX_GROUPS_PER_SIGNING);
+  const plans: SigningBatchPlan[] = [];
+  let startGroupIndex = 0;
+
+  for (const batchGroups of groupBatches) {
+    const groupSizes = batchGroups.map((g) => g.length);
+    const flat = batchGroups.flat();
+    plans.push({
+      startGroupIndex,
+      groups: batchGroups,
+      flat,
+      groupSizes,
+    });
+    startGroupIndex += batchGroups.length;
+  }
+  return plans;
+}
+
+/** Full plan: atomic groups + signing batches. */
+export function createClaimAllPlan(groups: algosdk.Transaction[][]): {
+  groups: algosdk.Transaction[][];
+  signingBatches: SigningBatchPlan[];
+} {
+  const normalized = ensureAtomicGroups(groups);
+  return {
+    groups: normalized,
+    signingBatches: createSigningBatches(normalized),
+  };
+}
+
+/**
+ * Signing batches from pre-built encoded groups (e.g. ulujs `custom()`).
+ * Does not decode/re-encode — preserves wallet-valid group bytes.
+ */
+export function createSigningBatchesFromEncoded(
+  encodedGroups: Uint8Array[][]
+): SigningBatchPlanEncoded[] {
+  if (encodedGroups.length === 0) return [];
+
+  for (const group of encodedGroups) {
+    if (group.length > MAX_TXNS_PER_GROUP) {
+      throw new Error(
+        `Atomic group has ${group.length} transactions (max ${MAX_TXNS_PER_GROUP})`
+      );
+    }
+  }
+
+  const groupBatches = chunk(encodedGroups, MAX_GROUPS_PER_SIGNING);
+  const plans: SigningBatchPlanEncoded[] = [];
+  let startGroupIndex = 0;
+
+  for (const batchGroups of groupBatches) {
+    const groupSizes = batchGroups.map((g) => g.length);
+    plans.push({
+      startGroupIndex,
+      groups: batchGroups,
+      flat: batchGroups.flat(),
+      groupSizes,
+    });
+    startGroupIndex += batchGroups.length;
+  }
+  return plans;
+}

--- a/src/lib/algorand/signing.ts
+++ b/src/lib/algorand/signing.ts
@@ -1,0 +1,198 @@
+/**
+ * Wallet signing for Claim All batches.
+ *
+ * Signing batches flatten multiple atomic groups for fewer wallet popups. After signing, we
+ * slice the signed byte array back into per-group chunks using `groupSizes` before submission.
+ */
+
+import algosdk from "algosdk";
+import type {
+  SignTransactionsFn,
+  SigningBatchPlan,
+  SigningBatchPlanEncoded,
+} from "@/lib/dorkfi/types";
+import { isInvalidGroupSignError } from "@/utils/errorUtils";
+
+export function transactionsToBytes(txns: algosdk.Transaction[]): Uint8Array[] {
+  return txns.map((t) => algosdk.encodeUnsignedTransaction(t));
+}
+
+export function normalizeSignedBytes(
+  signed: Uint8Array | Uint8Array[] | (Uint8Array | null)[]
+): Uint8Array[] {
+  const arr = Array.isArray(signed) ? signed : [signed];
+  return arr.map((t, i) => {
+    if (t == null) {
+      throw new Error(`Wallet returned null at signed transaction index ${i}`);
+    }
+    return t;
+  });
+}
+
+/**
+ * Reconstruct signed atomic groups from one flat signed array and per-group sizes.
+ */
+export function reconstructSignedGroups(
+  signedFlat: Uint8Array[],
+  groupSizes: number[]
+): Uint8Array[][] {
+  const expected = groupSizes.reduce((s, n) => s + n, 0);
+  if (signedFlat.length !== expected) {
+    throw new Error(
+      `Signed length ${signedFlat.length} does not match expected ${expected} from group sizes`
+    );
+  }
+  const out: Uint8Array[][] = [];
+  let offset = 0;
+  for (const size of groupSizes) {
+    out.push(signedFlat.slice(offset, offset + size));
+    offset += size;
+  }
+  return out;
+}
+
+export type SignBatchResult = {
+  signedGroups: Uint8Array[][];
+  /** True if we fell back to one wallet prompt per atomic group (batch sign rejected). */
+  usedPerGroupFallback: boolean;
+};
+
+/**
+ * Sign one signing batch. Tries flattened batch first; on Invalid Group (4300), signs each
+ * atomic group in the batch separately.
+ */
+export async function signBatch(
+  plan: SigningBatchPlan,
+  signTransactions: SignTransactionsFn
+): Promise<SignBatchResult> {
+  const unsignedFlat = transactionsToBytes(plan.flat);
+
+  try {
+    const signedFlat = normalizeSignedBytes(await signTransactions(unsignedFlat));
+    return {
+      signedGroups: reconstructSignedGroups(signedFlat, plan.groupSizes),
+      usedPerGroupFallback: false,
+    };
+  } catch (err) {
+    if (!isInvalidGroupSignError(err) || plan.groups.length <= 1) {
+      throw err;
+    }
+    const signedGroups: Uint8Array[][] = [];
+    for (const group of plan.groups) {
+      const bytes = transactionsToBytes(group);
+      signedGroups.push(normalizeSignedBytes(await signTransactions(bytes)));
+    }
+    return { signedGroups, usedPerGroupFallback: true };
+  }
+}
+
+/**
+ * Sign every batch in order. `onBatchStart` runs before each wallet prompt (cancel check).
+ */
+export async function signAllBatches(
+  batches: SigningBatchPlan[],
+  signTransactions: SignTransactionsFn,
+  options?: {
+    onBatchStart?: (batchIndex: number, total: number) => void;
+    shouldCancel?: () => boolean;
+  }
+): Promise<{ signedGroups: Uint8Array[][]; usedPerGroupFallback: boolean }> {
+  const allSigned: Uint8Array[][] = [];
+  let usedFallback = false;
+
+  for (let i = 0; i < batches.length; i++) {
+    if (options?.shouldCancel?.()) {
+      throw new ClaimAllCancelledError();
+    }
+    options?.onBatchStart?.(i, batches.length);
+    const batch = batches[i]!;
+    const result = await signBatch(batch, signTransactions);
+    allSigned.push(...result.signedGroups);
+    if (result.usedPerGroupFallback) usedFallback = true;
+  }
+
+  return { signedGroups: allSigned, usedPerGroupFallback: usedFallback };
+}
+
+/**
+ * Sign one encoded batch. Uses raw ulujs bytes (no decode). Multi-group batches sign
+ * one atomic group per wallet call — Lute/Pera reject flattened multi-group (4300).
+ */
+export async function signEncodedBatch(
+  plan: SigningBatchPlanEncoded,
+  signTransactions: SignTransactionsFn
+): Promise<SignBatchResult> {
+  if (plan.groups.length > 1) {
+    return signEachEncodedGroup(plan.groups, signTransactions);
+  }
+
+  try {
+    const signedFlat = normalizeSignedBytes(await signTransactions(plan.flat));
+    return {
+      signedGroups: reconstructSignedGroups(signedFlat, plan.groupSizes),
+      usedPerGroupFallback: false,
+    };
+  } catch (err) {
+    if (!isInvalidGroupSignError(err)) throw err;
+    return signEachEncodedGroup(plan.groups, signTransactions);
+  }
+}
+
+async function signEachEncodedGroup(
+  groups: Uint8Array[][],
+  signTransactions: SignTransactionsFn
+): Promise<SignBatchResult> {
+  const signedGroups: Uint8Array[][] = [];
+  for (const group of groups) {
+    signedGroups.push(normalizeSignedBytes(await signTransactions(group)));
+  }
+  return { signedGroups, usedPerGroupFallback: groups.length > 1 };
+}
+
+/**
+ * Sign pre-built encoded atomic groups (NFT drip / ulujs path).
+ */
+export async function signAllEncodedBatches(
+  batches: SigningBatchPlanEncoded[],
+  signTransactions: SignTransactionsFn,
+  options?: {
+    onBatchStart?: (batchIndex: number, total: number) => void;
+    onGroupStart?: (groupIndex: number, totalGroups: number) => void;
+    shouldCancel?: () => boolean;
+  }
+): Promise<{ signedGroups: Uint8Array[][]; usedPerGroupFallback: boolean }> {
+  const allSigned: Uint8Array[][] = [];
+  let usedFallback = false;
+  let globalGroupIndex = 0;
+
+  for (let i = 0; i < batches.length; i++) {
+    if (options?.shouldCancel?.()) throw new ClaimAllCancelledError();
+    options?.onBatchStart?.(i, batches.length);
+    const batch = batches[i]!;
+
+    if (batch.groups.length > 1) {
+      for (const group of batch.groups) {
+        if (options?.shouldCancel?.()) throw new ClaimAllCancelledError();
+        options?.onGroupStart?.(globalGroupIndex, batches.reduce((n, b) => n + b.groups.length, 0));
+        allSigned.push(normalizeSignedBytes(await signTransactions(group)));
+        globalGroupIndex++;
+        usedFallback = true;
+      }
+      continue;
+    }
+
+    const result = await signEncodedBatch(batch, signTransactions);
+    allSigned.push(...result.signedGroups);
+    globalGroupIndex += batch.groups.length;
+    if (result.usedPerGroupFallback) usedFallback = true;
+  }
+
+  return { signedGroups: allSigned, usedPerGroupFallback: usedFallback };
+}
+
+export class ClaimAllCancelledError extends Error {
+  constructor() {
+    super("Claim All cancelled before signing");
+    this.name = "ClaimAllCancelledError";
+  }
+}

--- a/src/lib/algorand/submission.ts
+++ b/src/lib/algorand/submission.ts
@@ -1,0 +1,70 @@
+/**
+ * On-chain submission for Claim All.
+ *
+ * Each atomic group is broadcast with `sendRawTransaction(group)` and confirmed independently.
+ * A failure in one group does not prevent submitting later groups (partial failure handling).
+ */
+
+import algosdk, { type Algodv2 } from "algosdk";
+
+export type GroupSubmitResult = {
+  groupIndex: number;
+  txId?: string;
+  confirmedRound?: number;
+  error?: string;
+};
+
+export type SubmitSignedGroupsOptions = {
+  algod: Algodv2;
+  signedGroups: Uint8Array[][];
+  waitRounds?: number;
+  /** Only submit these global group indices (retry mode). */
+  onlyGroupIndices?: number[];
+  onGroupSubmitted?: (result: GroupSubmitResult) => void;
+};
+
+/**
+ * Submit signed atomic groups independently; continue after individual failures.
+ */
+export async function submitSignedGroups(
+  options: SubmitSignedGroupsOptions
+): Promise<{
+  successfulTxIds: string[];
+  failedGroups: number[];
+  confirmedRounds: number[];
+}> {
+  const { algod, signedGroups, waitRounds = 4, onlyGroupIndices, onGroupSubmitted } = options;
+  const indices =
+    onlyGroupIndices ?? signedGroups.map((_, i) => i);
+
+  const successfulTxIds: string[] = [];
+  const failedGroups: number[] = [];
+  const confirmedRounds: number[] = [];
+
+  for (const groupIndex of indices) {
+    const group = signedGroups[groupIndex];
+    if (!group?.length) {
+      failedGroups.push(groupIndex);
+      onGroupSubmitted?.({
+        groupIndex,
+        error: "Missing signed transaction group",
+      });
+      continue;
+    }
+
+    try {
+      const res = await algod.sendRawTransaction(group).do();
+      const pending = await algosdk.waitForConfirmation(algod, res.txid, waitRounds);
+      const round = pending.confirmedRound ?? 0;
+      successfulTxIds.push(res.txid);
+      if (round > 0) confirmedRounds.push(round);
+      onGroupSubmitted?.({ groupIndex, txId: res.txid, confirmedRound: round });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      failedGroups.push(groupIndex);
+      onGroupSubmitted?.({ groupIndex, error: message });
+    }
+  }
+
+  return { successfulTxIds, failedGroups, confirmedRounds };
+}

--- a/src/lib/dorkfi/claimAll.ts
+++ b/src/lib/dorkfi/claimAll.ts
@@ -1,0 +1,395 @@
+/**
+ * DorkFi Claim All orchestration.
+ *
+ * ## Transaction lifecycle
+ * 1. **Build** — `buildTransactions(positions)` returns unsigned txns (any mix of types).
+ * 2. **Group** — chunk into atomic groups (≤16 txns), `assignGroupID` per group.
+ * 3. **Sign batches** — flatten up to 16 groups per wallet call; reconstruct boundaries after.
+ * 4. **Submit** — each atomic group is `sendRawTransaction` + `waitForConfirmation` separately.
+ *
+ * ## Why signing batches ≠ execution groups
+ * - Execution group: Algorand consensus unit (max 16 txns, one group ID).
+ * - Signing batch: UX unit for the wallet (may contain many execution groups).
+ *
+ * ## ARC-200 / NFT drip note
+ * Builders like ulujs `custom()` may already return grouped bytes. Use
+ * `claimAllFromEncodedGroups` instead of flat `buildTransactions` when groups are pre-built.
+ */
+
+import type { Algodv2 } from "algosdk";
+import {
+  createClaimAllPlan,
+  createSigningBatchesFromEncoded,
+  groupTransactions,
+} from "@/lib/algorand/grouping";
+import { ClaimAllCancelledError, signAllBatches, signAllEncodedBatches } from "@/lib/algorand/signing";
+import { submitSignedGroups } from "@/lib/algorand/submission";
+import type {
+  ClaimAllProgress,
+  ClaimAllResult,
+  ClaimAllRewardsOptions,
+  ClaimState,
+} from "@/lib/dorkfi/types";
+import { isTransactionUserRejection } from "@/utils/errorUtils";
+
+function emitProgress(
+  onProgress: ((p: ClaimAllProgress) => void) | undefined,
+  partial: Omit<ClaimAllProgress, "progressPercent"> & { progressPercent?: number }
+): void {
+  if (!onProgress) return;
+  const total = partial.totalBatches || 1;
+  const batchFrac = (partial.currentBatch + 1) / total;
+  const groupFrac =
+    partial.totalGroups > 0 ? partial.successfulGroups / partial.totalGroups : 0;
+  const progressPercent =
+    partial.progressPercent ??
+    Math.round(
+      (partial.state === "building"
+        ? 10
+        : partial.state === "awaiting_signature"
+          ? 10 + batchFrac * 40
+          : partial.state === "submitting"
+            ? 50 + groupFrac * 50
+            : partial.state === "complete"
+              ? 100
+              : partial.state === "partial_failure"
+                ? 50 + groupFrac * 50
+                : 0) * 10
+    ) / 10;
+
+  onProgress({ ...partial, progressPercent });
+}
+
+function setState(
+  onStateChange: ((s: ClaimState) => void) | undefined,
+  state: ClaimState
+): void {
+  onStateChange?.(state);
+}
+
+/**
+ * Claim rewards for many positions with grouped atomic execution and batched signing.
+ *
+ * @example
+ * ```ts
+ * await claimAllRewards({
+ *   positions: markets,
+ *   buildTransactions: (p) => buildMarketClaimTxns(p),
+ *   signTransactions,
+ *   algodClient: algod,
+ *   onProgress: (p) => setProgress(p),
+ * });
+ * ```
+ */
+export async function claimAllRewards<TPosition>(
+  options: ClaimAllRewardsOptions<TPosition>
+): Promise<ClaimAllResult> {
+  const {
+    positions,
+    buildTransactions,
+    signTransactions,
+    algodClient,
+    onProgress,
+    onStateChange,
+    signal,
+    waitRounds = 4,
+    retryGroupIndices,
+    preSignedGroups,
+  } = options;
+
+  if (positions.length === 0 && !preSignedGroups?.length) {
+    return {
+      successfulTxIds: [],
+      failedGroups: [],
+      confirmedRounds: [],
+      state: "complete",
+    };
+  }
+
+  try {
+    setState(onStateChange, "building");
+    emitProgress(onProgress, {
+      state: "building",
+      currentBatch: 0,
+      totalBatches: 0,
+      currentGroup: 0,
+      totalGroups: 0,
+      successfulGroups: 0,
+      failedGroups: 0,
+      message: "Building claim transactions…",
+    });
+
+    let signedGroups: Uint8Array[][];
+
+    if (preSignedGroups?.length) {
+      signedGroups = preSignedGroups;
+    } else {
+      const built = await buildTransactions(positions);
+      const { groups, signingBatches } = createClaimAllPlan(groupTransactions(built));
+      const totalGroups = groups.length;
+      const totalBatches = signingBatches.length;
+
+      setState(onStateChange, "awaiting_signature");
+      emitProgress(onProgress, {
+        state: "awaiting_signature",
+        currentBatch: 0,
+        totalBatches,
+        currentGroup: 0,
+        totalGroups,
+        successfulGroups: 0,
+        failedGroups: 0,
+        message: "Approve transactions in your wallet",
+      });
+
+      if (signal?.aborted) throw new ClaimAllCancelledError();
+
+      const signResult = await signAllBatches(signingBatches, signTransactions, {
+        shouldCancel: () => signal?.aborted === true,
+        onBatchStart: (batchIndex, total) => {
+          emitProgress(onProgress, {
+            state: "awaiting_signature",
+            currentBatch: batchIndex,
+            totalBatches: total,
+            currentGroup: signingBatches[batchIndex]?.startGroupIndex ?? 0,
+            totalGroups,
+            successfulGroups: 0,
+            failedGroups: 0,
+            message: `Signing batch ${batchIndex + 1} of ${total}`,
+          });
+        },
+      });
+      signedGroups = signResult.signedGroups;
+    }
+
+    const totalGroups = signedGroups.length;
+    setState(onStateChange, "submitting");
+    let successfulGroups = 0;
+    let failedCount = 0;
+
+    const submitResult = await submitSignedGroups({
+      algod: algodClient,
+      signedGroups,
+      waitRounds,
+      onlyGroupIndices: retryGroupIndices,
+      onGroupSubmitted: (r) => {
+        if (r.txId) successfulGroups++;
+        else failedCount++;
+        emitProgress(onProgress, {
+          state: "submitting",
+          currentBatch: 0,
+          totalBatches: 1,
+          currentGroup: r.groupIndex,
+          totalGroups,
+          successfulGroups,
+          failedGroups: failedCount,
+          message: r.txId
+            ? `Confirmed group ${r.groupIndex + 1}`
+            : `Failed group ${r.groupIndex + 1}`,
+        });
+      },
+    });
+
+    const state: ClaimState =
+      submitResult.failedGroups.length > 0 ? "partial_failure" : "complete";
+    setState(onStateChange, state);
+    emitProgress(onProgress, {
+      state,
+      currentBatch: 0,
+      totalBatches: 1,
+      currentGroup: totalGroups,
+      totalGroups,
+      successfulGroups: submitResult.successfulTxIds.length,
+      failedGroups: submitResult.failedGroups.length,
+      progressPercent: 100,
+      message:
+        state === "complete"
+          ? "All claim groups confirmed"
+          : `${submitResult.failedGroups.length} group(s) failed`,
+    });
+
+    return {
+      ...submitResult,
+      state,
+      signedGroups,
+    };
+  } catch (err) {
+    if (err instanceof ClaimAllCancelledError) {
+      setState(onStateChange, "idle");
+      return {
+        successfulTxIds: [],
+        failedGroups: [],
+        confirmedRounds: [],
+        cancelled: true,
+        state: "idle",
+      };
+    }
+    if (isTransactionUserRejection(err)) {
+      setState(onStateChange, "idle");
+      return {
+        successfulTxIds: [],
+        failedGroups: [],
+        confirmedRounds: [],
+        cancelled: true,
+        state: "idle",
+      };
+    }
+    setState(onStateChange, "error");
+    throw err;
+  }
+}
+
+export interface ClaimAllFromEncodedGroupsOptions {
+  encodedGroups: Uint8Array[][];
+  signTransactions: ClaimAllRewardsOptions<unknown>["signTransactions"];
+  algodClient: Algodv2;
+  onProgress?: (progress: ClaimAllProgress) => void;
+  onStateChange?: (state: ClaimState) => void;
+  signal?: AbortSignal;
+  waitRounds?: number;
+}
+
+/**
+ * Claim All when atomic groups are already built (e.g. ulujs NFT drip `custom()` output).
+ */
+export async function claimAllFromEncodedGroups(
+  options: ClaimAllFromEncodedGroupsOptions
+): Promise<ClaimAllResult> {
+  const signingBatches = createSigningBatchesFromEncoded(options.encodedGroups);
+
+  const emptyResult: ClaimAllResult = {
+    successfulTxIds: [],
+    failedGroups: [],
+    confirmedRounds: [],
+    state: "complete",
+  };
+
+  if (signingBatches.length === 0) return emptyResult;
+
+  const {
+    algodClient,
+    signTransactions,
+    onProgress,
+    onStateChange,
+    signal,
+    waitRounds = 4,
+  } = options;
+
+  const totalGroups = options.encodedGroups.length;
+  const totalBatches = signingBatches.length;
+
+  try {
+    setState(onStateChange, "awaiting_signature");
+
+    emitProgress(onProgress, {
+      state: "awaiting_signature",
+      currentBatch: 0,
+      totalBatches,
+      currentGroup: 0,
+      totalGroups,
+      successfulGroups: 0,
+      failedGroups: 0,
+      message: "Approve transactions in your wallet",
+    });
+
+    if (signal?.aborted) throw new ClaimAllCancelledError();
+
+    const { signedGroups, usedPerGroupFallback } = await signAllEncodedBatches(
+      signingBatches,
+      signTransactions,
+      {
+        shouldCancel: () => signal?.aborted === true,
+        onBatchStart: (batchIndex, total) => {
+          emitProgress(onProgress, {
+            state: "awaiting_signature",
+            currentBatch: batchIndex,
+            totalBatches: total,
+            currentGroup: signingBatches[batchIndex]?.startGroupIndex ?? 0,
+            totalGroups,
+            successfulGroups: 0,
+            failedGroups: 0,
+            message: `Signing batch ${batchIndex + 1} of ${total}`,
+          });
+        },
+        onGroupStart: (groupIndex, total) => {
+          emitProgress(onProgress, {
+            state: "awaiting_signature",
+            currentBatch: 0,
+            totalBatches,
+            currentGroup: groupIndex,
+            totalGroups: total,
+            successfulGroups: 0,
+            failedGroups: 0,
+            message: `Approve group ${groupIndex + 1} of ${total}`,
+          });
+        },
+      }
+    );
+
+    if (usedPerGroupFallback && onProgress) {
+      emitProgress(onProgress, {
+        state: "awaiting_signature",
+        currentBatch: totalBatches,
+        totalBatches,
+        currentGroup: totalGroups,
+        totalGroups,
+        successfulGroups: 0,
+        failedGroups: 0,
+        message: "Signed one atomic group per wallet approval",
+      });
+    }
+
+    setState(onStateChange, "submitting");
+    let successfulGroups = 0;
+    let failedCount = 0;
+
+    const submitResult = await submitSignedGroups({
+      algod: algodClient,
+      signedGroups,
+      waitRounds,
+      onGroupSubmitted: (r) => {
+        if (r.txId) successfulGroups++;
+        else failedCount++;
+        emitProgress(onProgress, {
+          state: "submitting",
+          currentBatch: 0,
+          totalBatches: 1,
+          currentGroup: r.groupIndex,
+          totalGroups,
+          successfulGroups,
+          failedGroups: failedCount,
+        });
+      },
+    });
+
+    const state: ClaimState =
+      submitResult.failedGroups.length > 0 ? "partial_failure" : "complete";
+    setState(onStateChange, state);
+
+    return { ...submitResult, state, signedGroups };
+  } catch (err) {
+    if (err instanceof ClaimAllCancelledError || isTransactionUserRejection(err)) {
+      setState(onStateChange, "idle");
+      return { ...emptyResult, cancelled: true, state: "idle" };
+    }
+    setState(onStateChange, "error");
+    throw err;
+  }
+}
+
+/**
+ * Retry submission for failed groups only (no resign if `preSignedGroups` provided).
+ */
+export async function retryFailedClaimGroups(
+  options: ClaimAllRewardsOptions<unknown> & {
+    failedGroupIndices: number[];
+    preSignedGroups: Uint8Array[][];
+  }
+): Promise<ClaimAllResult> {
+  return claimAllRewards({
+    ...options,
+    positions: [],
+    buildTransactions: async () => [],
+    retryGroupIndices: options.failedGroupIndices,
+    preSignedGroups: options.preSignedGroups,
+  });
+}

--- a/src/lib/dorkfi/types.ts
+++ b/src/lib/dorkfi/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared types for DorkFi "Claim All" batching.
+ *
+ * Lifecycle: idle → building → awaiting_signature → submitting → complete | partial_failure | error
+ */
+
+/** Algorand protocol limit: transactions in one atomic group. */
+export const MAX_TXNS_PER_GROUP = 16;
+
+/**
+ * Wallet signing batch limit: how many atomic groups to flatten into one `signTransactions` call.
+ * Execution still submits each atomic group separately on-chain.
+ */
+export const MAX_GROUPS_PER_SIGNING = 16;
+
+export type ClaimState =
+  | "idle"
+  | "building"
+  | "awaiting_signature"
+  | "submitting"
+  | "complete"
+  | "partial_failure"
+  | "error";
+
+export interface ClaimAllProgress {
+  state: ClaimState;
+  /** 0-based signing batch index (wallet popup). */
+  currentBatch: number;
+  totalBatches: number;
+  /** 0-based atomic group index across the full run. */
+  currentGroup: number;
+  totalGroups: number;
+  successfulGroups: number;
+  failedGroups: number;
+  /** 0–100 for UI progress bars. */
+  progressPercent: number;
+  message?: string;
+}
+
+export interface ClaimAllResult {
+  successfulTxIds: string[];
+  /** Global atomic group indices (0..totalGroups-1) that failed submission. */
+  failedGroups: number[];
+  confirmedRounds: number[];
+  /** True if the user rejected a wallet signature. */
+  cancelled?: boolean;
+  /** Final state after the run. */
+  state: ClaimState;
+  /** Signed bytes per atomic group (for retry-failed submission). */
+  signedGroups?: Uint8Array[][];
+}
+
+/** Metadata for one signing batch (subset of atomic groups). */
+export interface SigningBatchPlan {
+  /** Global index of the first atomic group in this batch. */
+  startGroupIndex: number;
+  /** Atomic groups included in this batch (each already has assignGroupID applied). */
+  groups: import("algosdk").Transaction[][];
+  /** Flattened txns passed to the wallet for this batch. */
+  flat: import("algosdk").Transaction[];
+  /** Txn count per atomic group within `flat`, in order. */
+  groupSizes: number[];
+}
+
+/** Signing batch using raw unsigned bytes (from on-chain builders). */
+export interface SigningBatchPlanEncoded {
+  startGroupIndex: number;
+  groups: Uint8Array[][];
+  flat: Uint8Array[];
+  groupSizes: number[];
+}
+
+/** Full plan after building and grouping, before signing. */
+export interface ClaimAllPlan {
+  /** All atomic groups in execution order. */
+  groups: import("algosdk").Transaction[][];
+  signingBatches: SigningBatchPlan[];
+}
+
+export type SignTransactionsFn = (
+  txns: Uint8Array[]
+) => Promise<Uint8Array | Uint8Array[] | (Uint8Array | null)[]>;
+
+export interface ClaimAllRewardsOptions<TPosition> {
+  /** Claimable positions/markets/NFTs — interpreted by `buildTransactions`. */
+  positions: TPosition[];
+  /** Build unsigned claim txns (app calls, ARC-200 transfers, payments, etc.). */
+  buildTransactions: (positions: TPosition[]) => Promise<import("algosdk").Transaction[]>;
+  signTransactions: SignTransactionsFn;
+  algodClient: import("algosdk").Algodv2;
+  onProgress?: (progress: ClaimAllProgress) => void;
+  onStateChange?: (state: ClaimState) => void;
+  /** Abort before the next wallet sign (checked between signing batches). */
+  signal?: AbortSignal;
+  waitRounds?: number;
+  /**
+   * When set, only submit these global group indices (retry failed groups).
+   * Caller must supply already-signed bytes via `preSignedGroups`.
+   */
+  retryGroupIndices?: number[];
+  preSignedGroups?: Uint8Array[][];
+}

--- a/src/services/nftDripClaimService.ts
+++ b/src/services/nftDripClaimService.ts
@@ -1,0 +1,423 @@
+import algosdk, { type Algodv2 } from "algosdk";
+import { abi, CONTRACT } from "ulujs";
+import type { UnitNftDripCampaignConfig } from "@/config/nftDrips";
+
+const ONE_WEEK_SECONDS = 7 * 24 * 3600;
+
+/** Algorand atomic transaction group size limit. */
+export const ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP = 16;
+
+export { MAX_TXNS_PER_GROUP, MAX_GROUPS_PER_SIGNING } from "@/lib/dorkfi/types";
+export type { ClaimAllProgress, ClaimAllResult, ClaimState } from "@/lib/dorkfi/types";
+export { claimAllFromEncodedGroups, claimAllRewards, retryFailedClaimGroups } from "@/lib/dorkfi/claimAll";
+
+/** Max NFTs per wallet claim (Nautilus-style single `custom()` group). */
+export const NFT_DRIP_CLAIMS_PER_GROUP = 6;
+/** @deprecated Use {@link NFT_DRIP_CLAIMS_PER_GROUP}. */
+export const NFT_DRIP_MAX_CLAIMS_PER_SESSION = NFT_DRIP_CLAIMS_PER_GROUP;
+
+export type NftDripInfo = {
+  collectionId: number;
+  tokenId: string;
+  lastDripTimestamp: number;
+  claimAmount: number;
+  maxClaimAmount: number;
+  availableClaimAmount: number;
+  claimableAmount: number;
+};
+
+export type NftDripClaimTarget = {
+  contractId: number;
+  tokenId: string;
+  claimableAmount: number;
+  config: UnitNftDripCampaignConfig;
+};
+
+function toNum(v: unknown): number {
+  if (v === undefined || v === null) return 0;
+  if (typeof v === "bigint") return Number(v);
+  const n = Number(v);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+export function computeClaimableAmount(
+  lastDripTimestamp: number,
+  availableClaimAmount: number,
+  dripPerWeekRaw: number
+): number {
+  if (availableClaimAmount <= 0) return 0;
+  if (lastDripTimestamp <= 0) return availableClaimAmount;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const elapsed = Math.max(0, nowSeconds - lastDripTimestamp);
+  const accrued = (elapsed / ONE_WEEK_SECONDS) * dripPerWeekRaw;
+  const amountDivisible = Math.floor(accrued / dripPerWeekRaw) * dripPerWeekRaw;
+  return Math.min(amountDivisible, availableClaimAmount);
+}
+
+export async function readNftDripInfo(
+  cfg: UnitNftDripCampaignConfig,
+  nftContractId: number,
+  tokenId: string,
+  owner: string,
+  algod: Algodv2
+): Promise<NftDripInfo | null> {
+  if (!cfg.dripContractId) return null;
+
+  const tryDrip = async (readonly: boolean): Promise<NftDripInfo | null> => {
+    const CONTRACT_CI = new CONTRACT(
+      cfg.dripContractId,
+      algod,
+      undefined,
+      {
+        name: "drip",
+        desc: "drip",
+        methods: [
+          {
+            name: "drip",
+            args: [
+              { type: "uint64", name: "collection_id" },
+              { type: "uint256", name: "token_id" },
+            ],
+            readonly,
+            returns: { type: "(uint64,uint256,uint64,uint256,uint256)" },
+          },
+        ],
+        events: [],
+      },
+      { addr: owner, sk: new Uint8Array(0) }
+    );
+    const result = await CONTRACT_CI.drip(Number(nftContractId), Number(tokenId));
+    if (!result.success) return null;
+    const rv = result.returnValue;
+    if (rv === undefined || rv === null) return null;
+    const r = rv as Record<number, unknown>;
+    const claimAmount = toNum(r[3]);
+    const maxClaimAmount = toNum(r[4]);
+    const lastDripTimestamp = toNum(r[2]);
+    const availableClaimAmount = Math.max(0, maxClaimAmount - claimAmount);
+    const claimableAmount = computeClaimableAmount(
+      lastDripTimestamp,
+      availableClaimAmount,
+      cfg.dripPerWeekRaw
+    );
+    return {
+      collectionId: toNum(r[0]),
+      tokenId: r[1] != null ? String(r[1]) : tokenId,
+      lastDripTimestamp,
+      claimAmount,
+      maxClaimAmount,
+      availableClaimAmount,
+      claimableAmount,
+    };
+  };
+
+  try {
+    const info = await tryDrip(true);
+    if (info !== null) return info;
+    return await tryDrip(false);
+  } catch {
+    return null;
+  }
+}
+
+function errorMessageChain(err: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = err;
+  for (let depth = 0; depth < 4 && current; depth++) {
+    if (current instanceof Error) {
+      parts.push(current.message);
+      current = current.cause;
+    } else {
+      parts.push(String(current));
+      break;
+    }
+  }
+  return parts.join(" ");
+}
+
+function isOversizedAtomicGroupBuildError(err: unknown): boolean {
+  const msg = errorMessageChain(err);
+  return (
+    /max group size is 16/i.test(msg) ||
+    /grouped together but max/i.test(msg) ||
+    /transaction group limit/i.test(msg)
+  );
+}
+
+function throwOversizedClaimBatchError(targetCount: number): never {
+  throw new Error(
+    `${targetCount} claims exceed the ${ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP}-transaction atomic group limit`
+  );
+}
+
+/** True when ulujs can build this slice as one atomic group (≤16 txns). */
+async function claimSliceFitsOneAtomicGroup(
+  cfg: UnitNftDripCampaignConfig,
+  slice: NftDripClaimTarget[],
+  ownerAddress: string,
+  algod: Algodv2,
+  maxTxnsPerGroup = ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP
+): Promise<boolean> {
+  try {
+    const built = await buildNftDripClaimGroupBytes(cfg, slice, ownerAddress, algod);
+    return built.length > 0 && built.length <= maxTxnsPerGroup;
+  } catch (err) {
+    if (isOversizedAtomicGroupBuildError(err)) return false;
+    throw err;
+  }
+}
+
+/**
+ * Splits claims into multiple on-chain groups (each ≤16 txns via separate `custom()` builds).
+ */
+export async function chunkClaimTargetsByTxnLimit(
+  cfg: UnitNftDripCampaignConfig,
+  targets: NftDripClaimTarget[],
+  ownerAddress: string,
+  algod: Algodv2,
+  maxTxnsPerGroup = ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP
+): Promise<{ chunks: NftDripClaimTarget[][]; builtGroups: Uint8Array[][] }> {
+  if (targets.length === 0) return { chunks: [], builtGroups: [] };
+
+  const soloFits = await claimSliceFitsOneAtomicGroup(
+    cfg,
+    [targets[0]!],
+    ownerAddress,
+    algod,
+    maxTxnsPerGroup
+  );
+  if (!soloFits) {
+    throw new Error(
+      `NFT #${targets[0]!.tokenId} exceeds the ${maxTxnsPerGroup}-transaction atomic group limit`
+    );
+  }
+
+  let txnsPerAdditionalClaim = 1;
+  if (targets.length >= 2) {
+    const twoFits = await claimSliceFitsOneAtomicGroup(
+      cfg,
+      targets.slice(0, 2),
+      ownerAddress,
+      algod,
+      maxTxnsPerGroup
+    );
+    if (twoFits) {
+      const oneGroup = await buildNftDripClaimGroupBytes(cfg, [targets[0]!], ownerAddress, algod);
+      const twoGroup = await buildNftDripClaimGroupBytes(
+        cfg,
+        targets.slice(0, 2),
+        ownerAddress,
+        algod
+      );
+      txnsPerAdditionalClaim = Math.max(1, twoGroup.length - oneGroup.length);
+    }
+  }
+
+  let estimatedMaxClaims = 1;
+  const oneLen = (await buildNftDripClaimGroupBytes(cfg, [targets[0]!], ownerAddress, algod)).length;
+  let estimatedTotal = oneLen;
+  while (estimatedTotal + txnsPerAdditionalClaim <= maxTxnsPerGroup) {
+    estimatedTotal += txnsPerAdditionalClaim;
+    estimatedMaxClaims++;
+  }
+
+  const chunks: NftDripClaimTarget[][] = [];
+  const builtGroups: Uint8Array[][] = [];
+  let index = 0;
+  while (index < targets.length) {
+    let size = Math.min(estimatedMaxClaims, targets.length - index);
+    let placed = false;
+    while (size >= 1) {
+      const slice = targets.slice(index, index + size);
+      const fits = await claimSliceFitsOneAtomicGroup(
+        cfg,
+        slice,
+        ownerAddress,
+        algod,
+        maxTxnsPerGroup
+      );
+      if (fits) {
+        const built = await buildNftDripClaimGroupBytes(cfg, slice, ownerAddress, algod);
+        chunks.push(slice);
+        builtGroups.push(built);
+        index += size;
+        placed = true;
+        break;
+      }
+      size--;
+    }
+    if (!placed) {
+      const t = targets[index]!;
+      throw new Error(
+        `Could not fit NFT #${t.tokenId} into a valid transaction group (max ${maxTxnsPerGroup} per group)`
+      );
+    }
+  }
+  return { chunks, builtGroups };
+}
+
+export type NftDripClaimSigningBundle = {
+  /** All unsigned txns in wallet order (multiple atomic groups concatenated). */
+  unsignedFlat: Uint8Array[];
+  /** Txn count per on-chain atomic group. */
+  groupSizes: number[];
+  /** Every target included across all groups. */
+  targetsForSign: NftDripClaimTarget[];
+  /** Wallet-ready bytes per on-chain group (used if batch sign fails). */
+  preparedGroups: Uint8Array[][];
+};
+
+/**
+ * Use ulujs `custom()` bytes as-is (do not re-assign group id — that breaks signing with 4300).
+ */
+export function flattenBuiltGroupsForSigning(builtGroups: Uint8Array[][]): Pick<
+  NftDripClaimSigningBundle,
+  "unsignedFlat" | "groupSizes" | "preparedGroups"
+> {
+  const preparedGroups: Uint8Array[][] = [];
+  const groupSizes: number[] = [];
+  const unsignedFlat: Uint8Array[] = [];
+
+  for (const groupBytes of builtGroups) {
+    if (groupBytes.length > ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP) {
+      throw new Error(
+        `Transaction group has ${groupBytes.length} transactions (max ${ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP})`
+      );
+    }
+    preparedGroups.push(groupBytes);
+    groupSizes.push(groupBytes.length);
+    unsignedFlat.push(...groupBytes);
+  }
+  return { unsignedFlat, groupSizes, preparedGroups };
+}
+
+export async function buildNftDripClaimSigningBundle(
+  cfg: UnitNftDripCampaignConfig,
+  targets: NftDripClaimTarget[],
+  ownerAddress: string,
+  algod: Algodv2
+): Promise<NftDripClaimSigningBundle> {
+  if (targets.length === 0) {
+    return { unsignedFlat: [], groupSizes: [], targetsForSign: [], preparedGroups: [] };
+  }
+  if (targets.length > NFT_DRIP_CLAIMS_PER_GROUP) {
+    throw new Error(
+      `At most ${NFT_DRIP_CLAIMS_PER_GROUP} NFTs per claim (got ${targets.length})`
+    );
+  }
+
+  // Never pass the full claim list into one `custom()` probe — ulujs simulates all extra txns
+  // together and throws "168 transactions grouped together but max group size is 16".
+  // Only try the Nautilus single-group path for small selections.
+  if (targets.length <= NFT_DRIP_CLAIMS_PER_GROUP) {
+    try {
+      if (await claimSliceFitsOneAtomicGroup(cfg, targets, ownerAddress, algod)) {
+        const built = await buildNftDripClaimGroupBytes(cfg, targets, ownerAddress, algod);
+        const flat = flattenBuiltGroupsForSigning([built]);
+        return { ...flat, targetsForSign: targets };
+      }
+    } catch (err) {
+      if (!isOversizedAtomicGroupBuildError(err)) throw err;
+    }
+  }
+
+  const { chunks, builtGroups } = await chunkClaimTargetsByTxnLimit(
+    cfg,
+    targets,
+    ownerAddress,
+    algod
+  );
+  const flat = flattenBuiltGroupsForSigning(builtGroups);
+  return {
+    ...flat,
+    targetsForSign: chunks.flat(),
+  };
+}
+
+export type SignTransactionsFn = import("@/lib/dorkfi/types").SignTransactionsFn;
+
+/** Build one atomic claim group (same reward token + drip app). Caller must keep ≤16 txns. */
+export async function buildNftDripClaimGroupBytes(
+  cfg: UnitNftDripCampaignConfig,
+  targets: NftDripClaimTarget[],
+  ownerAddress: string,
+  algod: Algodv2
+): Promise<Uint8Array[]> {
+  if (targets.length === 0) throw new Error("No NFTs to claim");
+
+  const sym = cfg.rewardSymbol;
+  const ci = new CONTRACT(
+    cfg.rewardTokenContractId,
+    algod,
+    undefined,
+    abi.custom,
+    { addr: ownerAddress, sk: new Uint8Array(0) }
+  );
+  const builder = {
+    drip: new CONTRACT(
+      cfg.dripContractId,
+      algod,
+      undefined,
+      {
+        name: "drip",
+        desc: "drip",
+        methods: [
+          {
+            name: "claim",
+            args: [
+              { type: "uint64", name: "collection_id" },
+              { type: "uint256", name: "token_id" },
+            ],
+            readonly: false,
+            returns: { type: "uint256" },
+          },
+        ],
+        events: [],
+      },
+      { addr: ownerAddress, sk: new Uint8Array(0) },
+      true,
+      false,
+      true
+    ),
+  };
+
+  const buildN: Record<string, unknown>[] = [];
+  let i = 0;
+  for (const t of targets) {
+    const txnO = (await builder.drip.claim(Number(t.contractId), Number(t.tokenId))).obj;
+    buildN.push({
+      ...txnO,
+      payment: 1e6 - 7000 + i++,
+      note: new TextEncoder().encode(`claim ${sym} from ${t.contractId}-${t.tokenId}`),
+    });
+  }
+  if (buildN.length === 0) throw new Error("Failed to build claim transaction(s)");
+  ci.setExtraTxns(buildN);
+  ci.setEnableGroupResourceSharing(true);
+  ci.setFee(4000);
+
+  let customR: { success: boolean; txns?: string[] };
+  try {
+    customR = await ci.custom();
+  } catch (err) {
+    if (isOversizedAtomicGroupBuildError(err)) throwOversizedClaimBatchError(targets.length);
+    throw err;
+  }
+
+  if (!customR.success || !Array.isArray(customR.txns)) {
+    if (targets.length > 1) throwOversizedClaimBatchError(targets.length);
+    throw new Error("Failed to build claim transaction(s)");
+  }
+  if (customR.txns.length > ALGORAND_MAX_TXNS_PER_ATOMIC_GROUP) {
+    throwOversizedClaimBatchError(targets.length);
+  }
+  return (customR.txns as string[]).map((txn) => Uint8Array.from(Buffer.from(txn, "base64")));
+}
+
+export function formatDripRewardAmount(raw: number, decimals: number): string {
+  const div = 10 ** decimals;
+  return (raw / div).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: Math.min(decimals, 8),
+  });
+}

--- a/src/services/paidWorkflowGateway.ts
+++ b/src/services/paidWorkflowGateway.ts
@@ -78,23 +78,60 @@ export type NftHolderUnsignedClaimTxnRow = {
   summary?: string;
 };
 
+/** Max manual claims per batch (matches claim-agent-service). */
+export const MAX_NFT_HOLDER_MANUAL_CLAIMS = 100;
+
+export type NftHolderUnsignedClaimGroup = {
+  slot?: NftHolderUnsignedClaimSlot | null;
+  claimable: boolean;
+  transactions: NftHolderUnsignedClaimTxnRow[];
+  errors: unknown[];
+};
+
 export type NftHolderUnsignedClaimResponse = {
   address: string;
   claimable: boolean;
   slot?: NftHolderUnsignedClaimSlot | null;
   transactions: NftHolderUnsignedClaimTxnRow[];
+  /** When `maxSlots` > 1 on the agent, one atomic group per claimable slot. */
+  groups?: NftHolderUnsignedClaimGroup[];
   errors: unknown[];
+};
+
+export type NftHolderBatchUnsignedClaimResponse = {
+  claims: NftHolderUnsignedClaimResponse[];
+  summary: {
+    total: number;
+    claimable: number;
+    withTransactions: number;
+    failed: number;
+  };
 };
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }
 
-function parseUnsignedClaimJson(json: unknown): NftHolderUnsignedClaimResponse {
-  if (!isRecord(json)) {
-    throw new Error("Invalid unsigned claim response: not an object");
-  }
-  const transactionsRaw = json.transactions;
+function parseUnsignedClaimSlot(raw: unknown): NftHolderUnsignedClaimSlot | null | undefined {
+  if (raw === null) return null;
+  if (!isRecord(raw)) return undefined;
+  const s = raw;
+  return {
+    campaignId: typeof s.campaignId === "string" ? s.campaignId : undefined,
+    campaignName: typeof s.campaignName === "string" ? s.campaignName : undefined,
+    owner: typeof s.owner === "string" ? s.owner : undefined,
+    collectionId: typeof s.collectionId === "number" ? s.collectionId : undefined,
+    tokenId: typeof s.tokenId === "string" ? s.tokenId : undefined,
+    dripContractId: typeof s.dripContractId === "number" ? s.dripContractId : undefined,
+    rewardTokenContractId:
+      typeof s.rewardTokenContractId === "number" ? s.rewardTokenContractId : undefined,
+    rewardSymbol: typeof s.rewardSymbol === "string" ? s.rewardSymbol : undefined,
+    claimableRaw: typeof s.claimableRaw === "string" ? s.claimableRaw : undefined,
+    claimableDisplay: typeof s.claimableDisplay === "string" ? s.claimableDisplay : undefined,
+  };
+}
+
+function parseUnsignedClaimTransactions(transactionsRaw: unknown): NftHolderUnsignedClaimTxnRow[] {
   if (!Array.isArray(transactionsRaw)) {
     throw new Error("Invalid unsigned claim response: missing transactions[]");
   }
@@ -118,38 +155,91 @@ function parseUnsignedClaimJson(json: unknown): NftHolderUnsignedClaimResponse {
       summary: typeof row.summary === "string" ? row.summary : undefined,
     });
   }
+  return transactions;
+}
+
+function parseUnsignedClaimGroup(raw: unknown): NftHolderUnsignedClaimGroup | null {
+  if (!isRecord(raw)) return null;
+  const transactions = parseUnsignedClaimTransactions(raw.transactions);
+  const claimable = typeof raw.claimable === "boolean" ? raw.claimable : transactions.length > 0;
+  return {
+    slot: parseUnsignedClaimSlot(raw.slot),
+    claimable,
+    transactions,
+    errors: Array.isArray(raw.errors) ? raw.errors : [],
+  };
+}
+
+function parseUnsignedClaimJson(json: unknown): NftHolderUnsignedClaimResponse {
+  if (!isRecord(json)) {
+    throw new Error("Invalid unsigned claim response: not an object");
+  }
+  const transactions = parseUnsignedClaimTransactions(json.transactions);
   const addr = typeof json.address === "string" ? json.address : "";
   const claimable = typeof json.claimable === "boolean" ? json.claimable : false;
   const errors = Array.isArray(json.errors) ? json.errors : [];
-  let slot: NftHolderUnsignedClaimSlot | null | undefined;
-  if (json.slot === null) {
-    slot = null;
-  } else if (isRecord(json.slot)) {
-    const s = json.slot;
-    slot = {
-      campaignId: typeof s.campaignId === "string" ? s.campaignId : undefined,
-      campaignName: typeof s.campaignName === "string" ? s.campaignName : undefined,
-      owner: typeof s.owner === "string" ? s.owner : undefined,
-      collectionId: typeof s.collectionId === "number" ? s.collectionId : undefined,
-      tokenId: typeof s.tokenId === "string" ? s.tokenId : undefined,
-      dripContractId: typeof s.dripContractId === "number" ? s.dripContractId : undefined,
-      rewardTokenContractId:
-        typeof s.rewardTokenContractId === "number" ? s.rewardTokenContractId : undefined,
-      rewardSymbol: typeof s.rewardSymbol === "string" ? s.rewardSymbol : undefined,
-      claimableRaw: typeof s.claimableRaw === "string" ? s.claimableRaw : undefined,
-      claimableDisplay: typeof s.claimableDisplay === "string" ? s.claimableDisplay : undefined,
-    };
+  const slot = parseUnsignedClaimSlot(json.slot);
+  let groups: NftHolderUnsignedClaimGroup[] | undefined;
+  if (Array.isArray(json.groups)) {
+    const parsed = json.groups.map(parseUnsignedClaimGroup).filter((g): g is NftHolderUnsignedClaimGroup => g != null);
+    if (parsed.length > 0) groups = parsed;
   }
-  return { address: addr, claimable, slot, transactions, errors };
+  return { address: addr, claimable, slot, transactions, groups, errors };
+}
+
+/** Collect signable groups from a single-address or per-address batch response. */
+export function collectNftHolderUnsignedClaimGroups(
+  claim: NftHolderUnsignedClaimResponse
+): NftHolderUnsignedClaimGroup[] {
+  if (claim.groups?.length) {
+    return claim.groups.filter((g) => g.transactions.length > 0);
+  }
+  if (claim.transactions.length > 0) {
+    return [
+      {
+        slot: claim.slot,
+        claimable: claim.claimable,
+        transactions: claim.transactions,
+        errors: claim.errors,
+      },
+    ];
+  }
+  return [];
+}
+
+export function estimateNftHolderClaimFeeMicros(rows: NftHolderUnsignedClaimTxnRow[]): bigint {
+  let total = 0n;
+  for (const row of rows) {
+    if (!row.feeMicros) continue;
+    try {
+      total += BigInt(row.feeMicros);
+    } catch {
+      /* ignore invalid fee */
+    }
+  }
+  return total;
+}
+
+function getNftClaimAgentApiKey(): string | undefined {
+  const raw = (import.meta.env.VITE_NFT_CLAIM_AGENT_API_KEY as string | undefined)?.trim();
+  return raw || undefined;
+}
+
+function nftClaimAgentAuthHeaders(): HeadersInit {
+  const key = getNftClaimAgentApiKey();
+  if (!key) return {};
+  return { Authorization: `Bearer ${key}`, "x-api-key": key };
 }
 
 /**
- * Manual claim: unsigned transaction group from {@link getNftHolderClaimAgentBase}
- * (`GET …/claim/:address/unsigned?relayer=`).
+ * Manual claim: unsigned transaction group(s) from {@link getNftHolderClaimAgentBase}
+ * (`GET …/claim/:address/unsigned?relayer=&maxSlots=`).
  */
 export async function fetchNftHolderUnsignedClaim(params: {
   beneficiaryAddress: string;
   relayerAddress: string;
+  /** 1–100; default 1. Values > 1 request all claimable slots up to the cap. */
+  maxSlots?: number;
 }): Promise<NftHolderUnsignedClaimResponse> {
   const beneficiary = params.beneficiaryAddress.trim();
   const relayer = params.relayerAddress.trim();
@@ -159,15 +249,98 @@ export async function fetchNftHolderUnsignedClaim(params: {
   if (!relayer) {
     throw new Error("Missing relayer address for unsigned claim");
   }
+  const maxSlots = Math.min(
+    MAX_NFT_HOLDER_MANUAL_CLAIMS,
+    Math.max(1, Math.floor(params.maxSlots ?? 1))
+  );
   const base = getNftHolderClaimAgentBase();
   const url = new URL(`${base}/${encodeURIComponent(beneficiary)}/unsigned`);
   url.searchParams.set("relayer", relayer);
+  if (maxSlots > 1) url.searchParams.set("maxSlots", String(maxSlots));
   const res = await fetch(url.toString());
   if (!res.ok) {
     throw new Error(`Unsigned claim HTTP ${res.status}`);
   }
   const json: unknown = await res.json();
   return parseUnsignedClaimJson(json);
+}
+
+/**
+ * Batch manual claim: up to {@link MAX_NFT_HOLDER_MANUAL_CLAIMS} beneficiary addresses.
+ * Uses `POST …/claim/batch/unsigned` when an API key is configured; otherwise parallel GETs.
+ */
+export async function fetchNftHolderBatchUnsignedClaims(params: {
+  beneficiaryAddresses: string[];
+  relayerAddress: string;
+}): Promise<NftHolderBatchUnsignedClaimResponse> {
+  const relayer = params.relayerAddress.trim();
+  if (!relayer) {
+    throw new Error("Missing relayer address for batch unsigned claim");
+  }
+  const unique = [
+    ...new Set(
+      params.beneficiaryAddresses.map((a) => a.trim()).filter((a) => a.length > 0)
+    ),
+  ].slice(0, MAX_NFT_HOLDER_MANUAL_CLAIMS);
+  if (unique.length === 0) {
+    throw new Error("Add at least one beneficiary address");
+  }
+  if (unique.length > MAX_NFT_HOLDER_MANUAL_CLAIMS) {
+    throw new Error(`Batch is limited to ${MAX_NFT_HOLDER_MANUAL_CLAIMS} claims`);
+  }
+
+  const base = getNftHolderClaimAgentBase();
+  const apiKey = getNftClaimAgentApiKey();
+
+  if (apiKey) {
+    const url = new URL(`${base}/batch/unsigned`);
+    url.searchParams.set("relayer", relayer);
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...nftClaimAgentAuthHeaders() },
+      body: JSON.stringify({ claims: unique.map((address) => ({ address })) }),
+    });
+    if (!res.ok) {
+      throw new Error(`Batch unsigned claim HTTP ${res.status}`);
+    }
+    const json: unknown = await res.json();
+    if (!isRecord(json) || !Array.isArray(json.claims)) {
+      throw new Error("Invalid batch unsigned claim response");
+    }
+    const claims = json.claims.map(parseUnsignedClaimJson);
+    const summaryRaw = json.summary;
+    const summary = isRecord(summaryRaw)
+      ? {
+          total: typeof summaryRaw.total === "number" ? summaryRaw.total : claims.length,
+          claimable: typeof summaryRaw.claimable === "number" ? summaryRaw.claimable : 0,
+          withTransactions:
+            typeof summaryRaw.withTransactions === "number" ? summaryRaw.withTransactions : 0,
+          failed: typeof summaryRaw.failed === "number" ? summaryRaw.failed : 0,
+        }
+      : {
+          total: claims.length,
+          claimable: claims.filter((c) => c.claimable && c.transactions.length > 0).length,
+          withTransactions: claims.filter((c) => c.transactions.length > 0).length,
+          failed: claims.filter((c) => c.transactions.length === 0).length,
+        };
+    return { claims, summary };
+  }
+
+  const claims = await Promise.all(
+    unique.map((beneficiaryAddress) =>
+      fetchNftHolderUnsignedClaim({ beneficiaryAddress, relayerAddress: relayer })
+    )
+  );
+  const withTransactions = claims.filter((c) => c.transactions.length > 0).length;
+  return {
+    claims,
+    summary: {
+      total: claims.length,
+      claimable: claims.filter((c) => c.claimable && c.transactions.length > 0).length,
+      withTransactions,
+      failed: claims.length - withTransactions,
+    },
+  };
 }
 
 const DEFAULT_NFT_CLAIM_MANUAL_URL = "https://docs.dork.fi";

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -2,6 +2,64 @@
  * Converts technical error messages to user-friendly messages
  */
 
+function errorMessageString(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/** Wallet / signer declined the transaction (not a protocol or build failure). */
+export function isTransactionUserRejection(error: unknown): boolean {
+  const msg = errorMessageString(error).toLowerCase();
+  if (
+    msg.includes("user rejected") ||
+    msg.includes("rejected request") ||
+    msg.includes("user cancelled") ||
+    msg.includes("user canceled") ||
+    msg.includes("user denied") ||
+    msg.includes("request rejected") ||
+    msg.includes("signing cancelled") ||
+    msg.includes("signing canceled") ||
+    msg.includes("transaction cancelled") ||
+    msg.includes("transaction canceled") ||
+    msg.includes("cancelled by user") ||
+    msg.includes("canceled by user")
+  ) {
+    return true;
+  }
+  const code = (error as { code?: number | string })?.code;
+  if (code === 4001 || code === "4001" || code === "ACTION_REJECTED") return true;
+  return false;
+}
+
+/** Wallet rejected txn list because atomic group structure is invalid (ARC-0001 / Lute 4300). */
+export function isInvalidGroupSignError(error: unknown): boolean {
+  const msg = errorMessageString(error).toLowerCase();
+  if (msg.includes("invalid group")) return true;
+  const code = (error as { code?: number | string })?.code;
+  if (code === 4300 || code === "4300") return true;
+  return (code === 4201 || code === "4201") && msg.includes("group");
+}
+
+export type TransactionErrorFeedback = {
+  userRejected: boolean;
+  message: string;
+};
+
+export function getTransactionErrorFeedback(error: unknown): TransactionErrorFeedback {
+  const userRejected = isTransactionUserRejection(error);
+  return {
+    userRejected,
+    message: userRejected
+      ? "Transaction cancelled in your wallet. You can try again when ready."
+      : getUserFriendlyError(error),
+  };
+}
+
 /**
  * Formats microAlgos to ALGO with proper decimals
  * Shows up to 6 decimal places, removing trailing zeros

--- a/src/utils/nftHolderManualClaimAddresses.ts
+++ b/src/utils/nftHolderManualClaimAddresses.ts
@@ -1,0 +1,30 @@
+import { MAX_NFT_HOLDER_MANUAL_CLAIMS } from "@/services/paidWorkflowGateway";
+
+/** Parse newline- or comma-separated AVM addresses (up to 100 unique). */
+export function parseBeneficiaryAddressesFromText(text: string): {
+  addresses: string[];
+  errors: string[];
+} {
+  const errors: string[] = [];
+  const parts = text
+    .split(/[\n,;]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const p of parts) {
+    const key = p.toUpperCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (p.length < 50 || p.length > 60) {
+      errors.push(`Skipped invalid address: ${p.slice(0, 12)}…`);
+      continue;
+    }
+    unique.push(p);
+    if (unique.length >= MAX_NFT_HOLDER_MANUAL_CLAIMS) break;
+  }
+  if (parts.length > MAX_NFT_HOLDER_MANUAL_CLAIMS) {
+    errors.push(`Only the first ${MAX_NFT_HOLDER_MANUAL_CLAIMS} unique addresses are used.`);
+  }
+  return { addresses: unique, errors };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -13,6 +13,8 @@ interface ImportMetaEnv {
   readonly VITE_NFT_CLAIM_AGENT_BASE?: string;
   /** Optional 58-char relayer for `GET …/claim/:addr/unsigned?relayer=`; defaults to the beneficiary address. */
   readonly VITE_NFT_CLAIM_RELAYER_ADDRESS?: string;
+  /** Optional API key for `POST …/claim/batch/unsigned` (Bearer + x-api-key). Without it, batch uses parallel GETs. */
+  readonly VITE_NFT_CLAIM_AGENT_API_KEY?: string;
   /** Optional absolute URL for “claim manually” in the NFT rewards modal (defaults to docs). */
   readonly VITE_NFT_CLAIM_MANUAL_URL?: string;
   /** `claimlayer-paid-claimall` JSON `targetChain` (default `voi:mainnet`). Execute body includes `algorandAddress` + `address` (AVM beneficiary). */


### PR DESCRIPTION
## Summary

- Replace claim-agent unsigned-tx manual flow with on-chain UNIT drip claims (ulujs/Nautilus-style) for Dorks and Dorks V2 on Voi, embedded in the portfolio manual-claim modal.
- Cap each wallet approval at six NFTs per batch; remove standalone `/tools/dork-drip` pages.
- Add Algorand grouping/signing/submission helpers with encoded-byte signing and per-group fallback for Invalid Group (4300) wallet errors.

## Test plan

- [ ] On Voi portfolio with Dorks/Dorks V2 NFTs, open **Open manual claim** from NFT rewards modal
- [ ] Connect wallet matching portfolio beneficiary; verify NFT list and claimable amounts load
- [ ] Claim single NFT, claim selected (≤6), and **Claim batch** with >6 claimable (only first 6 submit; repeat for remainder)
- [ ] Confirm one wallet prompt per batch and successful on-chain confirmation
- [ ] Verify Dorks / Dorks V2 tabs both build and submit claims
- [ ] Cancel wallet signature — UI should recover without losing NFT list


Made with [Cursor](https://cursor.com)