### PR TITLE
Fix mobile Markets filters stuck while scrolling (#394)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.748",
+  "version": "0.1.749",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -3769,7 +3769,7 @@ const MarketsTable = () => {
             </div>
           </div>
 
-          <div className="sticky top-2 z-20 -mx-1 px-1 pb-2 rounded-lg bg-blue-50/95 dark:bg-slate-900/95 backdrop-blur-sm">
+          <div className="-mx-1 px-1 pb-2 rounded-lg md:sticky md:top-2 md:z-20 md:bg-blue-50/95 dark:md:bg-slate-900/95 md:backdrop-blur-sm">
             <MarketSearchFilters
               embedded
               searchTerm={searchTerm}


### PR DESCRIPTION
## Summary
- Fixes [#394](https://github.com/DorkFi/dorkfi-app/issues/394): on mobile, Markets filters no longer stay pinned while scrolling.
- Scopes sticky positioning and backdrop styling on the `MarketSearchFilters` wrapper to `md+` viewports (768px+), matching the app's mobile breakpoint.
- Preserves sticky filter behavior on tablet and desktop for long market lists.

## Test plan
- [ ] Open Markets on a mobile viewport (<768px) and scroll the market list — filters should scroll off-screen with the page content.
- [ ] Open Markets on tablet/desktop (≥768px) and scroll — filters should remain sticky near the top while browsing markets.
- [ ] Verify tier tabs, search, and filter chips still work on both mobile and desktop.


Made with [Cursor](https://cursor.com)