### PR TITLE
feat(nft): gate pay-agent on Base behind enableAgentClaim flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.726",
+  "version": "0.1.729",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/portfolio/NftHolderRewardsGatewayPaySection.tsx
+++ b/src/components/portfolio/NftHolderRewardsGatewayPaySection.tsx
@@ -20,8 +20,9 @@ import {
   getClaimlayerUsdAmount,
   getPaidWorkflowGatewayOrigin,
 } from "@/services/paidWorkflowGateway";
-import { AlertTriangle, ChevronRight, Loader2, RefreshCw } from "lucide-react";
+import { AlertTriangle, ChevronRight, Construction, Loader2, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isFeatureEnabled } from "@/config";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 
 const walletConnectProjectId =
@@ -430,6 +431,24 @@ function NftHolderRewardsGatewayPayInner({
   );
 }
 
+function AgentClaimMaintenancePanel() {
+  return (
+    <div className="space-y-3 text-slate-100" role="status" aria-live="polite">
+      <div className="flex gap-3 rounded-xl border border-amber-500/35 bg-amber-950/25 px-4 py-4">
+        <Construction className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" aria-hidden />
+        <div className="min-w-0 space-y-1.5">
+          <p className="text-sm font-semibold text-amber-50">Maintenance mode</p>
+          <p className="text-xs leading-relaxed text-slate-400">
+            Pay agent on Base (x402) is temporarily unavailable. Wallet connection and USDC
+            payment are disabled until maintenance completes. Manual claim on Voi remains available
+            above when you are on the Voi network.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 type NftHolderRewardsGatewayPaySectionProps = {
   algorandPortfolioAddress: string;
   /** Connected AVM account from the app wallet (required for this flow; not sent as `targetAddress`). */
@@ -451,6 +470,10 @@ export function NftHolderRewardsGatewayPaySection({
   onClose,
   onClaimSuccessShare,
 }: NftHolderRewardsGatewayPaySectionProps) {
+  if (!isFeatureEnabled("enableAgentClaim")) {
+    return <AgentClaimMaintenancePanel />;
+  }
+
   const gatewayOrigin = getPaidWorkflowGatewayOrigin();
 
   if (!gatewayOrigin) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -859,6 +859,8 @@ export interface GlobalConfig {
     enableGasStation: boolean;
     enableNFTBoost: boolean;
     enableLiquidatablePositions: boolean;
+    /** NFT holder rewards — pay agent on Base (x402) in portfolio modal. */
+    enableAgentClaim: boolean;
   };
 }
 
@@ -3054,6 +3056,7 @@ export const config: GlobalConfig = {
     enableGasStation: false,
     enableNFTBoost: true, // Enable NFT boost for governance voting power
     enableLiquidatablePositions: true, // Enable liquidatable positions section in portfolio
+    enableAgentClaim: true, // NFT holder reward claim — Base x402 pay-agent section
   },
 };
 
@@ -4010,7 +4013,7 @@ export const getPreFiParameters = (
 export const isFeatureEnabled = (
   feature: keyof GlobalConfig["features"]
 ): boolean => {
-  return config.features[feature];
+  return getConfig().features[feature];
 };
 
 /**
@@ -4083,6 +4086,12 @@ export const getEnvironmentConfig = (): Partial<GlobalConfig> => {
     envFeatures.enableLiquidatablePositions =
       import.meta.env.VITE_ENABLE_LIQUIDATABLE_POSITIONS === "true" ||
       import.meta.env.VITE_ENABLE_LIQUIDATABLE_POSITIONS === "1";
+  }
+
+  if (typeof import.meta.env.VITE_ENABLE_AGENT_CLAIM !== "undefined") {
+    envFeatures.enableAgentClaim =
+      import.meta.env.VITE_ENABLE_AGENT_CLAIM === "true" ||
+      import.meta.env.VITE_ENABLE_AGENT_CLAIM === "1";
   }
 
   if (env === "development") {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,4 +19,6 @@ interface ImportMetaEnv {
   readonly VITE_NFT_CLAIM_MANUAL_URL?: string;
   /** `claimlayer-paid-claimall` JSON `targetChain` (default `voi:mainnet`). Execute body includes `algorandAddress` + `address` (AVM beneficiary). */
   readonly VITE_CLAIMLAYER_TARGET_CHAIN?: string;
+  /** When `false` or `0`, NFT holder pay-agent on Base shows maintenance UI instead of WalletConnect. */
+  readonly VITE_ENABLE_AGENT_CLAIM?: string;
 }


### PR DESCRIPTION
## Summary
- Add `enableAgentClaim` feature flag (default on) with `VITE_ENABLE_AGENT_CLAIM` env override.
- When disabled, the NFT holder rewards pay-agent section shows a maintenance panel instead of mounting WalletConnect / Wagmi on Base.
- Route `isFeatureEnabled` through `getConfig()` so Vite env feature overrides apply consistently.

## Test plan
- [ ] Open portfolio NFT holder rewards modal with flag enabled (default): WalletConnect and Pay agent on Base flow render as before.
- [ ] Set `VITE_ENABLE_AGENT_CLAIM=false`, rebuild, reopen modal: maintenance panel shown; no RainbowKit connect button.
- [ ] Confirm manual claim on Voi section still works when on Voi network with flag disabled.
- [ ] `npm run build` passes.


Made with [Cursor](https://cursor.com)