### PR TITLE
Add Folks V2 wBTC (NTT) market and legacy/V2 disambiguation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.729",
+  "version": "0.1.744",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -15,10 +15,12 @@ import {
   getAllTokensWithDisplayInfo,
   getFolksAdaptersForPhase,
   getTokenConfig,
+  resolveTokenConfigFromDisplayToken,
   resolveTokenForMarketPosition,
   getAlgorandNetworkFromNetworkId,
   tokenStandardUsesNativeWalletBalance,
 } from "@/config";
+import { marketContractIdFromRowCacheKey } from "@/hooks/useOnDemandMarketData";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
 
@@ -328,12 +330,15 @@ const MarketsTable = () => {
     marketRowKey?: string;
     /** Config `tokens` key from the row (e.g. `fALGO`); passed to SupplyBorrowModal for token resolution. */
     configSymbol?: string;
+    /** nt200 market contract id (disambiguates e.g. legacy vs V2 wBTC). */
+    marketId?: string;
   }>({
     isOpen: false,
     asset: null,
     poolId: undefined,
     marketRowKey: undefined,
     configSymbol: undefined,
+    marketId: undefined,
   });
   const [withdrawModal, setWithdrawModal] = useState({
     isOpen: false,
@@ -859,6 +864,21 @@ const MarketsTable = () => {
     [markets]
   );
 
+  const marketContractIdFromMarketRowKey = useCallback(
+    (marketRowKey: string | undefined) => {
+      if (!marketRowKey) return undefined;
+      const row = markets.find(
+        (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
+      );
+      const fromInfo = row?.marketInfo?.marketId;
+      if (fromInfo != null && String(fromInfo).trim() !== "") {
+        return String(fromInfo).trim();
+      }
+      return marketContractIdFromRowCacheKey(marketRowKey);
+    },
+    [markets]
+  );
+
   const resolveTokenForDisplayedAsset = useCallback(
     (
       asset: string,
@@ -872,9 +892,14 @@ const MarketsTable = () => {
         asset,
         poolId,
         configSymbol,
+        marketContractId: marketContractIdFromMarketRowKey(marketRowKey),
       });
     },
-    [currentNetwork, configSymbolFromMarketRowKey]
+    [
+      currentNetwork,
+      configSymbolFromMarketRowKey,
+      marketContractIdFromMarketRowKey,
+    ]
   );
 
   const borrowModalAvailableAssets = useMemo(() => {
@@ -1031,12 +1056,29 @@ const MarketsTable = () => {
     }
 
     const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
+    const marketRow =
+      marketRowKey != null
+        ? markets.find(
+            (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
+          )
+        : undefined;
+    const marketId =
+      marketContractIdFromMarketRowKey(marketRowKey) ??
+      (marketRow?.marketInfo?.marketId != null
+        ? String(marketRow.marketInfo.marketId)
+        : undefined) ??
+      resolveTokenForDisplayedAsset(asset, poolId, marketRowKey)
+        ?.underlyingContractId;
     setDepositModal({
       isOpen: true,
       asset,
       poolId,
       marketRowKey,
       configSymbol,
+      marketId:
+        marketId != null && String(marketId).trim() !== ""
+          ? String(marketId).trim()
+          : undefined,
     });
 
     setIsLoadingBalance(true);
@@ -1343,6 +1385,7 @@ const MarketsTable = () => {
       poolId: undefined,
       marketRowKey: undefined,
       configSymbol: undefined,
+      marketId: undefined,
     });
     setDepositPoolCollateralMarkets([]);
 
@@ -2592,27 +2635,20 @@ const MarketsTable = () => {
       // `network.tokens` key (e.g. `ALGO`); row may have `originalSymbol` `fALGO` under that key.
       const originalSymbol =
         "originalSymbol" in token ? (token as { originalSymbol?: string }).originalSymbol : asset;
-      const tokensMapKey =
-        (token as { configKey?: string }).configKey ?? originalSymbol;
-      const tokenConfigRaw = getTokenConfig(currentNetwork, tokensMapKey);
-      if (!tokenConfigRaw) {
-        console.error(
-          `Original token config not found for ${asset} (tokensMapKey: ${tokensMapKey}, originalSymbol: ${originalSymbol})`
-        );
-        return { balance: 0, balanceUSD: 0 };
-      }
-
-      // Handle case where tokenConfig might be an array (multiple markets)
-      // Compare poolIds as strings to ensure exact match
-      const originalTokenConfig = Array.isArray(tokenConfigRaw)
-        ? tokenConfigRaw.find(
-          (tc) => String(tc.poolId) === String(token.poolId)
-        ) || tokenConfigRaw[0]
-        : tokenConfigRaw;
+      const originalTokenConfig = resolveTokenConfigFromDisplayToken(
+        currentNetwork,
+        {
+          configKey: (token as { configKey?: string }).configKey,
+          originalSymbol,
+          symbol: token.symbol,
+          poolId: token.poolId,
+          underlyingContractId: token.underlyingContractId,
+        }
+      );
 
       if (!originalTokenConfig) {
         console.error(
-          `Original token config not found for ${asset} (tokensMapKey: ${tokensMapKey}, poolId: ${token.poolId})`
+          `Original token config not found for ${asset} (poolId: ${token.poolId}, contractId: ${token.underlyingContractId})`
         );
         return { balance: 0, balanceUSD: 0 };
       }
@@ -2967,14 +3003,39 @@ const MarketsTable = () => {
     }
 
     if (!market && poolIdStr) {
-      // Exact match by asset + poolId (required for 2 WAD markets etc. – never use another market’s data)
-      market = markets.find(
-        (m) =>
-          m.asset === asset &&
-          (String(m.poolId) === poolIdStr ||
-            String((m as { marketInfo?: { poolId?: string } }).marketInfo?.poolId) === poolIdStr)
-      );
-      // When poolId was provided, do not fall back to a different market – wrong collateral factor etc.
+      const contractFromKey = marketContractIdFromRowCacheKey(marketRowKey);
+      if (contractFromKey) {
+        const displayToken = resolveTokenForDisplayedAsset(
+          asset,
+          poolIdStr,
+          marketRowKey
+        );
+        market = markets.find((m) => {
+          if (m.asset !== asset) return false;
+          const poolMatch =
+            String(m.poolId) === poolIdStr ||
+            String(
+              (m as { marketInfo?: { poolId?: string } }).marketInfo?.poolId
+            ) === poolIdStr;
+          if (!poolMatch) return false;
+          const mid =
+            m.marketInfo?.marketId != null
+              ? String(m.marketInfo.marketId)
+              : displayToken?.underlyingContractId;
+          return mid === contractFromKey;
+        });
+      }
+      if (!market) {
+        // Exact match by asset + poolId (required for 2 WAD markets etc.)
+        market = markets.find(
+          (m) =>
+            m.asset === asset &&
+            (String(m.poolId) === poolIdStr ||
+              String(
+                (m as { marketInfo?: { poolId?: string } }).marketInfo?.poolId
+              ) === poolIdStr)
+        );
+      }
       if (!market) return null;
     }
 
@@ -3040,15 +3101,17 @@ const MarketsTable = () => {
           }
         : undefined;
 
-    const tokenConfigRaw = getTokenConfig(
-      currentNetwork,
-      (market as { configSymbol?: string }).configSymbol ?? asset
+    const rowKeyForConfig =
+      marketRowKey ?? (market as { _sortKey?: string })._sortKey;
+    const displayToken = resolveTokenForDisplayedAsset(
+      asset,
+      poolIdStr ?? undefined,
+      rowKeyForConfig
     );
-    const tokenConfig = Array.isArray(tokenConfigRaw)
-      ? poolIdStr
-        ? tokenConfigRaw.find((c: { poolId?: string }) => String(c.poolId) === poolIdStr) ?? tokenConfigRaw[0]
-        : tokenConfigRaw[0]
-      : tokenConfigRaw;
+    const tokenConfig =
+      displayToken != null
+        ? resolveTokenConfigFromDisplayToken(currentNetwork, displayToken)
+        : undefined;
     const decimals = (tokenConfig as { decimals?: number } | undefined)?.decimals ?? 8;
 
     return {
@@ -3824,6 +3887,8 @@ const MarketsTable = () => {
               asset={depositModal.asset}
               poolId={depositModal.poolId}
               configSymbol={depositModal.configSymbol}
+              marketId={depositModal.marketId}
+              marketRowKey={depositModal.marketRowKey}
               network={currentNetwork}
               mode="deposit"
               assetData={

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -181,6 +181,7 @@ import { useFolksMainnetAlgoDepositLiveApyPercent } from "@/hooks/useFolksMainne
 import { useFolksMainnetUsdcPoolLiveApyPercent } from "@/hooks/useFolksMainnetUsdcPoolLiveApyPercent";
 import { useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent";
 import { useFolksMainnetFiTinyEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent";
+import { useFolksMainnetWbtcNttPoolLiveApyPercent } from "@/hooks/useFolksMainnetWbtcNttPoolLiveApyPercent";
 
 /* eslint-disable no-case-declarations -- many sort switch blocks use const in cases */
 /* eslint-disable react-hooks/exhaustive-deps -- many callbacks intentionally use stable deps subset */
@@ -374,6 +375,9 @@ const Portfolio = () => {
   const folksFiTinyEcosystemLiveApy = useFolksMainnetFiTinyEcosystemPoolLiveApyPercent(
     liveIntrinsicApyFetchEnabled
   );
+  const folksWbtcNttLiveApy = useFolksMainnetWbtcNttPoolLiveApyPercent(
+    liveIntrinsicApyFetchEnabled
+  );
   const liveIntrinsicSupplyApy = useMemo<LiveIntrinsicSupplyApySnapshot>(
     () => ({
       tinymanLiquidStakingPercent: tinymanLiveIntrinsicApyPct,
@@ -389,6 +393,10 @@ const Portfolio = () => {
         folksFiTinyEcosystemLiveApy?.depositPercent ?? null,
       folksMainnetFiTinyEcosystemBorrowPercent:
         folksFiTinyEcosystemLiveApy?.borrowPercent ?? null,
+      folksMainnetWbtcNttDepositPercent:
+        folksWbtcNttLiveApy?.depositPercent ?? null,
+      folksMainnetWbtcNttBorrowPercent:
+        folksWbtcNttLiveApy?.borrowPercent ?? null,
     }),
     [
       tinymanLiveIntrinsicApyPct,
@@ -397,6 +405,7 @@ const Portfolio = () => {
       folksUsdcPoolLiveApy,
       folksFiUsdcEcosystemLiveApy,
       folksFiTinyEcosystemLiveApy,
+      folksWbtcNttLiveApy,
     ]
   );
 

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -45,6 +45,7 @@ import {
   tokenConfigHasNonFolksAdapter,
   tokenConfigHasAdapters,
   tokenStandardIsFolksAsaBridge,
+  resolveTokenConfigFromDisplayToken,
   FOLKS_MAINNET_ALGO_WITHDRAW,
   isFolksAlgoWithdrawTwoStepEnabled,
 } from "@/config";
@@ -1692,13 +1693,13 @@ const PortfolioModals = ({
     }
     const networkToUse = (repayModal.network || currentNetwork) as NetworkId;
     const tokens = getAllTokensWithDisplayInfo(networkToUse);
-    const tok = repayModal.poolId
-      ? tokens.find(
-          (t) =>
-            t.symbol === repayModal.asset &&
-            String(t.poolId) === String(repayModal.poolId)
-        )
-      : tokens.find((t) => t.symbol === repayModal.asset);
+    const tok = resolveSupplyBorrowToken(
+      tokens,
+      repayModal.asset ?? "",
+      repayModal.poolId,
+      repayModal.configSymbol,
+      repayModal.marketId
+    );
     const poolIdStr = repayModal.poolId
       ? String(repayModal.poolId)
       : tok?.poolId != null
@@ -1835,49 +1836,34 @@ const PortfolioModals = ({
 
       // Get token configuration using the borrow's network
       const tokens = getAllTokensWithDisplayInfo(networkToUse);
-      // If poolId is provided, find the token that matches both symbol and poolId
-      // Otherwise, fall back to finding by symbol only (for backward compatibility)
-      const token = repayModal.poolId
-        ? tokens.find(
-            (t) =>
-              t.symbol === repayModal.asset && t.poolId === repayModal.poolId
-          )
-        : tokens.find((t) => t.symbol === repayModal.asset);
+      const token = resolveSupplyBorrowToken(
+        tokens,
+        repayModal.asset ?? "",
+        repayModal.poolId,
+        repayModal.configSymbol,
+        repayModal.marketId
+      );
 
       if (!token) {
         throw new Error(
           `Token not found for ${repayModal.asset}${
             repayModal.poolId ? ` with poolId ${repayModal.poolId}` : ""
-          } on network ${networkToUse}`
+          }${repayModal.marketId ? ` marketId ${repayModal.marketId}` : ""} on network ${networkToUse}`
         );
       }
 
-      // Use originalSymbol to look up the config, as asset might be a display symbol
-      const originalSymbol =
-        "originalSymbol" in token
-          ? (token as any).originalSymbol
-          : repayModal.asset;
-      const originalTokenConfigRaw = getTokenConfig(
+      const originalTokenConfig = resolveTokenConfigFromDisplayToken(
         networkToUse,
-        originalSymbol
+        token
       );
-      if (!originalTokenConfigRaw) {
-        throw new Error(
-          `Token config not found for ${repayModal.asset} (originalSymbol: ${originalSymbol}) on network ${networkToUse}`
-        );
-      }
-
-      // Handle case where tokenConfig might be an array (multiple markets)
-      // Compare poolIds as strings to ensure exact match
-      const originalTokenConfig = Array.isArray(originalTokenConfigRaw)
-        ? originalTokenConfigRaw.find(
-            (tc) => String(tc.poolId) === String(token.poolId)
-          ) || originalTokenConfigRaw[0]
-        : originalTokenConfigRaw;
 
       if (!originalTokenConfig) {
         throw new Error(
-          `Token config not found for ${repayModal.asset} with poolId ${token.poolId} on network ${networkToUse}`
+          `Token config not found for ${repayModal.asset} with poolId ${token.poolId}${
+            token.underlyingContractId
+              ? ` contractId ${token.underlyingContractId}`
+              : ""
+          } on network ${networkToUse}`
         );
       }
 
@@ -2688,24 +2674,23 @@ const PortfolioModals = ({
             repayModal.configSymbol,
             repayModal.marketId
           );
+          const tcRepayModal = repayTokenRow
+            ? resolveTokenConfigFromDisplayToken(networkRep, repayTokenRow)
+            : undefined;
           const cfgSymRep =
-            repayTokenRow.configKey ??
-            repayTokenRow.originalSymbol ??
-            repayTokenRow.symbol;
-          const rawTcRep = getTokenConfig(networkRep, cfgSymRep);
-          const tcRepayModal = Array.isArray(rawTcRep)
-            ? rawTcRep.find(
-                (c) => String(c.poolId) === String(repayTokenRow.poolId)
-              ) ?? rawTcRep[0]
-            : rawTcRep;
+            repayTokenRow?.configKey ??
+            repayTokenRow?.originalSymbol ??
+            repayTokenRow?.symbol ??
+            repayModal.configSymbol ??
+            repayModal.asset;
           const repayFolksAdaptersList = tcRepayModal
             ? getFolksAdaptersForPhase(tcRepayModal, "repay")
             : [];
           const repayDecimals =
-            tcRepayModal?.decimals ?? repayTokenRow.decimals ?? 6;
+            tcRepayModal?.decimals ?? repayTokenRow?.decimals ?? 6;
 
           const repayMintKey = `${networkRep}|${cfgSymRep}|${String(
-            repayTokenRow.poolId ?? ""
+            repayTokenRow?.poolId ?? ""
           )}`;
 
           const xalgoConsensusRepayAlgoOption =

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/services/lendingService";
 import {
   getTokenConfig,
+  resolveTokenConfigFromDisplayToken,
   getAllTokensWithDisplayInfo,
   getAlgorandNetworkFromNetworkId,
   getNetworkConfig,
@@ -204,19 +205,7 @@ export function resolveSupplyBorrowToken<T extends SupplyBorrowTokenRow>(
   const poolOk = (t: T) =>
     poolId == null || poolId === "" || String(t.poolId) === String(poolId);
 
-  // Prefer config key first: API `marketId` may not match `underlyingContractId` (e.g. asset id),
-  // and display `symbol` + pool collide for ALGO vs fALGO.
-  if (configSymbol) {
-    const byKey = tokens.find(
-      (t) =>
-        poolOk(t) &&
-        (t.configKey === configSymbol ||
-          t.originalSymbol === configSymbol ||
-          t.symbol === configSymbol)
-    );
-    if (byKey) return byKey;
-  }
-
+  // Prefer market contract + pool first (e.g. legacy vs V2 wBTC share `wBTC` + pool id).
   if (marketId != null && marketId !== "" && poolId != null && poolId !== "") {
     const byContract = tokens.find(
       (t) =>
@@ -230,6 +219,27 @@ export function resolveSupplyBorrowToken<T extends SupplyBorrowTokenRow>(
         String(t.poolId ?? "") === String(poolId)
     );
     if (byOriginal) return byOriginal;
+  }
+
+  if (configSymbol) {
+    const keyHits = tokens.filter(
+      (t) =>
+        poolOk(t) &&
+        (t.configKey === configSymbol ||
+          t.originalSymbol === configSymbol ||
+          t.symbol === configSymbol)
+    );
+    if (keyHits.length === 1) return keyHits[0];
+    if (keyHits.length > 1 && marketId != null && String(marketId) !== "") {
+      const mid = String(marketId);
+      const byMid = keyHits.find(
+        (t) =>
+          String(t.underlyingContractId ?? "") === mid ||
+          String(t.originalContractId ?? "") === mid
+      );
+      if (byMid) return byMid;
+    }
+    if (keyHits.length > 0) return keyHits[0];
   }
 
   if (poolId != null && poolId !== "") {
@@ -1677,13 +1687,16 @@ const SupplyBorrowModal = ({
           );
         }
 
-        // Handle case where tokenConfig might be an array (multiple markets)
-        // Compare poolIds as strings to ensure exact match
-        const tokenConfig = Array.isArray(tokenConfigRaw)
-          ? tokenConfigRaw.find(
-            (tc) => String(tc.poolId) === String(token.poolId)
-          ) || tokenConfigRaw[0]
-          : tokenConfigRaw;
+        const tokenConfig = resolveTokenConfigFromDisplayToken(
+          networkToUse as NetworkId,
+          {
+            configKey: (token as { configKey?: string }).configKey,
+            originalSymbol,
+            symbol: token.symbol,
+            poolId: token.poolId,
+            underlyingContractId: token.underlyingContractId,
+          }
+        );
 
         if (!tokenConfig) {
           throw new Error(
@@ -2835,16 +2848,20 @@ const SupplyBorrowModal = ({
         );
       }
 
-      // Handle case where tokenConfig might be an array (multiple markets)
-      const originalTokenConfig = Array.isArray(tokenConfigRaw)
-        ? tokenConfigRaw.find(
-          (tc) => String(tc.poolId) === String(token.poolId)
-        ) || tokenConfigRaw[0]
-        : tokenConfigRaw;
+      const originalTokenConfig = resolveTokenConfigFromDisplayToken(
+        actualNetwork as NetworkId,
+        {
+          configKey: (token as { configKey?: string }).configKey,
+          originalSymbol,
+          symbol: token.symbol,
+          poolId: token.poolId,
+          underlyingContractId: token.underlyingContractId,
+        }
+      );
 
       if (!originalTokenConfig) {
         throw new Error(
-          `Original token config not found for ${asset} (originalSymbol: ${originalSymbol})`
+          `Original token config not found for ${asset} (originalSymbol: ${originalSymbol}, contractId: ${token.underlyingContractId})`
         );
       }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,7 @@ import {
   FOLKS_FINANCE_ALGORAND_MAINNET_POOLS_BY_KEY,
   FOLKS_FINANCE_FIUSDC_ADAPTER_POOL_PARAMS,
   FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+  FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
   type FolksFinancePoolParams,
 } from "@/constants/folksFinance";
 
@@ -155,7 +156,8 @@ export interface TokenConfig {
   | "folks_mainnet_algo_pool_deposit"
   | "folks_mainnet_usdc_pool_deposit"
   | "folks_mainnet_fiusdc_ecosystem_pool_deposit"
-  | "folks_mainnet_fitiny_ecosystem_pool_deposit";
+  | "folks_mainnet_fitiny_ecosystem_pool_deposit"
+  | "folks_mainnet_wbtc_ntt_pool_deposit";
   /**
    * Optional intrinsic borrow APY in percentage points (e.g. 1.5 for 1.5%), added to displayed
    * borrow APY for this listing (e.g. wrapped-asset borrow uplift).
@@ -171,7 +173,9 @@ export interface TokenConfig {
   | "folks_mainnet_algo_pool_deposit"
   | "folks_mainnet_usdc_pool_borrow"
   | "folks_mainnet_fiusdc_ecosystem_pool_deposit"
-  | "folks_mainnet_fitiny_ecosystem_pool_deposit";
+  | "folks_mainnet_fitiny_ecosystem_pool_deposit"
+  | "folks_mainnet_wbtc_ntt_pool_deposit"
+  | "folks_mainnet_wbtc_ntt_pool_borrow";
   /**
    * Optional wrapped-asset / bridge adapters (e.g. Folks mint/redeem), in order.
    * Use {@link TokenAdapterConfig.phases} to split deposit vs withdraw legs, and `id` + `label`
@@ -612,6 +616,87 @@ export const FOLKS_MAINNET_FITINY_REPAY_UNDERLYING = {
   repayWalletBasis: "underlying" as const,
   phases: ["repay"] as const,
   folksParams: FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+/** Folks V2 WBTC (NTT) — same phase split as {@link FOLKS_MAINNET_USDC_DEPOSIT_FUSDC_WALLET}. */
+export const FOLKS_MAINNET_WBTC_DEPOSIT_FWBTC_WALLET = {
+  id: "folks-mainnet-wbtc-deposit-fwbtc",
+  name: "fWBTC",
+  type: "folks" as const,
+  label: "fWBTC",
+  depositWalletBasis: "market_token" as const,
+  phases: ["deposit"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_DEPOSIT_UNDERLYING = {
+  id: "folks-mainnet-wbtc-deposit-wbtc",
+  name: "wBTC",
+  type: "folks" as const,
+  label: "wBTC",
+  depositWalletBasis: "underlying" as const,
+  phases: ["deposit"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_WITHDRAW = {
+  id: "folks-mainnet-wbtc-withdraw-wbtc",
+  name: "wBTC",
+  type: "folks" as const,
+  label: "wBTC",
+  withdrawReceiveBasis: "underlying" as const,
+  phases: ["withdraw"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_WITHDRAW_FASSET_WALLET = {
+  id: "folks-mainnet-wbtc-withdraw-fwbtc",
+  name: "fWBTC",
+  type: "folks" as const,
+  label: "fWBTC",
+  withdrawReceiveBasis: "market_token" as const,
+  phases: ["withdraw"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_BORROW_FWBTC_WALLET = {
+  id: "folks-mainnet-wbtc-borrow-fwbtc",
+  name: "fWBTC",
+  type: "folks" as const,
+  label: "fWBTC",
+  borrowReceiveBasis: "market_token" as const,
+  phases: ["borrow"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_BORROW_UNDERLYING = {
+  id: "folks-mainnet-wbtc-borrow-wbtc",
+  name: "wBTC",
+  type: "folks" as const,
+  label: "wBTC",
+  borrowReceiveBasis: "underlying" as const,
+  phases: ["borrow"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_REPAY_FWBTC_WALLET = {
+  id: "folks-mainnet-wbtc-repay-fwbtc",
+  name: "fWBTC",
+  type: "folks" as const,
+  label: "fWBTC",
+  repayWalletBasis: "market_token" as const,
+  phases: ["repay"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
+} satisfies TokenAdapterConfig;
+
+export const FOLKS_MAINNET_WBTC_REPAY_UNDERLYING = {
+  id: "folks-mainnet-wbtc-repay-wbtc",
+  name: "wBTC",
+  type: "folks" as const,
+  label: "wBTC",
+  repayWalletBasis: "underlying" as const,
+  phases: ["repay"] as const,
+  folksParams: FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS,
 } satisfies TokenAdapterConfig;
 
 export type FolksTokenAdapterConfig = Extract<
@@ -2399,12 +2484,12 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
       FOLKS_MAINNET_FITINY_REPAY_FITINY_WALLET,
       FOLKS_MAINNET_FITINY_REPAY_UNDERLYING,
     ],
+    dataAddedAt: "2026-04-29T00:00:00.000Z",
     intrinsicApyPercent: 4.66,
     intrinsicBorrowApyPercent: 4.66,
     intrinsicApyLiveSource: "folks_mainnet_fitiny_ecosystem_pool_deposit",
     intrinsicBorrowApyLiveSource: "folks_mainnet_fitiny_ecosystem_pool_deposit",
     iconBadgeFromSymbol: "FOLKS",
-    dataAddedAt: "2026-04-29T00:00:00.000Z",
   },
   FINITE: [{
     assetId: "400593267",
@@ -2499,22 +2584,52 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
     logoPath: "/lovable-uploads/goBTC.webp",
     tokenStandard: "asa",
   },
-  wBTC: {
-    assetId: "1058926737",
-    poolId: "3333688282",
-    contractId: "3211827406",
-    nTokenId: "3348042762",
-    migration: {
-      poolId: "3207735602",
+  wBTC: [
+    {
+      assetId: "1058926737",
+      poolId: "3333688282",
       contractId: "3211827406",
-      nTokenId: "3211979645",
+      nTokenId: "3348042762",
+      migration: {
+        poolId: "3207735602",
+        contractId: "3211827406",
+        nTokenId: "3211979645",
+      },
+      decimals: 8,
+      name: "wBTC",
+      symbol: "wBTC",
+      logoPath: "/lovable-uploads/wBTCm.png",
+      tokenStandard: "asa",
     },
-    decimals: 8,
-    name: "wBTC",
-    symbol: "wBTC",
-    logoPath: "/lovable-uploads/wBTCm.png",
-    tokenStandard: "asa",
-  },
+    {
+      assetId: "3495558025", // Folks V2 WBTC (NTT) underlying
+      poolId: "3333688282",
+      contractId: "3573862137", // Folks V2 Wrapped BTC (arc200)
+      nTokenId: "3573966772",
+      decimals: 8,
+      name: "wBTC",
+      symbol: "wBTC",
+      logoPath: "/lovable-uploads/wBTCm.png",
+      tokenStandard: "asa-asa",
+      dataAddedAt: "2026-05-26T00:00:00.000Z",
+      requireStandaloneFAssetOptInBeforeDeposit: true,
+      adapters: [
+        FOLKS_MAINNET_WBTC_DEPOSIT_FWBTC_WALLET,
+        FOLKS_MAINNET_WBTC_DEPOSIT_UNDERLYING,
+        FOLKS_MAINNET_WBTC_WITHDRAW,
+        FOLKS_MAINNET_WBTC_WITHDRAW_FASSET_WALLET,
+        FOLKS_MAINNET_WBTC_BORROW_FWBTC_WALLET,
+        FOLKS_MAINNET_WBTC_BORROW_UNDERLYING,
+        FOLKS_MAINNET_WBTC_REPAY_FWBTC_WALLET,
+        FOLKS_MAINNET_WBTC_REPAY_UNDERLYING,
+      ],
+      intrinsicApyPercent: 1,
+      intrinsicBorrowApyPercent: 1,
+      intrinsicApyLiveSource: "folks_mainnet_wbtc_ntt_pool_deposit",
+      intrinsicBorrowApyLiveSource: "folks_mainnet_wbtc_ntt_pool_deposit",
+      iconBadgeFromSymbol: "FOLKS",
+    },
+  ],
   LINK: {
     assetId: "1200094857",
     poolId: "3333688282",
@@ -3484,51 +3599,69 @@ export function resolveTokenConfigFromDisplayToken(
 }
 
 /**
- * Single `TokenConfig` row for `symbol` + optional `poolId`, or any row matching `poolId` when
- * `getTokenConfig(symbol)` misses (e.g. fALGO row stored under `tokens.ALGO[]`).
+ * Single `TokenConfig` row for `symbol` + optional `poolId` (+ `marketContractId` when several
+ * rows share a pool, e.g. legacy vs V2 wBTC).
  */
 function resolveTokenConfigRowWithPool(
   networkId: NetworkId,
   symbol: string,
-  poolId: string | undefined
+  poolId: string | undefined,
+  marketContractId?: string
 ): TokenConfig | undefined {
+  const contractStr = String(marketContractId ?? "").trim();
   const raw = getTokenConfig(networkId, symbol);
   if (raw) {
-    return Array.isArray(raw)
-      ? poolId != null && poolId !== ""
-        ? raw.find((c) => String(c.poolId) === String(poolId)) ?? raw[0]
-        : raw[0]
-      : raw;
+    if (!Array.isArray(raw)) return raw;
+    const poolStr = poolId != null && poolId !== "" ? String(poolId) : "";
+    if (poolStr !== "" && contractStr !== "") {
+      const byBoth = raw.find(
+        (c) =>
+          String(c.poolId ?? "") === poolStr &&
+          String(c.contractId ?? "").trim() === contractStr
+      );
+      if (byBoth) return byBoth;
+    }
+    if (poolStr !== "") {
+      return raw.find((c) => String(c.poolId) === poolStr) ?? raw[0];
+    }
+    return raw[0];
   }
   if (poolId == null || poolId === "") return undefined;
+  const poolStr = String(poolId);
   const book = config.networks[networkId].tokens;
   for (const val of Object.values(book)) {
     if (Array.isArray(val)) {
-      const hit = val.find((c) => String(c.poolId) === String(poolId));
+      if (contractStr !== "") {
+        const byBoth = val.find(
+          (c) =>
+            String(c.poolId ?? "") === poolStr &&
+            String(c.contractId ?? "").trim() === contractStr
+        );
+        if (byBoth) return byBoth;
+      }
+      const hit = val.find((c) => String(c.poolId) === poolStr);
       if (hit) return hit;
-    } else if (val && String(val.poolId) === String(poolId)) {
-      return val;
+    } else if (val && String(val.poolId) === poolStr) {
+      if (
+        contractStr === "" ||
+        String(val.contractId ?? "").trim() === contractStr
+      ) {
+        return val;
+      }
     }
   }
   return undefined;
 }
 
-/** Intrinsic supply APY (% points) from config when set; 0 if unset or not applicable. */
-export const getIntrinsicSupplyApyPercent = (
-  networkId: NetworkId | string | undefined,
-  symbol: string,
-  poolId: string | undefined
-): number => {
-  if (!networkId) return 0;
-  const row = resolveTokenConfigRowWithPool(
-    networkId as NetworkId,
-    symbol,
-    poolId
-  );
-  if (!row) return 0;
-  const v = row.intrinsicApyPercent;
+function intrinsicSupplyApyBaseFromRow(row: TokenConfig | undefined): number {
+  const v = row?.intrinsicApyPercent;
   return typeof v === "number" && Number.isFinite(v) ? v : 0;
-};
+}
+
+function intrinsicBorrowApyBaseFromRow(row: TokenConfig | undefined): number {
+  const v = row?.intrinsicBorrowApyPercent;
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
 
 /** Optional live intrinsic supply APY values (percentage points) for {@link resolveIntrinsicSupplyApyPercent}. */
 export type LiveIntrinsicSupplyApySnapshot = {
@@ -3548,6 +3681,158 @@ export type LiveIntrinsicSupplyApySnapshot = {
   folksMainnetFiTinyEcosystemDepositPercent?: number | null;
   /** Folks Algorand Ecosystem TINY pool variable borrow yield, percentage points. */
   folksMainnetFiTinyEcosystemBorrowPercent?: number | null;
+  /** Folks V2 WBTC (NTT) pool deposit yield, percentage points. */
+  folksMainnetWbtcNttDepositPercent?: number | null;
+  /** Folks V2 WBTC (NTT) pool variable borrow yield, percentage points. */
+  folksMainnetWbtcNttBorrowPercent?: number | null;
+};
+
+function applyLiveIntrinsicSupplyApySource(
+  source: TokenConfig["intrinsicApyLiveSource"] | undefined,
+  live: LiveIntrinsicSupplyApySnapshot | null | undefined,
+  base: number
+): number {
+  if (source === "tinyman_liquid_staking") {
+    const v = live?.tinymanLiquidStakingPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "xalgo_governance_lambda") {
+    const v = live?.xalgoGovernanceLambdaPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_algo_pool_deposit") {
+    const v = live?.folksMainnetAlgoDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_usdc_pool_deposit") {
+    const v = live?.folksMainnetUsdcDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fiusdc_ecosystem_pool_deposit") {
+    const v = live?.folksMainnetFiUsdcEcosystemDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fitiny_ecosystem_pool_deposit") {
+    const v = live?.folksMainnetFiTinyEcosystemDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_wbtc_ntt_pool_deposit") {
+    const v = live?.folksMainnetWbtcNttDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  return base;
+}
+
+function applyLiveIntrinsicBorrowApySource(
+  source: TokenConfig["intrinsicBorrowApyLiveSource"] | undefined,
+  live: LiveIntrinsicSupplyApySnapshot | null | undefined,
+  base: number
+): number {
+  if (source === "tinyman_liquid_staking") {
+    const v = live?.tinymanLiquidStakingPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "xalgo_governance_lambda") {
+    const v = live?.xalgoGovernanceLambdaPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_algo_pool_deposit") {
+    const v = live?.folksMainnetAlgoDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_usdc_pool_borrow") {
+    const v = live?.folksMainnetUsdcBorrowPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fiusdc_ecosystem_pool_borrow") {
+    const v = live?.folksMainnetFiUsdcEcosystemBorrowPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fiusdc_ecosystem_pool_deposit") {
+    const v = live?.folksMainnetFiUsdcEcosystemDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fitiny_ecosystem_pool_borrow") {
+    const v = live?.folksMainnetFiTinyEcosystemBorrowPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_fitiny_ecosystem_pool_deposit") {
+    const v = live?.folksMainnetFiTinyEcosystemDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_wbtc_ntt_pool_deposit") {
+    const v = live?.folksMainnetWbtcNttDepositPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  if (source === "folks_mainnet_wbtc_ntt_pool_borrow") {
+    const v = live?.folksMainnetWbtcNttBorrowPercent;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    return base;
+  }
+  return base;
+}
+
+/** Intrinsic supply APY (% points) from config when set; 0 if unset or not applicable. */
+export const getIntrinsicSupplyApyPercent = (
+  networkId: NetworkId | string | undefined,
+  symbol: string,
+  poolId: string | undefined,
+  marketContractId?: string
+): number => {
+  if (!networkId) return 0;
+  const row = resolveTokenConfigRowWithPool(
+    networkId as NetworkId,
+    symbol,
+    poolId,
+    marketContractId
+  );
+  return intrinsicSupplyApyBaseFromRow(row);
+};
+
+/** Resolve live / static intrinsic supply APY from an already-resolved config row. */
+export function resolveIntrinsicSupplyApyPercentForTokenConfig(
+  networkId: NetworkId | string | undefined,
+  row: TokenConfig | undefined,
+  live?: LiveIntrinsicSupplyApySnapshot | null
+): number {
+  const base = intrinsicSupplyApyBaseFromRow(row);
+  if (networkId !== "algorand-mainnet") return base;
+  return applyLiveIntrinsicSupplyApySource(
+    row?.intrinsicApyLiveSource,
+    live,
+    base
+  );
+}
+
+/** Resolve live / static intrinsic borrow APY from an already-resolved config row. */
+export function resolveIntrinsicBorrowApyPercentForTokenConfig(
+  networkId: NetworkId | string | undefined,
+  row: TokenConfig | undefined,
+  live?: LiveIntrinsicSupplyApySnapshot | null
+): number {
+  const base = intrinsicBorrowApyBaseFromRow(row);
+  if (networkId !== "algorand-mainnet") return base;
+  return applyLiveIntrinsicBorrowApySource(
+    row?.intrinsicBorrowApyLiveSource,
+    live,
+    base
+  );
 };
 
 /**
@@ -3559,72 +3844,31 @@ export const resolveIntrinsicSupplyApyPercent = (
   networkId: NetworkId | string | undefined,
   symbol: string,
   poolId: string | undefined,
-  live?: LiveIntrinsicSupplyApySnapshot | null
+  live?: LiveIntrinsicSupplyApySnapshot | null,
+  marketContractId?: string
 ): number => {
-  const base = getIntrinsicSupplyApyPercent(networkId, symbol, poolId);
-  if (networkId !== "algorand-mainnet") return base;
   const row = resolveTokenConfigRowWithPool(
     networkId as NetworkId,
     symbol,
-    poolId
+    poolId,
+    marketContractId
   );
-  const source = row?.intrinsicApyLiveSource;
-  if (source === "tinyman_liquid_staking") {
-    const v = live?.tinymanLiquidStakingPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "xalgo_governance_lambda") {
-    const v = live?.xalgoGovernanceLambdaPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_algo_pool_deposit") {
-    const v = live?.folksMainnetAlgoDepositPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_usdc_pool_deposit") {
-    const v = live?.folksMainnetUsdcDepositPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_fiusdc_ecosystem_pool_deposit") {
-    const v = live?.folksMainnetFiUsdcEcosystemDepositPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_fitiny_ecosystem_pool_deposit") {
-    const v = live?.folksMainnetFiTinyEcosystemDepositPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  return base;
+  return resolveIntrinsicSupplyApyPercentForTokenConfig(networkId, row, live);
 };
 
 /** Whether this listing uses any configured live intrinsic supply APY source on Algorand mainnet. */
 export const tokenRowUsesLiveIntrinsicApy = (
   networkId: NetworkId | string | undefined,
   symbol: string,
-  poolId: string | undefined
+  poolId: string | undefined,
+  marketContractId?: string
 ): boolean => {
   if (networkId !== "algorand-mainnet") return false;
   const row = resolveTokenConfigRowWithPool(
     networkId as NetworkId,
     symbol,
-    poolId
+    poolId,
+    marketContractId
   );
   const s = row?.intrinsicApyLiveSource;
   return (
@@ -3633,7 +3877,8 @@ export const tokenRowUsesLiveIntrinsicApy = (
     s === "folks_mainnet_algo_pool_deposit" ||
     s === "folks_mainnet_usdc_pool_deposit" ||
     s === "folks_mainnet_fiusdc_ecosystem_pool_deposit" ||
-    s === "folks_mainnet_fitiny_ecosystem_pool_deposit"
+    s === "folks_mainnet_fitiny_ecosystem_pool_deposit" ||
+    s === "folks_mainnet_wbtc_ntt_pool_deposit"
   );
 };
 
@@ -3641,13 +3886,15 @@ export const tokenRowUsesLiveIntrinsicApy = (
 export const tokenRowUsesLiveIntrinsicBorrowApy = (
   networkId: NetworkId | string | undefined,
   symbol: string,
-  poolId: string | undefined
+  poolId: string | undefined,
+  marketContractId?: string
 ): boolean => {
   if (networkId !== "algorand-mainnet") return false;
   const row = resolveTokenConfigRowWithPool(
     networkId as NetworkId,
     symbol,
-    poolId
+    poolId,
+    marketContractId
   );
   const s = row?.intrinsicBorrowApyLiveSource;
   return (
@@ -3656,7 +3903,11 @@ export const tokenRowUsesLiveIntrinsicBorrowApy = (
     s === "folks_mainnet_algo_pool_deposit" ||
     s === "folks_mainnet_usdc_pool_borrow" ||
     s === "folks_mainnet_fiusdc_ecosystem_pool_borrow" ||
-    s === "folks_mainnet_fitiny_ecosystem_pool_borrow"
+    s === "folks_mainnet_fiusdc_ecosystem_pool_deposit" ||
+    s === "folks_mainnet_fitiny_ecosystem_pool_borrow" ||
+    s === "folks_mainnet_fitiny_ecosystem_pool_deposit" ||
+    s === "folks_mainnet_wbtc_ntt_pool_deposit" ||
+    s === "folks_mainnet_wbtc_ntt_pool_borrow"
   );
 };
 
@@ -3664,17 +3915,17 @@ export const tokenRowUsesLiveIntrinsicBorrowApy = (
 export const getIntrinsicBorrowApyPercent = (
   networkId: NetworkId | string | undefined,
   symbol: string,
-  poolId: string | undefined
+  poolId: string | undefined,
+  marketContractId?: string
 ): number => {
   if (!networkId) return 0;
   const row = resolveTokenConfigRowWithPool(
     networkId as NetworkId,
     symbol,
-    poolId
+    poolId,
+    marketContractId
   );
-  if (!row) return 0;
-  const v = row.intrinsicBorrowApyPercent;
-  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+  return intrinsicBorrowApyBaseFromRow(row);
 };
 
 /**
@@ -3686,59 +3937,16 @@ export const resolveIntrinsicBorrowApyPercent = (
   networkId: NetworkId | string | undefined,
   symbol: string,
   poolId: string | undefined,
-  live?: LiveIntrinsicSupplyApySnapshot | null
+  live?: LiveIntrinsicSupplyApySnapshot | null,
+  marketContractId?: string
 ): number => {
-  const base = getIntrinsicBorrowApyPercent(networkId, symbol, poolId);
-  if (networkId !== "algorand-mainnet") return base;
   const row = resolveTokenConfigRowWithPool(
     networkId as NetworkId,
     symbol,
-    poolId
+    poolId,
+    marketContractId
   );
-  const source = row?.intrinsicBorrowApyLiveSource;
-  if (source === "tinyman_liquid_staking") {
-    const v = live?.tinymanLiquidStakingPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "xalgo_governance_lambda") {
-    const v = live?.xalgoGovernanceLambdaPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_algo_pool_deposit") {
-    const v = live?.folksMainnetAlgoDepositPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_usdc_pool_borrow") {
-    const v = live?.folksMainnetUsdcBorrowPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_fiusdc_ecosystem_pool_borrow") {
-    const v = live?.folksMainnetFiUsdcEcosystemBorrowPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  if (source === "folks_mainnet_fitiny_ecosystem_pool_borrow") {
-    const v = live?.folksMainnetFiTinyEcosystemBorrowPercent;
-    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      return v;
-    }
-    return base;
-  }
-  return base;
+  return resolveIntrinsicBorrowApyPercentForTokenConfig(networkId, row, live);
 };
 
 export const getAllTokens = (networkId: NetworkId): TokenConfig[] => {
@@ -3885,12 +4093,15 @@ export function resolveTokenForMarketPosition(
     asset: string;
     poolId?: string;
     configSymbol?: string;
+    /** nt200 / Folks market contract (`TokenConfig.contractId`) when several rows share `poolId`. */
+    marketContractId?: string;
   }
 ): DisplayTokenInfo | null {
   const poolStr =
     params.poolId != null && String(params.poolId).trim() !== ""
       ? String(params.poolId).trim()
       : "";
+  const contractStr = String(params.marketContractId ?? "").trim();
   const tokens = getAllTokensWithDisplayInfo(networkId);
   const asset = params.asset.trim();
   const configSymbol = params.configSymbol?.trim();
@@ -3907,10 +4118,21 @@ export function resolveTokenForMarketPosition(
   };
 
   if (poolStr !== "") {
-    const direct = tokens.find(
+    const poolMatches = tokens.filter(
       (t) => matchesSymbol(t) && String(t.poolId ?? "") === poolStr
     );
-    if (direct?.poolId && direct.underlyingContractId) return direct;
+    if (contractStr !== "") {
+      const byContract = poolMatches.find(
+        (t) => String(t.underlyingContractId ?? "").trim() === contractStr
+      );
+      if (byContract?.poolId && byContract.underlyingContractId) {
+        return byContract;
+      }
+    }
+    if (poolMatches.length === 1) {
+      const direct = poolMatches[0];
+      if (direct?.poolId && direct.underlyingContractId) return direct;
+    }
 
     const book = config.networks[networkId]?.tokens;
     if (book) {

--- a/src/constants/folksFinance.ts
+++ b/src/constants/folksFinance.ts
@@ -291,6 +291,15 @@ export const FOLKS_FINANCE_FITINY_ADAPTER_POOL_PARAMS: FolksFinancePoolParams = 
   pool: "ISOLATED_TINY",
 };
 
+/**
+ * Adapter + SDK mint/withdraw params for Folks V2 WBTC (NTT). `pool` is the Folks SDK mainnet key
+ * `WBTC_NTT` (not legacy `WBTC` / `WBTC (old)`).
+ */
+export const FOLKS_FINANCE_WBTC_ADAPTER_POOL_PARAMS: FolksFinancePoolParams = {
+  ...FOLKS_FINANCE_ALGORAND_MAINNET_POOLS_BY_KEY.WBTC,
+  pool: "WBTC_NTT",
+};
+
 /** Resolve a mainnet pool row by `Pool` name from the docs (e.g. `ALGO`, `WBTC (old)`). */
 export function lookupFolksAlgorandMainnetPool(
   pool: string

--- a/src/hooks/useFolksMainnetWbtcNttPoolLiveApyPercent.ts
+++ b/src/hooks/useFolksMainnetWbtcNttPoolLiveApyPercent.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getAlgorandNetworkFromNetworkId } from "@/config";
+import algorandService from "@/services/algorandService";
+import {
+  fetchFolksMainnetWbtcNttPoolApySnapshot,
+  type FolksMainnetUsdcPoolApySnapshot,
+} from "@/services/folksMainnetDepositApyService";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Live Folks V2 WBTC (NTT) pool APYs — pass as
+ * `live.folksMainnetWbtcNttDepositPercent` / `live.folksMainnetWbtcNttBorrowPercent`.
+ */
+export function useFolksMainnetWbtcNttPoolLiveApyPercent(
+  enabled: boolean
+): FolksMainnetUsdcPoolApySnapshot | null {
+  const { data, status, error, fetchStatus } = useQuery({
+    queryKey: ["folks-mainnet-wbtc-ntt-pool-apy"],
+    queryFn: async () => {
+      const net = getAlgorandNetworkFromNetworkId("algorand-mainnet");
+      if (!net) {
+        throw new Error("algorand-mainnet not mapped to algod network");
+      }
+      const { algod } = algorandService.initializeClients(net);
+      return fetchFolksMainnetWbtcNttPoolApySnapshot(algod);
+    },
+    enabled,
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || !enabled) return;
+    if (status === "success" && data) {
+      console.debug("[folks-wbtc-ntt-apy] live snapshot", {
+        folksMainnetWbtcNttDepositPercent: data.depositPercent,
+        folksMainnetWbtcNttBorrowPercent: data.borrowPercent,
+        mapsTo: {
+          intrinsicApyLiveSource: "folks_mainnet_wbtc_ntt_pool_deposit",
+          intrinsicBorrowApyLiveSource: "folks_mainnet_wbtc_ntt_pool_deposit",
+        },
+      });
+    } else if (status === "error") {
+      console.warn("[folks-wbtc-ntt-apy] fetch failed", {
+        fetchStatus,
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  }, [enabled, status, data, error, fetchStatus]);
+
+  return data ?? null;
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -8,7 +8,9 @@ import {
   getMarketLabel,
   getRewardsProgramPublicBaseUrl,
   resolveIntrinsicSupplyApyPercent,
+  resolveIntrinsicSupplyApyPercentForTokenConfig,
   resolveIntrinsicBorrowApyPercent,
+  resolveIntrinsicBorrowApyPercentForTokenConfig,
   tokenRowUsesLiveIntrinsicApy,
   tokenRowUsesLiveIntrinsicBorrowApy,
   type LiveIntrinsicSupplyApySnapshot,
@@ -31,6 +33,7 @@ import { useFolksMainnetAlgoDepositLiveApyPercent } from "@/hooks/useFolksMainne
 import { useFolksMainnetUsdcPoolLiveApyPercent } from "@/hooks/useFolksMainnetUsdcPoolLiveApyPercent";
 import { useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiUsdcEcosystemPoolLiveApyPercent";
 import { useFolksMainnetFiTinyEcosystemPoolLiveApyPercent } from "@/hooks/useFolksMainnetFiTinyEcosystemPoolLiveApyPercent";
+import { useFolksMainnetWbtcNttPoolLiveApyPercent } from "@/hooks/useFolksMainnetWbtcNttPoolLiveApyPercent";
 import { resolveTokenIconBadgeUrl } from "@/utils/tokenImageUtils";
 
 export interface OnDemandMarketData {
@@ -95,18 +98,59 @@ export interface OnDemandMarketData {
 }
 
 /**
- * Stable row / cache key: canonical config symbol (not display override) + pool id.
- * Required when multiple markets share the same display name and pool (e.g. ALGO vs fALGO both "Algo").
+ * Stable row / cache key: canonical config symbol (not display override) + pool id (+ market contract when set).
+ * Required when multiple markets share the same display name and pool (e.g. ALGO vs fALGO, legacy vs V2 wBTC).
  */
 export function marketRowCacheKey(token: {
   originalSymbol?: string;
   symbol: string;
   poolId?: string | null;
+  underlyingContractId?: string;
 }): string {
   const sym = (token.originalSymbol ?? token.symbol).toLowerCase();
-  return token.poolId != null && String(token.poolId) !== ""
-    ? `${sym}-${String(token.poolId)}`
-    : sym;
+  const pool =
+    token.poolId != null && String(token.poolId) !== ""
+      ? String(token.poolId)
+      : "";
+  const contract = String(token.underlyingContractId ?? "").trim();
+  if (pool !== "" && contract !== "") {
+    return `${sym}-${pool}-${contract}`;
+  }
+  if (pool !== "") {
+    return `${sym}-${pool}`;
+  }
+  return sym;
+}
+
+/** Parse {@link marketRowCacheKey} back into symbol / pool / optional market contract. */
+export function parseMarketRowCacheKey(marketKey: string): {
+  symbol: string;
+  poolId?: string;
+  contractId?: string;
+} {
+  const key = String(marketKey ?? "").trim();
+  const parts = key.split("-").filter((p) => p !== "");
+  const symbol = parts[0] ?? "";
+  if (parts.length >= 3) {
+    const contractId = parts[parts.length - 1];
+    const poolId = parts.slice(1, -1).join("-");
+    return { symbol, poolId, contractId };
+  }
+  if (parts.length === 2) {
+    return { symbol, poolId: parts[1] };
+  }
+  return { symbol };
+}
+
+/** Market contract id encoded in {@link marketRowCacheKey} (`sym-pool-contract`), when present. */
+export function marketContractIdFromRowCacheKey(
+  marketRowKey: string | undefined
+): string | undefined {
+  const parsed = parseMarketRowCacheKey(String(marketRowKey ?? "").trim());
+  const contract = parsed.contractId?.trim();
+  return contract !== "" && contract != null && /^\d+$/.test(contract)
+    ? contract
+    : undefined;
 }
 
 /** `network.tokens` object key (e.g. `ALGO` when the row's `originalSymbol` is `fALGO`). */
@@ -267,6 +311,9 @@ export const useOnDemandMarketData = ({
   const folksFiTinyEcosystemLiveApy = useFolksMainnetFiTinyEcosystemPoolLiveApyPercent(
     algorandMainnetMarkets
   );
+  const folksWbtcNttLiveApy = useFolksMainnetWbtcNttPoolLiveApyPercent(
+    algorandMainnetMarkets
+  );
   const liveIntrinsicSupplyApy = useMemo<LiveIntrinsicSupplyApySnapshot>(
     () => ({
       tinymanLiquidStakingPercent: tinymanLiveIntrinsicApyPct,
@@ -282,6 +329,10 @@ export const useOnDemandMarketData = ({
         folksFiTinyEcosystemLiveApy?.depositPercent ?? null,
       folksMainnetFiTinyEcosystemBorrowPercent:
         folksFiTinyEcosystemLiveApy?.borrowPercent ?? null,
+      folksMainnetWbtcNttDepositPercent:
+        folksWbtcNttLiveApy?.depositPercent ?? null,
+      folksMainnetWbtcNttBorrowPercent:
+        folksWbtcNttLiveApy?.borrowPercent ?? null,
     }),
     [
       tinymanLiveIntrinsicApyPct,
@@ -290,6 +341,7 @@ export const useOnDemandMarketData = ({
       folksUsdcPoolLiveApy,
       folksFiUsdcEcosystemLiveApy,
       folksFiTinyEcosystemLiveApy,
+      folksWbtcNttLiveApy,
     ]
   );
 
@@ -331,20 +383,14 @@ export const useOnDemandMarketData = ({
         tokenConfig as TokenConfig | undefined
       );
 
-      const intrinsicApr = resolveIntrinsicSupplyApyPercent(
+      const intrinsicApr = resolveIntrinsicSupplyApyPercentForTokenConfig(
         currentNetwork,
-        tokensMapKey,
-        token.poolId != null && token.poolId !== ""
-          ? String(token.poolId)
-          : undefined,
+        tokenConfig,
         liveIntrinsicSupplyApy
       );
-      const intrinsicBorrowApy = resolveIntrinsicBorrowApyPercent(
+      const intrinsicBorrowApy = resolveIntrinsicBorrowApyPercentForTokenConfig(
         currentNetwork,
-        tokensMapKey,
-        token.poolId != null && token.poolId !== ""
-          ? String(token.poolId)
-          : undefined,
+        tokenConfig,
         liveIntrinsicSupplyApy
       );
 
@@ -401,30 +447,47 @@ export const useOnDemandMarketData = ({
           row.poolId != null && String(row.poolId) !== ""
             ? String(row.poolId)
             : undefined;
+        const contractId = parseMarketRowCacheKey(key).contractId;
         let rowNext = row;
         const patchRow = (partial: Partial<OnDemandMarketData>) => {
           rowNext = { ...rowNext, ...partial };
           changed = true;
         };
 
-        if (tokenRowUsesLiveIntrinsicApy(currentNetwork, sym, poolId)) {
+        if (
+          tokenRowUsesLiveIntrinsicApy(
+            currentNetwork,
+            sym,
+            poolId,
+            contractId
+          )
+        ) {
           const resolved = resolveIntrinsicSupplyApyPercent(
             currentNetwork,
             sym,
             poolId,
-            liveIntrinsicSupplyApy
+            liveIntrinsicSupplyApy,
+            contractId
           );
           const newSupply = resolved > 0 ? resolved : undefined;
           if (rowNext.intrinsicSupplyApyPercent !== newSupply) {
             patchRow({ intrinsicSupplyApyPercent: newSupply });
           }
         }
-        if (tokenRowUsesLiveIntrinsicBorrowApy(currentNetwork, sym, poolId)) {
+        if (
+          tokenRowUsesLiveIntrinsicBorrowApy(
+            currentNetwork,
+            sym,
+            poolId,
+            contractId
+          )
+        ) {
           const resolvedBorrow = resolveIntrinsicBorrowApyPercent(
             currentNetwork,
             sym,
             poolId,
-            liveIntrinsicSupplyApy
+            liveIntrinsicSupplyApy,
+            contractId
           );
           const newBorrow =
             resolvedBorrow > 0 ? resolvedBorrow : undefined;
@@ -443,21 +506,23 @@ export const useOnDemandMarketData = ({
   // Load individual market data
   const loadMarketData = useCallback(
     async (marketKey: string, bypassCache = false) => {
-      // Parse marketKey: canonical symbol + optional pool id (e.g. falgo-3333688282, algo-3333688282)
-      const parts = marketKey.split("-");
-      const symbol = parts[0];
-      const poolIdFromKey = parts.length > 1 ? parts.slice(1).join("-") : undefined;
+      const { symbol, poolId: poolIdFromKey, contractId: contractFromKey } =
+        parseMarketRowCacheKey(marketKey);
 
       const canonical = (t: (typeof tokens)[0]) =>
         (t.originalSymbol ?? t.symbol).toLowerCase();
 
-      // Find matching tokens (compare poolId as string so "123" and 123 both match – e.g. 2 WAD markets)
       const matchingTokens = tokens.filter((t) => {
-        const matchesSymbol = canonical(t) === symbol.toLowerCase();
+        if (canonical(t) !== symbol.toLowerCase()) return false;
         if (poolIdFromKey != null && poolIdFromKey !== "") {
-          return matchesSymbol && String(t.poolId) === String(poolIdFromKey);
+          if (String(t.poolId) !== String(poolIdFromKey)) return false;
         }
-        return matchesSymbol;
+        if (contractFromKey != null && contractFromKey !== "") {
+          if (String(t.underlyingContractId ?? "") !== String(contractFromKey)) {
+            return false;
+          }
+        }
+        return true;
       });
 
       if (matchingTokens.length === 0) return;
@@ -637,22 +702,17 @@ export const useOnDemandMarketData = ({
               tokenConfig as TokenConfig | undefined
             );
 
-            const intrinsicApr = resolveIntrinsicSupplyApyPercent(
+            const intrinsicApr = resolveIntrinsicSupplyApyPercentForTokenConfig(
               currentNetwork,
-              tokensMapKey,
-              tokenPoolId != null && tokenPoolId !== ""
-                ? String(tokenPoolId)
-                : undefined,
+              tokenConfig,
               liveIntrinsicSupplyApy
             );
-            const intrinsicBorrowApy = resolveIntrinsicBorrowApyPercent(
-              currentNetwork,
-              tokensMapKey,
-              tokenPoolId != null && tokenPoolId !== ""
-                ? String(tokenPoolId)
-                : undefined,
-              liveIntrinsicSupplyApy
-            );
+            const intrinsicBorrowApy =
+              resolveIntrinsicBorrowApyPercentForTokenConfig(
+                currentNetwork,
+                tokenConfig,
+                liveIntrinsicSupplyApy
+              );
 
             // Safely resolve supplyAPY - avoid NaN when supplyRate is undefined
             const supplyAPYValue =

--- a/src/services/folksMainnetDepositApyService.ts
+++ b/src/services/folksMainnetDepositApyService.ts
@@ -105,3 +105,20 @@ export async function fetchFolksMainnetFiTinyEcosystemPoolApySnapshot(
     ),
   };
 }
+
+/**
+ * Folks V2 WBTC (NTT) lending pool deposit and variable borrow yields — {@link MainnetPools.WBTC_NTT}.
+ */
+export async function fetchFolksMainnetWbtcNttPoolApySnapshot(
+  algod: Algodv2
+): Promise<FolksMainnetUsdcPoolApySnapshot> {
+  const info = await retrievePoolInfo(algod, MainnetPools.WBTC_NTT);
+  return {
+    depositPercent: yieldFixed16ToApyPercentPoints(
+      info.interest.depositInterestYield
+    ),
+    borrowPercent: yieldFixed16ToApyPercentPoints(
+      info.variableBorrow.variableBorrowInterestYield
+    ),
+  };
+}

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -661,9 +661,17 @@ export const fetchMarketInfo = async (
       console.log("fetchMarketInfo tokenConfigRaw", { tokenConfigRaw, token });
       let tokenConfig: TokenConfig | undefined;
       if (Array.isArray(tokenConfigRaw)) {
-        // Find the token config that matches the poolId
+        const poolStr = String(poolId);
+        const marketStr = String(marketId).trim();
         tokenConfig =
-          tokenConfigRaw.find((config) => String(config.poolId) === String(poolId)) ||
+          (marketStr !== ""
+            ? tokenConfigRaw.find(
+                (config) =>
+                  String(config.poolId) === poolStr &&
+                  String(config.contractId ?? "").trim() === marketStr
+              )
+            : undefined) ??
+          tokenConfigRaw.find((config) => String(config.poolId) === poolStr) ??
           tokenConfigRaw[0];
       } else {
         tokenConfig = tokenConfigRaw;


### PR DESCRIPTION
## Summary
- Add Folks V2 wBTC (NTT) on pool `3333688282` with `WBTC_NTT` Folks adapters, `asa-asa` config, and live Folks deposit intrinsic APY for supply and borrow display.
- Disambiguate legacy vs V2 wBTC everywhere they share the same pool id: market row cache keys, token config resolution, markets table supply/repay, portfolio repay, and `fetchMarketInfo` by `poolId` + `contractId`.
- Fix regressions where V2 rows picked legacy market `3211827406` (paused supply, wrong balances, missing intrinsic APY, broken Folks repay routes).

## Test plan
- [ ] Markets (mainnet): confirm two wBTC rows; V2 shows ~1.23% intrinsic on supply and borrow after live fetch loads
- [ ] Supply V2 wBTC with wBTC and fWBTC routes; confirm not blocked as “market paused”
- [ ] Wallet balance on V2 row shows underlying ASA `3495558025`, not legacy `1058926737`
- [ ] Borrow and repay on V2 position (`3573862137`); repay modal shows fWBTC / wBTC Folks routes and tx targets V2 market
- [ ] Legacy wBTC row still works independently (no Folks adapters on legacy config)


Made with [Cursor](https://cursor.com)