### PR TITLE
fix(wallet): rename xChain option to EVM Wallet (xChain)

### DIFF
--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -88,7 +88,7 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
         baseWallets.push(
           {
             id: "rainbowkit",
-            name: "MetaMask (xChain)",
+            name: "EVM Wallet (xChain)",
             icon:
               wallets.find((w) => w.id === "rainbowkit")?.metadata.icon || "🔗",
             description:


### PR DESCRIPTION
The RainbowKit entry supports any EVM wallet, not only MetaMask.