### PR TITLE
Markets page UX overhaul and EVM wallet label fix

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -29,16 +29,15 @@ import {
   SortOrder,
   type MarketFilter,
 } from "@/hooks/useOnDemandMarketData";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Separator } from "@/components/ui/separator";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { useIsMobile } from "@/hooks/use-mobile";
 import MarketSearchFilters from "@/components/markets/MarketSearchFilters";
+import MarketsPageGuidance from "@/components/markets/MarketsPageGuidance";
 import MarketPagination from "@/components/markets/MarketPagination";
 import SupplyBorrowModal from "@/components/SupplyBorrowModal";
 import WithdrawModal from "@/components/WithdrawModal";
@@ -320,6 +319,7 @@ const MarketsTable = () => {
   const [newMarketsOnly, setNewMarketsOnly] = useState(false);
   const [rewardMarketsOnly, setRewardMarketsOnly] = useState(false);
   const [multiPoolOnly, setMultiPoolOnly] = useState(false);
+  const [walletToolbarOpen, setWalletToolbarOpen] = useState(false);
   const [depositModal, setDepositModal] = useState<{
     isOpen: boolean;
     asset: string | null;
@@ -979,6 +979,36 @@ const MarketsTable = () => {
     setSortOrder(order);
     handleSortChange(field, order);
   };
+
+  const hasActiveFilters = useMemo(
+    () =>
+      searchTerm.trim() !== "" ||
+      newMarketsOnly ||
+      rewardMarketsOnly ||
+      multiPoolOnly ||
+      marketFilter !== "all" ||
+      sortField !== "default" ||
+      sortOrder !== "desc",
+    [
+      searchTerm,
+      newMarketsOnly,
+      rewardMarketsOnly,
+      multiPoolOnly,
+      marketFilter,
+      sortField,
+      sortOrder,
+    ]
+  );
+
+  const clearAllMarketFilters = useCallback(() => {
+    handleSearchTermChange("");
+    setNewMarketsOnly(false);
+    setRewardMarketsOnly(false);
+    setMultiPoolOnly(false);
+    setMarketFilter("all");
+    setCurrentPage(1);
+    handleSortFieldChange("default", "desc");
+  }, [setCurrentPage]);
 
   const handleDepositClick = async (
     asset: string,
@@ -3309,55 +3339,48 @@ const MarketsTable = () => {
   ]);
 
   return (
-    <div className="max-w-[1200px] mx-auto px-4">
-      <div className="space-y-4">
+    <div className="max-w-[1200px] mx-auto px-4 pt-0">
+      <div className="space-y-2 sm:space-y-3">
         {/* Network + liquidity toolbar */}
         {enabledNetworks.length > 0 && (
           <section
             aria-labelledby="markets-toolbar-heading"
-            className="mb-4"
+            className="mb-0"
           >
             <h2 id="markets-toolbar-heading" className="sr-only">
               Network, liquidity, and spendable ALGO
             </h2>
-            <div className="rounded-2xl border border-border/80 bg-muted/25 px-3 py-3 shadow-sm dark:bg-muted/10 sm:px-4 sm:py-3">
-              <div
-                className={cn(
-                  "flex flex-col gap-3",
-                  showMarketsLiquidityToolbar &&
-                    cn(
-                      "sm:flex-row sm:items-center sm:gap-4 md:gap-5 lg:items-start lg:gap-5 xl:gap-6",
-                      marketsToolbarSpendableExtraTight &&
-                        "lg:gap-3 xl:gap-4"
-                    )
-                )}
+            <div className="rounded-xl border border-border/80 bg-muted/25 px-2.5 py-2 shadow-sm dark:bg-muted/10 sm:px-3">
+              <Collapsible
+                open={showMarketsLiquidityToolbar ? walletToolbarOpen : undefined}
+                onOpenChange={
+                  showMarketsLiquidityToolbar ? setWalletToolbarOpen : undefined
+                }
+                className="flex flex-col gap-2"
               >
-                <div className="flex min-w-0 flex-col gap-1.5 self-start sm:shrink-0">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                    Network
-                  </span>
-                  <DropdownMenu>
+                <div className="flex flex-wrap items-center gap-2">
+                    <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
                         type="button"
                         variant="outline"
                         size="sm"
-                        className="h-9 gap-2 rounded-xl border-border bg-muted/40 px-3 dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35"
+                        className="h-8 gap-1.5 rounded-lg border-border bg-muted/40 px-2.5 text-xs sm:text-sm dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35"
                         aria-label={`Network: ${getNetworkConfig(currentNetwork).name}. Change network.`}
                       >
                         <img
                           src={getNetworkLogoPath(currentNetwork)}
                           alt=""
-                          className="h-5 w-5 shrink-0 rounded-full"
+                          className="h-4 w-4 shrink-0 rounded-full"
                           onError={(e) => {
                             const target = e.target as HTMLImageElement;
                             target.src = "/placeholder.svg";
                           }}
                         />
-                        <span className="text-sm font-medium">
+                        <span className="max-w-[9rem] truncate font-medium sm:max-w-none">
                           {getNetworkConfig(currentNetwork).name}
                         </span>
-                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" className="w-56">
@@ -3394,18 +3417,38 @@ const MarketsTable = () => {
                       })}
                     </DropdownMenuContent>
                   </DropdownMenu>
+
+                  {showMarketsLiquidityToolbar && (
+                      <CollapsibleTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8 gap-1.5 rounded-lg border-border bg-muted/40 px-2.5 text-xs sm:text-sm dark:bg-muted/25"
+                        >
+                          <Fuel className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          Wallet &amp; gas
+                          <ChevronDown
+                            className={cn(
+                              "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+                              walletToolbarOpen && "rotate-180"
+                            )}
+                          />
+                        </Button>
+                      </CollapsibleTrigger>
+                  )}
                 </div>
 
                 {showMarketsLiquidityToolbar && (
-                  <>
-                    <div
-                      className="pointer-events-none hidden h-7 w-px shrink-0 self-center bg-muted-foreground/25 dark:bg-muted-foreground/35 sm:block"
-                      aria-hidden
-                    />
-                    <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Liquidity
-                      </span>
+                      <CollapsibleContent className="border-t border-border/60 pt-2 mt-0.5">
+                        <div
+                          className={cn(
+                            "flex flex-col gap-3",
+                            "sm:flex-row sm:items-center sm:gap-3"
+                          )}
+                        >
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="sr-only">Liquidity</span>
                       <div className="flex w-full min-w-0 flex-col gap-2 sm:flex-row sm:flex-nowrap sm:items-center sm:gap-3 sm:w-auto">
                         <XchainUsdcBridgeControls />
                         {shouldShowXchainUsdcBridgeControls(
@@ -3421,14 +3464,14 @@ const MarketsTable = () => {
                           type="button"
                           variant="outline"
                           size="sm"
-                          className="flex h-9 w-fit shrink-0 items-center gap-2 self-start rounded-xl border-border bg-muted/40 dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35 sm:self-center"
+                          className="flex h-8 w-fit shrink-0 items-center gap-1.5 self-start rounded-lg border-border bg-muted/40 px-2.5 text-xs dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35 sm:self-center sm:text-sm"
                           onClick={() => {
                             setTinymanSwapOpenForGasUp(false);
                             setIsTinymanSwapModalOpen(true);
                           }}
                           aria-label="Open Tinyman swap"
                         >
-                          <ArrowDownUp className="h-4 w-4 shrink-0" />
+                          <ArrowDownUp className="h-3.5 w-3.5 shrink-0" />
                           Swap
                         </Button>
                       </div>
@@ -3574,9 +3617,10 @@ const MarketsTable = () => {
                         </div>
                       </div>
                     </div>
-                  </>
+                        </div>
+                      </CollapsibleContent>
                 )}
-              </div>
+              </Collapsible>
             </div>
           </section>
         )}
@@ -3584,35 +3628,11 @@ const MarketsTable = () => {
         {/* Hero Section */}
         <MarketsHeroSection />
 
-        {/* Search and Filters */}
-        <MarketSearchFilters
-          searchTerm={searchTerm}
-          onSearchChange={handleSearchTermChange}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          onSortChange={handleSortFieldChange}
-          newMarketsCount={newMarketsCount}
-          newMarketsOnly={newMarketsOnly}
-          onNewMarketsOnlyChange={(v) => {
-            setNewMarketsOnly(v);
-            setCurrentPage(1);
-          }}
-          rewardMarketsCount={rewardMarketsCount}
-          rewardMarketsOnly={rewardMarketsOnly}
-          onRewardMarketsOnlyChange={(v) => {
-            setRewardMarketsOnly(v);
-            setCurrentPage(1);
-          }}
-          multiPoolMarketsCount={multiPoolMarketsCount}
-          multiPoolOnly={multiPoolOnly}
-          onMultiPoolOnlyChange={(v) => {
-            setMultiPoolOnly(v);
-            setCurrentPage(1);
-          }}
-        />
-
         {/* Markets Table */}
-        <div className="rounded-xl border bg-gradient-to-br from-blue-50 to-cyan-50 dark:from-slate-900 dark:to-slate-800 border-gray-200/50 dark:border-ocean-teal/20 p-4 card-hover overflow-visible">
+        <div
+          ref={marketsListRef}
+          className="rounded-xl border bg-gradient-to-br from-blue-50 to-cyan-50 dark:from-slate-900 dark:to-slate-800 border-gray-200/50 dark:border-ocean-teal/20 p-4 card-hover overflow-visible"
+        >
           <div className="pb-4">
             <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4">
               <div className="text-xl md:text-2xl font-bold text-slate-800 dark:text-white">
@@ -3681,111 +3701,50 @@ const MarketsTable = () => {
                 )}
               </div>
             </div>
-            {/* Market filter: All / A / B / D — native select on mobile (tabs swallow taps on nested labels) */}
-            <div className="relative z-20 isolate mt-4 mb-3 w-full">
-              {isMobile ? (
-                <Select
-                  value={marketFilter}
-                  onValueChange={(v) =>
-                    handleMarketFilterChange(v as MarketFilter)
-                  }
-                >
-                  <SelectTrigger
-                    className="min-h-11 w-full bg-background"
-                    aria-label="Filter by market"
-                  >
-                    <SelectValue placeholder="All markets" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All markets</SelectItem>
-                    <SelectItem value="A">A market</SelectItem>
-                    <SelectItem value="B">B market</SelectItem>
-                    {hasDMarketTab && (
-                      <SelectItem value="D">D market</SelectItem>
-                    )}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Tabs
-                  value={marketFilter}
-                  onValueChange={(v) =>
-                    handleMarketFilterChange(v as MarketFilter)
-                  }
-                  className="w-full"
-                >
-                  <TabsList
-                    className={cn(
-                      "flex w-full h-auto min-h-10 flex-nowrap gap-1 p-1",
-                      hasDMarketTab ? "max-w-3xl" : "max-w-md"
-                    )}
-                  >
-                    <TabsTrigger
-                      value="all"
-                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
-                    >
-                      All Markets
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="A"
-                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
-                    >
-                      A Markets
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="B"
-                      className="min-h-10 min-w-0 flex-1 px-2 text-sm"
-                    >
-                      B Markets
-                    </TabsTrigger>
-                    {hasDMarketTab && (
-                      <TabsTrigger
-                        value="D"
-                        className="min-h-10 min-w-0 flex-1 px-2 text-sm"
-                      >
-                        D Markets
-                      </TabsTrigger>
-                    )}
-                  </TabsList>
-                </Tabs>
-              )}
-              {isMobile && marketFilter !== "all" && (
-                <p
-                  className="mt-2 text-xs text-muted-foreground"
-                  aria-live="polite"
-                >
-                  Showing {marketFilter} market
-                  {totalItems === 1 ? "" : "s"} ({totalItems})
-                </p>
-              )}
+            <div className="relative z-20 isolate mt-4 mb-2 w-full">
+              <MarketsPageGuidance />
             </div>
           </div>
-          {/* Informational guidance - matches Liquidations Queue styles */}
-          <section
-            aria-label="What you can do here"
-            className="mb-4 hidden md:block"
-          >
-            <p className="text-sm text-muted-foreground mt-1">
-              What You Can Do Here:
-            </p>
-            <div className="mt-3 space-y-1 text-xs text-slate-600 dark:text-slate-400">
-              <p>
-                • Supply Assets: Earn interest with interest bearing tokens
-                that grow in value over time.
-              </p>
-              <p>
-                • Borrow Against Collateral: Access liquidity without selling
-                your holdings.
-              </p>
-              <p>
-                • Track Utilization: See how much of each market is borrowed vs.
-                supplied — a key signal for demand and interest rates.
-              </p>
-              <p>
-                • Compare Risk Profiles: Different assets have different
-                Loan-to-Value (LTV) limits and liquidation thresholds.
-              </p>
-            </div>
-          </section>
+
+          <div className="sticky top-2 z-20 -mx-1 px-1 pb-2 rounded-lg bg-blue-50/95 dark:bg-slate-900/95 backdrop-blur-sm">
+            <MarketSearchFilters
+              embedded
+              searchTerm={searchTerm}
+              onSearchChange={handleSearchTermChange}
+              sortField={sortField}
+              sortOrder={sortOrder}
+              onSortChange={handleSortFieldChange}
+              marketFilter={marketFilter}
+              onMarketFilterChange={handleMarketFilterChange}
+              hasDMarketTab={hasDMarketTab}
+              isMobile={isMobile}
+              newMarketsCount={newMarketsCount}
+              newMarketsOnly={newMarketsOnly}
+              onNewMarketsOnlyChange={(v) => {
+                setNewMarketsOnly(v);
+                setCurrentPage(1);
+              }}
+              rewardMarketsCount={rewardMarketsCount}
+              rewardMarketsOnly={rewardMarketsOnly}
+              onRewardMarketsOnlyChange={(v) => {
+                setRewardMarketsOnly(v);
+                setCurrentPage(1);
+              }}
+              multiPoolMarketsCount={multiPoolMarketsCount}
+              multiPoolOnly={multiPoolOnly}
+              onMultiPoolOnlyChange={(v) => {
+                setMultiPoolOnly(v);
+                setCurrentPage(1);
+              }}
+              hasActiveFilters={hasActiveFilters}
+              onClearAll={clearAllMarketFilters}
+            />
+          </div>
+
+          <Separator
+            className="my-5 h-px bg-gradient-to-r from-transparent via-slate-300/70 to-transparent dark:via-ocean-teal/30"
+            aria-hidden
+          />
 
           {markets.length === 0 && !isLoading ? (
             <div className="text-center py-8">

--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -88,7 +88,7 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
         baseWallets.push(
           {
             id: "rainbowkit",
-            name: "MetaMask (xChain)",
+            name: "EVM Wallet (xChain)",
             icon:
               wallets.find((w) => w.id === "rainbowkit")?.metadata.icon || "🔗",
             description:

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/constants/marketUi";
 import { ARC200Service } from "@/services/arc200Service";
 import { migrationBalanceEffectKey } from "./migrationBalanceEffectKey";
+import { MarketRowStatusBadges } from "./MarketRowStatusBadges";
 import algorandService from "@/services/algorandService";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 
@@ -49,7 +50,7 @@ interface MarketCardViewProps {
 }
 
 const MarketCardView = ({ 
-  markets, 
+  markets,
   onRowClick, 
   onInfoClick, 
   onDepositClick, 
@@ -213,11 +214,17 @@ const MarketCardView = ({
                   poolLetterLabel={marketLabel}
                   imgClassName="w-10 h-10 md:w-8 md:h-8 flex-shrink-0 rounded-full object-contain"
                 />
-                <div className="flex flex-col items-center justify-center gap-1 text-center flex-1">
-                  <div className="font-semibold text-lg leading-tight">{market.asset}</div>
-                  <Badge variant="outline" className="text-xs px-2 py-0.5 h-4 flex items-center justify-center whitespace-nowrap">
+                <div className="flex min-w-0 max-w-full flex-1 flex-col items-center justify-center gap-1 text-center">
+                  <div className="font-semibold text-lg leading-tight whitespace-nowrap">
+                    {market.asset}
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className="inline-flex h-auto min-h-4 items-center justify-center whitespace-nowrap px-2 py-0.5 text-xs leading-none"
+                  >
                     CF {market.collateralFactor}%
                   </Badge>
+                  <MarketRowStatusBadges market={market} className="justify-center" />
                 </div>
               </div>
               {/* Removed info icon */}
@@ -226,7 +233,7 @@ const MarketCardView = ({
             {/* APY and Supply/Borrow Info */}
             <div className="grid grid-cols-2 gap-4 sm:gap-2 md:grid-cols-2 text-center">
               <div className="flex flex-col items-center md:items-start">
-                <div className="text-sm text-muted-foreground mb-1">Deposit APY</div>
+                <div className="text-sm text-muted-foreground mb-1">Supply APY</div>
                 <Badge
                   className={depositApyBadgeClassName(
                     market.hasRewards,

--- a/src/components/markets/MarketRowStatusBadges.tsx
+++ b/src/components/markets/MarketRowStatusBadges.tsx
@@ -1,0 +1,106 @@
+import { Sparkles, Gift, Ban } from "lucide-react";
+import type { OnDemandMarketData } from "@/hooks/useOnDemandMarketData";
+import { isAtBorrowCap, isAtDepositCap } from "@/constants/lendingCaps";
+import { cn } from "@/lib/utils";
+
+interface MarketRowStatusBadgesProps {
+  market: OnDemandMarketData;
+  className?: string;
+}
+
+const statusBadgeBase =
+  "inline-flex max-w-full flex-row flex-nowrap items-center justify-center gap-1 shrink-0 whitespace-nowrap rounded-full border px-1.5 py-0.5 text-[10px] font-medium leading-none sm:px-2 sm:text-[11px]";
+
+function CapBadge({
+  label,
+  shortLabel,
+  title,
+}: {
+  label: string;
+  shortLabel: string;
+  title: string;
+}) {
+  return (
+    <span
+      className={cn(
+        statusBadgeBase,
+        "border-border/80 bg-muted/30 text-muted-foreground"
+      )}
+      title={title}
+      aria-label={title}
+    >
+      <Ban className="h-3 w-3 shrink-0 sm:h-3.5 sm:w-3.5" aria-hidden />
+      <span className="sm:hidden">{shortLabel}</span>
+      <span className="hidden sm:inline">{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Compact row badges: new listing, rewards, supply/borrow cap.
+ */
+export function MarketRowStatusBadges({
+  market,
+  className,
+}: MarketRowStatusBadgesProps) {
+  const atSupplyCap = isAtDepositCap(
+    market.totalSupply,
+    market.supplyCap
+  );
+  const atBorrowCap = isAtBorrowCap(market.totalBorrow, market.borrowCap);
+
+  const showNew = market.isNew;
+  const showRewards = market.hasRewards;
+
+  if (!showNew && !showRewards && !atSupplyCap && !(atBorrowCap && !market.isSToken)) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex w-max max-w-full flex-wrap items-center justify-center gap-1",
+        className
+      )}
+    >
+      {showNew && (
+        <span
+          className={cn(
+            statusBadgeBase,
+            "border-ocean-teal/25 bg-ocean-teal/15 text-ocean-teal"
+          )}
+        >
+          <Sparkles className="h-3 w-3 shrink-0 sm:h-3.5 sm:w-3.5" aria-hidden />
+          New
+        </span>
+      )}
+      {showRewards && (
+        <span
+          className={cn(
+            statusBadgeBase,
+            "border-amber-500/30 bg-amber-500/15 text-amber-700 dark:text-amber-300"
+          )}
+        >
+          <Gift className="h-3 w-3 shrink-0 sm:h-3.5 sm:w-3.5" aria-hidden />
+          Rewards
+        </span>
+      )}
+      {atSupplyCap && (
+        <CapBadge
+          label="Supply cap"
+          shortLabel="S. cap"
+          title="Supply cap nearly full"
+        />
+      )}
+      {atBorrowCap && !market.isSToken && (
+        <CapBadge
+          label="Borrow cap"
+          shortLabel="B. cap"
+          title="Borrow cap nearly full"
+        />
+      )}
+    </div>
+  );
+}
+
+export default MarketRowStatusBadges;

--- a/src/components/markets/MarketSearchFilters.tsx
+++ b/src/components/markets/MarketSearchFilters.tsx
@@ -1,10 +1,27 @@
-import { Search, SortAsc, SortDesc, Sparkles, Gift, Layers } from "lucide-react";
+import { type ReactNode } from "react";
+import {
+  Search,
+  SortAsc,
+  SortDesc,
+  Sparkles,
+  Gift,
+  Layers,
+  X,
+  TrendingUp,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
-import { SortField, SortOrder } from "@/hooks/useOnDemandMarketData";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SortField, SortOrder, type MarketFilter } from "@/hooks/useOnDemandMarketData";
+import MarketsTierFilter from "@/components/markets/MarketsTierFilter";
+import { Separator } from "@/components/ui/separator";
 
 interface MarketSearchFiltersProps {
   searchTerm: string;
@@ -12,18 +29,50 @@ interface MarketSearchFiltersProps {
   sortField: SortField;
   sortOrder: SortOrder;
   onSortChange: (field: SortField, order: SortOrder) => void;
-  /** When > 0, shows "New markets only" toggle. */
+  marketFilter: MarketFilter;
+  onMarketFilterChange: (value: MarketFilter) => void;
+  hasDMarketTab: boolean;
+  isMobile?: boolean;
   newMarketsCount?: number;
   newMarketsOnly?: boolean;
   onNewMarketsOnlyChange?: (value: boolean) => void;
-  /** When > 0, shows "Reward markets only" toggle. */
   rewardMarketsCount?: number;
   rewardMarketsOnly?: boolean;
   onRewardMarketsOnlyChange?: (value: boolean) => void;
-  /** When > 0, shows "Multi-pool" toggle. */
   multiPoolMarketsCount?: number;
   multiPoolOnly?: boolean;
   onMultiPoolOnlyChange?: (value: boolean) => void;
+  hasActiveFilters?: boolean;
+  onClearAll?: () => void;
+  embedded?: boolean;
+}
+
+function FilterChip({
+  active,
+  onClick,
+  children,
+  className,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+        active
+          ? "border-ocean-teal/50 bg-ocean-teal/15 text-ocean-teal dark:text-ocean-teal"
+          : "border-border bg-background/80 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
 }
 
 const MarketSearchFilters = ({
@@ -32,6 +81,10 @@ const MarketSearchFilters = ({
   sortField,
   sortOrder,
   onSortChange,
+  marketFilter,
+  onMarketFilterChange,
+  hasDMarketTab,
+  isMobile = false,
   newMarketsCount = 0,
   newMarketsOnly = false,
   onNewMarketsOnlyChange,
@@ -41,121 +94,163 @@ const MarketSearchFilters = ({
   multiPoolMarketsCount = 0,
   multiPoolOnly = false,
   onMultiPoolOnlyChange,
+  hasActiveFilters = false,
+  onClearAll,
+  embedded = false,
 }: MarketSearchFiltersProps) => {
   const handleSortFieldChange = (field: SortField) => {
     onSortChange(field, sortOrder);
   };
 
   const toggleSortOrder = () => {
-    onSortChange(sortField, sortOrder === 'asc' ? 'desc' : 'asc');
+    onSortChange(sortField, sortOrder === "asc" ? "desc" : "asc");
   };
 
-  return (
-    <div className="bg-gradient-to-br from-blue-50 to-cyan-50 dark:from-slate-900 dark:to-slate-800 rounded-xl p-4 md:p-6 border border-gray-200/50 dark:border-ocean-teal/20 shadow-md card-hover hover:border-ocean-teal/40 transition-all">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="relative flex-1 w-full md:max-w-md">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-600 dark:text-ocean-teal h-4 w-4" />
-          <Input
-            placeholder="Search markets..."
-            value={searchTerm}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="pl-10 bg-white dark:bg-slate-800/50 border-gray-300 dark:border-ocean-teal/30 focus:border-ocean-teal text-slate-800 dark:text-white placeholder:text-slate-500 dark:placeholder:text-muted-foreground w-full"
-          />
-        </div>
-        
-        <div className="flex items-center gap-2">
-          <Select value={sortField} onValueChange={handleSortFieldChange}>
-            <SelectTrigger className="w-full md:w-48 bg-white dark:bg-slate-800/50 border-gray-300 dark:border-ocean-teal/30 text-slate-800 dark:text-white">
-              <SelectValue placeholder="Sort by..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="default">Default</SelectItem>
-              <SelectItem value="asset">Asset</SelectItem>
-              <SelectItem value="totalSupplyUSD">Total Supply</SelectItem>
-              <SelectItem value="supplyAPY">Deposit APY</SelectItem>
-              <SelectItem value="totalBorrowUSD">Total Borrow</SelectItem>
-              <SelectItem value="borrowAPY">Borrow APY</SelectItem>
-              <SelectItem value="utilization">Utilization</SelectItem>
-            </SelectContent>
-          </Select>
-          
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={toggleSortOrder}
-            className="border-gray-300 dark:border-ocean-teal/30 hover:bg-ocean-teal/10 text-slate-700 dark:text-ocean-teal"
-          >
-            {sortOrder === 'asc' ? <SortAsc className="h-4 w-4" /> : <SortDesc className="h-4 w-4" />}
-          </Button>
-        </div>
-      </div>
+  const applyQuickSort = (field: SortField) => {
+    onSortChange(field, "desc");
+  };
 
-      {((newMarketsCount > 0 && onNewMarketsOnlyChange) ||
-        (rewardMarketsCount > 0 && onRewardMarketsOnlyChange) ||
-        (multiPoolMarketsCount > 0 && onMultiPoolOnlyChange)) && (
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-3 mt-5">
-          {newMarketsCount > 0 && onNewMarketsOnlyChange && (
-            <div className="flex items-center gap-2">
-              <Switch
-                id="markets-new-only"
-                checked={newMarketsOnly}
-                onCheckedChange={onNewMarketsOnlyChange}
-                aria-label="Show new markets only"
+  const topSupplyActive = sortField === "supplyAPY" && sortOrder === "desc";
+  const topBorrowActive = sortField === "borrowAPY" && sortOrder === "desc";
+  const hasFilterChips =
+    (rewardMarketsCount > 0 && !!onRewardMarketsOnlyChange) ||
+    (newMarketsCount > 0 && !!onNewMarketsOnlyChange) ||
+    (multiPoolMarketsCount > 0 && !!onMultiPoolOnlyChange);
+
+  return (
+    <div
+      className={cn(
+        embedded
+          ? "mt-3"
+          : "rounded-xl p-4 md:p-6 border border-gray-200/50 dark:border-ocean-teal/20 bg-gradient-to-br from-blue-50 to-cyan-50 dark:from-slate-900 dark:to-slate-800 shadow-md"
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1">
+            <MarketsTierFilter
+              hideLabel
+              value={marketFilter}
+              onChange={onMarketFilterChange}
+              hasDMarketTab={hasDMarketTab}
+              isMobile={isMobile}
+            />
+          </div>
+          {hasActiveFilters && onClearAll && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClearAll}
+              className="h-8 shrink-0 gap-1 self-start text-muted-foreground hover:text-foreground sm:self-end"
+            >
+              <X className="h-3.5 w-3.5" />
+              Clear filters
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:flex-wrap">
+          <div className="relative flex-1 w-full min-w-0 sm:max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600 dark:text-ocean-teal h-4 w-4" />
+            <Input
+              placeholder="Search by asset name..."
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="pl-10 bg-white dark:bg-slate-800/50 border-gray-300 dark:border-ocean-teal/30 focus:border-ocean-teal text-slate-800 dark:text-white placeholder:text-slate-500 dark:placeholder:text-muted-foreground w-full"
+            />
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            <Select value={sortField} onValueChange={handleSortFieldChange}>
+              <SelectTrigger className="w-[9.5rem] sm:w-40 bg-white dark:bg-slate-800/50 border-gray-300 dark:border-ocean-teal/30">
+                <SelectValue placeholder="Sort by..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default</SelectItem>
+                <SelectItem value="asset">Asset</SelectItem>
+                <SelectItem value="totalSupplyUSD">Total supply</SelectItem>
+                <SelectItem value="supplyAPY">Supply APY</SelectItem>
+                <SelectItem value="totalBorrowUSD">Total borrow</SelectItem>
+                <SelectItem value="borrowAPY">Borrow APY</SelectItem>
+                <SelectItem value="utilization">Utilization</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="border-gray-300 dark:border-ocean-teal/30 shrink-0"
+              onClick={toggleSortOrder}
+              aria-label="Toggle sort direction"
+            >
+              {sortOrder === "asc" ? (
+                <SortAsc className="h-4 w-4" />
+              ) : (
+                <SortDesc className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <FilterChip
+            active={topSupplyActive}
+            onClick={() => applyQuickSort("supplyAPY")}
+          >
+            <TrendingUp className="h-3 w-3" />
+            Top supply APY
+          </FilterChip>
+          <FilterChip
+            active={topBorrowActive}
+            onClick={() => applyQuickSort("borrowAPY")}
+          >
+            <TrendingUp className="h-3 w-3" />
+            Top borrow APY
+          </FilterChip>
+          {hasFilterChips && (
+            <>
+              <Separator
+                orientation="horizontal"
+                className="basis-full h-px bg-gradient-to-r from-transparent via-slate-300/70 to-transparent dark:via-ocean-teal/30 sm:hidden"
+                aria-hidden
               />
-              <Label
-                htmlFor="markets-new-only"
-                className="text-sm font-medium text-slate-700 dark:text-slate-200 cursor-pointer flex items-center gap-1.5"
-              >
-                <Sparkles className="h-3.5 w-3.5 text-ocean-teal shrink-0" aria-hidden />
-                New markets only
-                <span className="text-xs font-normal text-muted-foreground">
-                  ({newMarketsCount})
-                </span>
-              </Label>
-            </div>
+              <Separator
+                orientation="vertical"
+                className="mx-0.5 hidden h-6 w-px bg-gradient-to-b from-transparent via-slate-300/70 to-transparent dark:via-ocean-teal/30 sm:block"
+                aria-hidden
+              />
+            </>
           )}
           {rewardMarketsCount > 0 && onRewardMarketsOnlyChange && (
-            <div className="flex items-center gap-2">
-              <Switch
-                id="markets-rewards-only"
-                checked={rewardMarketsOnly}
-                onCheckedChange={onRewardMarketsOnlyChange}
-                aria-label="Show reward markets only"
-              />
-              <Label
-                htmlFor="markets-rewards-only"
-                className="text-sm font-medium text-slate-700 dark:text-slate-200 cursor-pointer flex items-center gap-1.5"
-              >
-                <Gift className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" aria-hidden />
-                Reward markets only
-                <span className="text-xs font-normal text-muted-foreground">
-                  ({rewardMarketsCount})
-                </span>
-              </Label>
-            </div>
+            <FilterChip
+              active={rewardMarketsOnly}
+              onClick={() => onRewardMarketsOnlyChange(!rewardMarketsOnly)}
+            >
+              <Gift className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+              Rewards ({rewardMarketsCount})
+            </FilterChip>
+          )}
+          {newMarketsCount > 0 && onNewMarketsOnlyChange && (
+            <FilterChip
+              active={newMarketsOnly}
+              onClick={() => onNewMarketsOnlyChange(!newMarketsOnly)}
+            >
+              <Sparkles className="h-3 w-3 text-ocean-teal" />
+              New ({newMarketsCount})
+            </FilterChip>
           )}
           {multiPoolMarketsCount > 0 && onMultiPoolOnlyChange && (
-            <div className="flex items-center gap-2">
-              <Switch
-                id="markets-multi-pool-only"
-                checked={multiPoolOnly}
-                onCheckedChange={onMultiPoolOnlyChange}
-                aria-label="Show multi-pool markets only"
-              />
-              <Label
-                htmlFor="markets-multi-pool-only"
-                className="text-sm font-medium text-slate-700 dark:text-slate-200 cursor-pointer flex items-center gap-1.5"
-              >
-                <Layers className="h-3.5 w-3.5 text-ocean-teal shrink-0" aria-hidden />
-                Multi-pool
-                <span className="text-xs font-normal text-muted-foreground">
-                  ({multiPoolMarketsCount})
-                </span>
-              </Label>
-            </div>
+            <FilterChip
+              active={multiPoolOnly}
+              onClick={() => onMultiPoolOnlyChange(!multiPoolOnly)}
+            >
+              <Layers className="h-3 w-3 text-ocean-teal" />
+              Multi-pool only ({multiPoolMarketsCount})
+            </FilterChip>
           )}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/components/markets/MarketsDesktopTable.tsx
+++ b/src/components/markets/MarketsDesktopTable.tsx
@@ -38,6 +38,7 @@ import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 import { migrationBalanceEffectKey } from "./migrationBalanceEffectKey";
+import { MarketRowStatusBadges } from "./MarketRowStatusBadges";
 
 interface MarketsDesktopTableProps {
   markets: OnDemandMarketData[];
@@ -367,6 +368,149 @@ const MarketsDesktopTable = ({
     });
   };
 
+  const renderSupplyApyCell = (market: OnDemandMarketData) => (
+    <TableCell className="text-center">
+      {market.isSToken ? (
+        <span>&nbsp;</span>
+      ) : market.isLoading &&
+        market.intrinsicSupplyApyPercent == null &&
+        !market.rewardsBonusSupplyAprPercent &&
+        !market.apyCalculation ? (
+        <LoadingCell />
+      ) : market.error ? (
+        <ErrorCell error={market.error} />
+      ) : (
+        <Badge
+          className={depositApyBadgeClassName(
+            market.hasRewards,
+            market.intrinsicSupplyApyPercent
+          )}
+        >
+          <APYDisplay
+            apyCalculation={market.apyCalculation}
+            fallbackAPY={market.supplyAPY}
+            intrinsicApyPercent={market.intrinsicSupplyApyPercent}
+            bonusRewardsAprPercent={market.rewardsBonusSupplyAprPercent}
+            hasRewardsProgram={!!market.hasRewards}
+            hasIntrinsicApy={isIntrinsicDepositApyBadge(
+              market.hasRewards,
+              market.intrinsicSupplyApyPercent
+            )}
+            showTooltip={true}
+          />
+        </Badge>
+      )}
+    </TableCell>
+  );
+
+  const renderBorrowApyCell = (
+    market: OnDemandMarketData,
+    marketIndex?: number
+  ) => (
+    <TableCell className="text-center">
+      {market.isLoading &&
+      market.intrinsicBorrowApyPercent == null &&
+      !market.borrowApyCalculation ? (
+        <LoadingCell />
+      ) : market.error ? (
+        <ErrorCell error={market.error} />
+      ) : (
+        <Badge
+          className={borrowApyBadgeClassName(
+            market.intrinsicBorrowApyPercent,
+            BORROW_APY_BADGE_DEFAULT
+          )}
+        >
+          <BorrowAPYDisplay
+            apyCalculation={market.apyCalculation}
+            fallbackAPY={market.borrowAPY}
+            intrinsicBorrowApyPercent={market.intrinsicBorrowApyPercent}
+            showTooltip={true}
+            networkId={currentNetwork}
+            asset={market.asset}
+            poolId={market.marketInfo?.poolId ?? market.poolId}
+            market={market}
+            marketIndex={marketIndex}
+          />
+        </Badge>
+      )}
+    </TableCell>
+  );
+
+  const renderTotalSupplyCell = (market: OnDemandMarketData) => (
+    <TableCell className="text-center">
+      {market.isSToken ? (
+        <span>&nbsp;</span>
+      ) : market.isLoading ? (
+        <LoadingCell />
+      ) : market.error ? (
+        <ErrorCell error={market.error} />
+      ) : (
+        <div>
+          <div className="font-medium">
+            {formatCurrency(Math.round(market.totalSupplyUSD / 1_000_000), "USD", {
+              maximumFractionDigits: 0,
+            })}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {formatNumber(market.totalSupply, { maximumFractionDigits: 3 })}{" "}
+            {market.asset}
+          </div>
+        </div>
+      )}
+    </TableCell>
+  );
+
+  const renderTotalBorrowCell = (market: OnDemandMarketData) => (
+    <TableCell className="text-center">
+      {market.isLoading ? (
+        <LoadingCell />
+      ) : market.error ? (
+        <ErrorCell error={market.error} />
+      ) : (
+        <div>
+          <div className="font-medium">
+            {formatCurrency(Math.round(market.totalBorrowUSD / 1_000_000), "USD", {
+              maximumFractionDigits: 0,
+            })}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {formatNumber(market.totalBorrow, { maximumFractionDigits: 3 })}{" "}
+            {market.asset}
+          </div>
+        </div>
+      )}
+    </TableCell>
+  );
+
+  const renderUtilizationCell = (market: OnDemandMarketData) => (
+    <TableCell className="text-center">
+      {market.isLoading ? (
+        <LoadingCell />
+      ) : market.error ? (
+        <ErrorCell error={market.error} />
+      ) : market.asset === "WAD" ? (
+        <span></span>
+      ) : (
+        <div className="flex flex-col items-center space-y-1">
+          <div className="text-sm font-medium">
+            {market.isSToken
+              ? "100.0%"
+              : formatPercent(market.utilization / 100, {
+                  maximumFractionDigits: 1,
+                })}
+          </div>
+          <div className="flex justify-center w-full">
+            <Progress
+              value={market.isSToken ? 100 : market.utilization}
+              className="h-2 w-20"
+            />
+          </div>
+        </div>
+      )}
+    </TableCell>
+  );
+
   // Helper function to render a single market row
   const renderMarketRow = (
     market: OnDemandMarketData,
@@ -436,126 +580,28 @@ const MarketsDesktopTable = ({
                 );
               })()}
               {/* Asset name and CF badge stacked */}
-              <div className="flex flex-col items-center">
-                <div className="font-extrabold text-lg leading-tight">
+              <div className="flex min-w-[5.5rem] max-w-full flex-col items-center gap-1 sm:min-w-0">
+                <div className="font-extrabold text-lg leading-tight whitespace-nowrap">
                   {market.asset}
                 </div>
-                <Badge variant="outline" className="text-xs px-2.5 py-0.5 h-5 mt-1 text-muted-foreground flex items-center justify-center whitespace-nowrap min-w-fit">
+                <Badge
+                  variant="outline"
+                  className="inline-flex h-auto min-h-5 items-center justify-center whitespace-nowrap px-2.5 py-0.5 text-xs leading-none text-muted-foreground"
+                >
                   CF {Math.round(market.collateralFactor)}%
                 </Badge>
+                <MarketRowStatusBadges market={market} className="justify-center" />
               </div>
             </div>
             {/* Spacer to align with collapsible rows */}
             <div className="w-6 flex-shrink-0" />
           </div>
         </TableCell>
-        <TableCell className="text-center">
-          {market.isSToken ? (
-            <span>&nbsp;</span>
-          ) : market.isLoading ? (
-            <LoadingCell />
-          ) : market.error ? (
-            <ErrorCell error={market.error} />
-          ) : (
-            <div>
-              <div className="font-medium">
-                {formatCurrency(Math.round(market.totalSupplyUSD / 1_000_000), "USD", { maximumFractionDigits: 0 })}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {formatNumber(market.totalSupply, { maximumFractionDigits: 3 })} {market.asset}
-              </div>
-            </div>
-          )}
-        </TableCell>
-        <TableCell className="text-center">
-          {market.isSToken ? (
-            <span>&nbsp;</span>
-          ) : market.isLoading ? (
-            <LoadingCell />
-          ) : market.error ? (
-            <ErrorCell error={market.error} />
-          ) : (
-            <Badge
-              className={depositApyBadgeClassName(
-                market.hasRewards,
-                market.intrinsicSupplyApyPercent
-              )}
-            >
-              <APYDisplay 
-                apyCalculation={market.apyCalculation}
-                fallbackAPY={market.supplyAPY}
-                intrinsicApyPercent={market.intrinsicSupplyApyPercent}
-                bonusRewardsAprPercent={market.rewardsBonusSupplyAprPercent}
-                hasRewardsProgram={!!market.hasRewards}
-                hasIntrinsicApy={isIntrinsicDepositApyBadge(
-                  market.hasRewards,
-                  market.intrinsicSupplyApyPercent
-                )}
-                showTooltip={true}
-              />
-            </Badge>
-          )}
-        </TableCell>
-        <TableCell className="text-center">
-          {market.isLoading ? (
-            <LoadingCell />
-          ) : market.error ? (
-            <ErrorCell error={market.error} />
-          ) : (
-            <div>
-              <div className="font-medium">
-                {formatCurrency(Math.round(market.totalBorrowUSD / 1_000_000), "USD", { maximumFractionDigits: 0 })}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {formatNumber(market.totalBorrow, { maximumFractionDigits: 3 })} {market.asset}
-              </div>
-            </div>
-          )}
-        </TableCell>
-        <TableCell className="text-center">
-          {market.isLoading ? (
-            <LoadingCell />
-          ) : market.error ? (
-            <ErrorCell error={market.error} />
-          ) : (
-            <Badge
-              className={borrowApyBadgeClassName(
-                market.intrinsicBorrowApyPercent,
-                BORROW_APY_BADGE_DEFAULT
-              )}
-            >
-              <BorrowAPYDisplay 
-                apyCalculation={market.apyCalculation}
-                fallbackAPY={market.borrowAPY}
-                intrinsicBorrowApyPercent={market.intrinsicBorrowApyPercent}
-                showTooltip={true}
-                networkId={currentNetwork}
-                asset={market.asset}
-                poolId={market.marketInfo?.poolId ?? market.poolId}
-                market={market}
-                marketIndex={marketIndex}
-              />
-            </Badge>
-          )}
-        </TableCell>
-        <TableCell className="text-center">
-          {market.isLoading ? (
-            <LoadingCell />
-          ) : market.error ? (
-            <ErrorCell error={market.error} />
-          ) : market.asset === "WAD" ? (
-            <span></span>
-          ) : (
-            <div className="flex flex-col items-center space-y-1">
-              <div className="text-sm font-medium">
-                {market.isSToken ? "100.0%" : formatPercent(market.utilization / 100, { maximumFractionDigits: 1 })}
-              </div>
-              <div className="flex justify-center w-full">
-                <Progress value={market.isSToken ? 100 : market.utilization} className="h-2 w-20" />
-              </div>
-            </div>
-          )}
-        </TableCell>
+        {renderSupplyApyCell(market)}
+        {renderBorrowApyCell(market, marketIndex)}
+        {renderTotalSupplyCell(market)}
+        {renderTotalBorrowCell(market)}
+        {renderUtilizationCell(market)}
         <TableCell className="text-center">
           {(() => {
             // Get token to access originalSymbol if market override exists
@@ -705,22 +751,7 @@ const MarketsDesktopTable = ({
               </TableHead>
               <TableHead className="text-center">
                 <div className="flex items-center justify-center gap-1">
-                  Total Supply
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>
-                        <Info className="w-4 h-4 text-ocean-teal cursor-help" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {headerTooltips.totalDeposit}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              </TableHead>
-              <TableHead className="text-center">
-                <div className="flex items-center justify-center gap-1">
-                  Deposit APY
+                  Supply APY
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>
@@ -729,21 +760,6 @@ const MarketsDesktopTable = ({
                     </TooltipTrigger>
                     <TooltipContent>
                       {headerTooltips.depositAPY}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              </TableHead>
-              <TableHead className="text-center">
-                <div className="flex items-center justify-center gap-1">
-                  Total Borrow
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>
-                        <Info className="w-4 h-4 text-ocean-teal cursor-help" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {headerTooltips.totalBorrow}
                     </TooltipContent>
                   </Tooltip>
                 </div>
@@ -759,6 +775,36 @@ const MarketsDesktopTable = ({
                     </TooltipTrigger>
                     <TooltipContent>
                       {headerTooltips.borrowAPY}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </TableHead>
+              <TableHead className="text-center">
+                <div className="flex items-center justify-center gap-1">
+                  Total Supply
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Info className="w-4 h-4 text-ocean-teal cursor-help" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {headerTooltips.totalDeposit}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </TableHead>
+              <TableHead className="text-center">
+                <div className="flex items-center justify-center gap-1">
+                  Total Borrow
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Info className="w-4 h-4 text-ocean-teal cursor-help" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {headerTooltips.totalBorrow}
                     </TooltipContent>
                   </Tooltip>
                 </div>
@@ -916,112 +962,11 @@ const MarketsDesktopTable = ({
                         </button>
                       </div>
                   </TableCell>
-                  <TableCell className="text-center">
-                    {mainMarket.isSToken ? (
-                      <span>&nbsp;</span>
-                    ) : mainMarket.isLoading ? (
-                      <LoadingCell />
-                    ) : mainMarket.error ? (
-                      <ErrorCell error={mainMarket.error} />
-                    ) : (
-                      <div>
-                        <div className="font-medium">
-                          {formatCurrency(mainMarket.totalSupplyUSD / 1_000_000, "USD", { maximumFractionDigits: 0 })}
-                        </div>
-                        <div className="text-sm text-muted-foreground">
-                          {formatNumber(mainMarket.totalSupply, { maximumFractionDigits: 3 })} {mainMarket.asset}
-                        </div>
-                      </div>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {mainMarket.isSToken ? (
-                      <span>&nbsp;</span>
-                    ) : mainMarket.isLoading ? (
-                      <LoadingCell />
-                    ) : mainMarket.error ? (
-                      <ErrorCell error={mainMarket.error} />
-                    ) : (
-                      <Badge
-                        className={depositApyBadgeClassName(
-                          mainMarket.hasRewards,
-                          mainMarket.intrinsicSupplyApyPercent
-                        )}
-                      >
-                        <APYDisplay 
-                          apyCalculation={mainMarket.apyCalculation}
-                          fallbackAPY={mainMarket.supplyAPY}
-                          intrinsicApyPercent={mainMarket.intrinsicSupplyApyPercent}
-                          bonusRewardsAprPercent={mainMarket.rewardsBonusSupplyAprPercent}
-                          hasRewardsProgram={!!mainMarket.hasRewards}
-                          hasIntrinsicApy={isIntrinsicDepositApyBadge(
-                            mainMarket.hasRewards,
-                            mainMarket.intrinsicSupplyApyPercent
-                          )}
-                          showTooltip={true}
-                        />
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {mainMarket.isLoading ? (
-                      <LoadingCell />
-                    ) : mainMarket.error ? (
-                      <ErrorCell error={mainMarket.error} />
-                    ) : (
-                      <div>
-                        <div className="font-medium">
-                          {formatCurrency(mainMarket.totalBorrowUSD / 1_000_000, "USD", { maximumFractionDigits: 0 })}
-                        </div>
-                        <div className="text-sm text-muted-foreground">
-                          {formatNumber(mainMarket.totalBorrow, { maximumFractionDigits: 3 })} {mainMarket.asset}
-                        </div>
-                      </div>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {mainMarket.isLoading ? (
-                      <LoadingCell />
-                    ) : mainMarket.error ? (
-                      <ErrorCell error={mainMarket.error} />
-                    ) : (
-                      <Badge
-                        className={borrowApyBadgeClassName(
-                          mainMarket.intrinsicBorrowApyPercent,
-                          BORROW_APY_BADGE_DEFAULT
-                        )}
-                      >
-                        <BorrowAPYDisplay 
-                          apyCalculation={mainMarket.apyCalculation}
-                          fallbackAPY={mainMarket.borrowAPY}
-                          intrinsicBorrowApyPercent={mainMarket.intrinsicBorrowApyPercent}
-                          showTooltip={true}
-                          networkId={currentNetwork}
-                          asset={mainMarket.asset}
-                          poolId={mainMarket.marketInfo?.poolId ?? mainMarket.poolId}
-                          market={mainMarket}
-                        />
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {mainMarket.isLoading ? (
-                      <LoadingCell />
-                    ) : mainMarket.error ? (
-                      <ErrorCell error={mainMarket.error} />
-                    ) : mainMarket.asset === "WAD" ? (
-                      <span></span>
-                    ) : (
-                      <div className="flex flex-col items-center space-y-1">
-                        <div className="text-sm font-medium">
-                          {mainMarket.isSToken ? "100.0%" : formatPercent(mainMarket.utilization / 100, { maximumFractionDigits: 1 })}
-                        </div>
-                        <div className="flex justify-center w-full">
-                          <Progress value={mainMarket.isSToken ? 100 : mainMarket.utilization} className="h-2 w-20" />
-                        </div>
-                      </div>
-                    )}
-                  </TableCell>
+                  {renderSupplyApyCell(mainMarket)}
+                  {renderBorrowApyCell(mainMarket, 0)}
+                  {renderTotalSupplyCell(mainMarket)}
+                  {renderTotalBorrowCell(mainMarket)}
+                  {renderUtilizationCell(mainMarket)}
                   <TableCell className="text-center">
                     {(() => {
                       // Get token to access originalSymbol if market override exists

--- a/src/components/markets/MarketsHeroSection.tsx
+++ b/src/components/markets/MarketsHeroSection.tsx
@@ -7,7 +7,7 @@ const MarketsHeroSection = () => {
   return (
     <DorkFiCard 
       hoverable
-      className="relative text-center overflow-hidden p-6 md:p-8"
+      className="relative text-center overflow-hidden p-4 md:p-6"
     >
       {/* Decorative elements */}
       {/* Birds - light mode only */}
@@ -60,12 +60,12 @@ const MarketsHeroSection = () => {
 
       
       <div className="relative z-10">
-        <H1 className="m-0 text-4xl md:text-5xl">
+        <H1 className="m-0 text-3xl md:text-4xl">
           <span className="hero-header">Markets</span>
         </H1>
-        <Body className="text-sm sm:text-base md:text-lg lg:text-xl max-w-2xl md:max-w-none mx-auto">
-          <span className="block md:inline md:whitespace-nowrap">
-            Deposit tokens to earn interest. Need cash? Borrow without selling.
+        <Body className="text-sm sm:text-base md:text-lg max-w-2xl mx-auto text-muted-foreground">
+          <span className="block md:inline">
+            Supply to earn yield, or borrow against collateral without selling.
           </span>
         </Body>
       </div>

--- a/src/components/markets/MarketsPageGuidance.tsx
+++ b/src/components/markets/MarketsPageGuidance.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+const GUIDANCE_ITEMS = [
+  {
+    title: "Supply assets",
+    body: "Earn interest with interest-bearing tokens that grow in value over time.",
+  },
+  {
+    title: "Borrow against collateral",
+    body: "Access liquidity without selling your holdings.",
+  },
+  {
+    title: "Track utilization",
+    body: "See how much of each market is borrowed vs. supplied — a signal for demand and rates.",
+  },
+  {
+    title: "Compare risk profiles",
+    body: "Different assets have different LTV limits and liquidation thresholds. Use Core (A) vs Boost (B) tabs to compare pools.",
+  },
+] as const;
+
+const MarketsPageGuidance = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <p className="text-xs text-muted-foreground md:hidden">
+        Tap a market for details. Supply earns APY; borrow uses your collateral.
+      </p>
+
+      <Collapsible
+        open={open}
+        onOpenChange={setOpen}
+        className="hidden md:block"
+      >
+        <CollapsibleTrigger className="flex w-full items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+          {open ? (
+            <ChevronDown className="h-4 w-4 shrink-0" aria-hidden />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
+          )}
+          <span>How markets work</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="overflow-hidden">
+          <ul className="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-400 list-none pl-0">
+            {GUIDANCE_ITEMS.map((item) => (
+              <li key={item.title}>
+                <span className="font-medium text-slate-700 dark:text-slate-300">
+                  {item.title}:
+                </span>{" "}
+                {item.body}
+              </li>
+            ))}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+    </>
+  );
+};
+
+export default MarketsPageGuidance;

--- a/src/components/markets/MarketsTableContent.tsx
+++ b/src/components/markets/MarketsTableContent.tsx
@@ -9,7 +9,6 @@ import {
 import MarketsDesktopTable from "./MarketsDesktopTable";
 import MarketsTabletTable from "./MarketsTabletTable";
 import MarketCardView from "./MarketCardView";
-
 interface MarketsTableContentProps {
   marketFilter?: MarketFilter;
   markets: OnDemandMarketData[];

--- a/src/components/markets/MarketsTabletTable.tsx
+++ b/src/components/markets/MarketsTabletTable.tsx
@@ -403,35 +403,38 @@ const MarketsTabletTable = ({
             </div>
           </div>
         </TableCell>
-        {!hasSTokens && (
-          <TableCell className="text-center">
-            {market.isLoading ? (
-              <div className="text-xs text-muted-foreground">Loading...</div>
-            ) : market.error ? (
-              <div className="text-xs text-red-500">Error</div>
-            ) : (
-              <Badge
-                className={depositApyBadgeClassName(
+        <TableCell className="text-center">
+          {market.isSToken ? (
+            <span className="text-muted-foreground text-xs">&nbsp;</span>
+          ) : market.isLoading &&
+            market.intrinsicSupplyApyPercent == null &&
+            !market.rewardsBonusSupplyAprPercent &&
+            !market.apyCalculation ? (
+            <div className="text-xs text-muted-foreground">Loading...</div>
+          ) : market.error ? (
+            <div className="text-xs text-red-500">Error</div>
+          ) : (
+            <Badge
+              className={depositApyBadgeClassName(
+                market.hasRewards,
+                market.intrinsicSupplyApyPercent
+              )}
+            >
+              <APYDisplay 
+                apyCalculation={market.apyCalculation}
+                fallbackAPY={market.supplyAPY}
+                intrinsicApyPercent={market.intrinsicSupplyApyPercent}
+                bonusRewardsAprPercent={market.rewardsBonusSupplyAprPercent}
+                hasRewardsProgram={!!market.hasRewards}
+                hasIntrinsicApy={isIntrinsicDepositApyBadge(
                   market.hasRewards,
                   market.intrinsicSupplyApyPercent
                 )}
-              >
-                <APYDisplay 
-                  apyCalculation={market.apyCalculation}
-                  fallbackAPY={market.supplyAPY}
-                  intrinsicApyPercent={market.intrinsicSupplyApyPercent}
-                  bonusRewardsAprPercent={market.rewardsBonusSupplyAprPercent}
-                  hasRewardsProgram={!!market.hasRewards}
-                  hasIntrinsicApy={isIntrinsicDepositApyBadge(
-                    market.hasRewards,
-                    market.intrinsicSupplyApyPercent
-                  )}
-                  showTooltip={true}
-                />
-              </Badge>
-            )}
-          </TableCell>
-        )}
+                showTooltip={true}
+              />
+            </Badge>
+          )}
+        </TableCell>
         <TableCell className="text-center">
           {market.isLoading ? (
             <div className="text-xs text-muted-foreground">Loading...</div>
@@ -577,9 +580,6 @@ const MarketsTabletTable = ({
     );
   };
 
-  // Check if any market is an s-token to determine if we should hide Deposit APY column
-  const hasSTokens = markets.some(market => market.isSToken);
-
   if (markets.length === 0) {
     return (
       <div className="text-center py-8">
@@ -596,7 +596,7 @@ const MarketsTabletTable = ({
         <TableHeader>
           <TableRow>
             <TableHead className="text-center">Asset</TableHead>
-            {!hasSTokens && <TableHead className="text-center">Deposit APY</TableHead>}
+            <TableHead className="text-center">Supply APY</TableHead>
             <TableHead className="text-center">Borrow APY</TableHead>
             <TableHead className="text-center">Util</TableHead>
             <TableHead className="text-center">Actions</TableHead>
@@ -712,35 +712,38 @@ const MarketsTabletTable = ({
                       </button>
                     </div>
                   </TableCell>
-                  {!hasSTokens && (
-                    <TableCell className="text-center">
-                      {mainMarket.isLoading ? (
-                        <div className="text-xs text-muted-foreground">Loading...</div>
-                      ) : mainMarket.error ? (
-                        <div className="text-xs text-red-500">Error</div>
-                      ) : (
-                        <Badge
-                          className={depositApyBadgeClassName(
+                  <TableCell className="text-center">
+                    {mainMarket.isSToken ? (
+                      <span className="text-muted-foreground text-xs">&nbsp;</span>
+                    ) : mainMarket.isLoading &&
+                      mainMarket.intrinsicSupplyApyPercent == null &&
+                      !mainMarket.rewardsBonusSupplyAprPercent &&
+                      !mainMarket.apyCalculation ? (
+                      <div className="text-xs text-muted-foreground">Loading...</div>
+                    ) : mainMarket.error ? (
+                      <div className="text-xs text-red-500">Error</div>
+                    ) : (
+                      <Badge
+                        className={depositApyBadgeClassName(
+                          mainMarket.hasRewards,
+                          mainMarket.intrinsicSupplyApyPercent
+                        )}
+                      >
+                        <APYDisplay 
+                          apyCalculation={mainMarket.apyCalculation}
+                          fallbackAPY={mainMarket.supplyAPY}
+                          intrinsicApyPercent={mainMarket.intrinsicSupplyApyPercent}
+                          bonusRewardsAprPercent={mainMarket.rewardsBonusSupplyAprPercent}
+                          hasRewardsProgram={!!mainMarket.hasRewards}
+                          hasIntrinsicApy={isIntrinsicDepositApyBadge(
                             mainMarket.hasRewards,
                             mainMarket.intrinsicSupplyApyPercent
                           )}
-                        >
-                          <APYDisplay 
-                            apyCalculation={mainMarket.apyCalculation}
-                            fallbackAPY={mainMarket.supplyAPY}
-                            intrinsicApyPercent={mainMarket.intrinsicSupplyApyPercent}
-                            bonusRewardsAprPercent={mainMarket.rewardsBonusSupplyAprPercent}
-                            hasRewardsProgram={!!mainMarket.hasRewards}
-                            hasIntrinsicApy={isIntrinsicDepositApyBadge(
-                              mainMarket.hasRewards,
-                              mainMarket.intrinsicSupplyApyPercent
-                            )}
-                            showTooltip={true}
-                          />
-                        </Badge>
-                      )}
-                    </TableCell>
-                  )}
+                          showTooltip={true}
+                        />
+                      </Badge>
+                    )}
+                  </TableCell>
                   <TableCell className="text-center">
                     {mainMarket.isLoading ? (
                       <div className="text-xs text-muted-foreground">Loading...</div>

--- a/src/components/markets/MarketsTierFilter.tsx
+++ b/src/components/markets/MarketsTierFilter.tsx
@@ -1,0 +1,174 @@
+import { HelpCircle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import { marketPoolBadgeBgClassName } from "@/constants/marketUi";
+import { cn } from "@/lib/utils";
+
+export const MARKET_TIER_OPTIONS: {
+  value: MarketFilter;
+  label: string;
+  description: string;
+  poolLetter?: string;
+}[] = [
+  {
+    value: "all",
+    label: "All Markets",
+    description: "Every lending market on this network.",
+  },
+  {
+    value: "A",
+    label: "A Markets",
+    poolLetter: "A",
+    description:
+      "Core liquidity markets with standard risk parameters and WAD minting support.",
+  },
+  {
+    value: "B",
+    label: "B Markets",
+    poolLetter: "B",
+    description:
+      "Isolated higher-risk markets with stricter collateral limits and reduced exposure.",
+  },
+  {
+    value: "D",
+    label: "D Markets",
+    poolLetter: "D",
+    description:
+      "Dynamic routing markets that optimize liquidity and yield across multiple pools.",
+  },
+];
+
+interface MarketsTierFilterProps {
+  value: MarketFilter;
+  onChange: (value: MarketFilter) => void;
+  hasDMarketTab: boolean;
+  isMobile?: boolean;
+  totalItems?: number;
+  className?: string;
+  /** Hide section title (when parent supplies layout). */
+  hideLabel?: boolean;
+}
+
+function TierHelpButton({
+  options,
+}: {
+  options: typeof MARKET_TIER_OPTIONS;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          aria-label="About market pool tiers"
+        >
+          <HelpCircle className="h-3.5 w-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs space-y-2 p-3 text-left">
+        {options
+          .filter((o) => o.value !== "all")
+          .map((o) => (
+            <div key={o.value}>
+              <p className="font-medium text-foreground">{o.label}</p>
+              <p className="text-xs text-muted-foreground">{o.description}</p>
+            </div>
+          ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+const MarketsTierFilter = ({
+  value,
+  onChange,
+  hasDMarketTab,
+  isMobile = false,
+  totalItems,
+  className,
+  hideLabel = false,
+}: MarketsTierFilterProps) => {
+  const options = MARKET_TIER_OPTIONS.filter(
+    (o) => o.value !== "D" || hasDMarketTab
+  );
+
+  const activeOption = options.find((o) => o.value === value);
+
+  return (
+    <div className={cn("min-w-0", className)}>
+      {!hideLabel && (
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Pool tier
+          </span>
+          <TierHelpButton options={options} />
+        </div>
+      )}
+
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          isMobile && "overflow-x-auto pb-0.5"
+        )}
+        role="radiogroup"
+        aria-label="Filter by pool tier"
+      >
+        {options.map((o) => {
+          const isActive = value === o.value;
+          const isLetterOnly = !!o.poolLetter;
+
+          return (
+            <button
+              key={o.value}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              aria-label={o.label}
+              title={o.description}
+              onClick={() => onChange(o.value)}
+              className={cn(
+                "inline-flex shrink-0 items-center justify-center font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-teal/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                isLetterOnly
+                  ? "h-9 w-9 rounded-full border text-sm"
+                  : "rounded-full border px-3.5 py-2 text-sm",
+                isActive
+                  ? "border-ocean-teal/60 bg-ocean-teal/15 text-foreground shadow-[0_0_0_1px_rgba(13,255,190,0.25)]"
+                  : "border-border/70 bg-background/40 text-muted-foreground hover:border-ocean-teal/35 hover:bg-muted/50 hover:text-foreground dark:bg-slate-800/30",
+                isLetterOnly &&
+                  isActive &&
+                  "ring-2 ring-ocean-teal/40 ring-offset-2 ring-offset-background"
+              )}
+            >
+              {o.poolLetter ? (
+                <span
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-bold leading-none text-white",
+                    marketPoolBadgeBgClassName(o.poolLetter)
+                  )}
+                >
+                  {o.poolLetter}
+                </span>
+              ) : (
+                <span className="whitespace-nowrap">All Markets</span>
+              )}
+            </button>
+          );
+        })}
+        {hideLabel && <TierHelpButton options={options} />}
+      </div>
+
+      {value !== "all" && totalItems != null && !hideLabel && (
+        <p className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+          Showing {activeOption?.label ?? value} · {totalItems} market
+          {totalItems === 1 ? "" : "s"}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MarketsTierFilter;

--- a/src/components/markets/STokenRow.tsx
+++ b/src/components/markets/STokenRow.tsx
@@ -93,42 +93,7 @@ const STokenRow = ({
         </div>
       </TableCell>
       <TableCell className="text-center">
-        {market.isLoading ? (
-          <LoadingCell />
-        ) : market.error ? (
-          <ErrorCell error={market.error} />
-        ) : (
-          <div className="text-muted-foreground text-sm">
-            
-          </div>
-        )}
-      </TableCell>
-      <TableCell className="text-center">
-        {market.isLoading ? (
-          <LoadingCell />
-        ) : market.error ? (
-          <ErrorCell error={market.error} />
-        ) : (
-          <div className="text-muted-foreground text-sm">
-            
-          </div>
-        )}
-      </TableCell>
-      <TableCell className="text-center">
-        {market.isLoading ? (
-          <LoadingCell />
-        ) : market.error ? (
-          <ErrorCell error={market.error} />
-        ) : (
-          <div>
-            <div className="font-medium text-purple-700 dark:text-purple-300">
-              {formatCurrency(Math.round(market.totalBorrowUSD / 1_000_000), "USD", { maximumFractionDigits: 0 })}
-            </div>
-            <div className="text-sm text-muted-foreground">
-              {formatNumber(market.totalBorrow, { maximumFractionDigits: 3 })} {market.asset}
-            </div>
-          </div>
-        )}
+        <span className="text-muted-foreground text-sm">&nbsp;</span>
       </TableCell>
       <TableCell className="text-center">
         {market.isLoading ? (
@@ -155,6 +120,25 @@ const STokenRow = ({
               marketIndex={marketIndex}
             />
           </Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-center">
+        <span className="text-muted-foreground text-sm">&nbsp;</span>
+      </TableCell>
+      <TableCell className="text-center">
+        {market.isLoading ? (
+          <LoadingCell />
+        ) : market.error ? (
+          <ErrorCell error={market.error} />
+        ) : (
+          <div>
+            <div className="font-medium text-purple-700 dark:text-purple-300">
+              {formatCurrency(Math.round(market.totalBorrowUSD / 1_000_000), "USD", { maximumFractionDigits: 0 })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {formatNumber(market.totalBorrow, { maximumFractionDigits: 3 })} {market.asset}
+            </div>
+          </div>
         )}
       </TableCell>
       <TableCell className="text-center">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,6 +12,7 @@ import PreFi from "@/pages/PreFi";
 import { useIsMobile } from "@/hooks/use-mobile";
 import LiquidationMonitor from "@/components/liquidation/LiquidationMonitor";
 import { isFeatureEnabled } from "@/config";
+import { cn } from "@/lib/utils";
 
 interface Token {
   symbol: string;
@@ -37,6 +38,7 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
   );
   const location = useLocation();
   const isMobile = useIsMobile();
+  const isMarketsTab = activeTab === "markets";
 
   console.log(
     "Index render - activeTab:",
@@ -113,8 +115,19 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
 
       <Header activeTab={activeTab} onTabChange={onTabChange} />
 
-      <main className="max-w-[1200px] mx-auto px-2 sm:px-4 md:px-6 py-4 md:py-8 relative z-10">
-        <div className="space-y-4 sm:space-y-6">{renderTabContent()}</div>
+      <main
+        className={cn(
+          "max-w-[1200px] mx-auto px-2 sm:px-4 md:px-6 relative z-10",
+          isMarketsTab ? "pt-2 pb-4 md:pt-3 md:pb-6" : "py-4 md:py-8"
+        )}
+      >
+        <div
+          className={cn(
+            isMarketsTab ? "space-y-2 sm:space-y-3" : "space-y-4 sm:space-y-6"
+          )}
+        >
+          {renderTabContent()}
+        </div>
       </main>
 
       <Footer />


### PR DESCRIPTION
## Summary

- **Markets page:** Reorganize pool tier controls into the filter bar with A/B/D pill badges, move search and quick filters below onboarding guidance, and surface Supply/Borrow APY columns by default. Expose sort field and direction as inline controls, promote multi-pool to a chip filter, and remove the More filters popover. Tighten header spacing, collapse wallet tools on mobile, fix cap status badges on narrow layouts, and add collapsible onboarding copy.
- **Wallet modal:** Rename the xChain connect option to **EVM Wallet (xChain)** so the label reflects that RainbowKit supports any EVM wallet, not only MetaMask.

## Test plan

- [ ] Open Markets on desktop, tablet, and mobile — verify tier pills, search, filter chips, sort controls, and APY columns render correctly
- [ ] Toggle New, Rewards, Multi-pool, and tier filters; confirm Clear all resets state
- [ ] Collapse/expand wallet toolbar and onboarding guidance on narrow viewports
- [ ] Open Wallet modal and confirm xChain option reads "EVM Wallet (xChain)"
- [ ] Connect via xChain with a non-MetaMask EVM wallet