### PR TITLE
Disable Mint button when borrow cap utilization reaches threshold (#384)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.749",
+  "version": "0.1.752",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/markets/MarketRowStatusBadges.tsx
+++ b/src/components/markets/MarketRowStatusBadges.tsx
@@ -52,7 +52,7 @@ export function MarketRowStatusBadges({
   const showNew = market.isNew;
   const showRewards = market.hasRewards;
 
-  if (!showNew && !showRewards && !atSupplyCap && !(atBorrowCap && !market.isSToken)) {
+  if (!showNew && !showRewards && !atSupplyCap && !atBorrowCap) {
     return null;
   }
 
@@ -92,7 +92,7 @@ export function MarketRowStatusBadges({
           title="Supply cap nearly full"
         />
       )}
-      {atBorrowCap && !market.isSToken && (
+      {atBorrowCap && (
         <CapBadge
           label="Borrow cap"
           shortLabel="B. cap"

--- a/src/components/markets/MarketsTableActions.tsx
+++ b/src/components/markets/MarketsTableActions.tsx
@@ -1,5 +1,8 @@
 
 import DorkFiButton from "@/components/ui/DorkFiButton";
+import {
+  MINT_BORROW_CAP_TOOLTIP,
+} from "@/constants/lendingCaps";
 import { ArrowRightLeft } from "lucide-react";
 
 interface MarketsTableActionsProps {
@@ -25,7 +28,7 @@ interface MarketsTableActionsProps {
 
 /**
  * Deposit / Borrow (or Mint for sToken) actions.
- * For sToken the second button is "Mint"; it is not disabled by borrowDisabled by design (mint is independent of borrow cap).
+ * For mintable (sToken) markets, Mint is disabled when borrow cap utilization reaches the configured threshold.
  */
 const MarketsTableActions = ({
   asset,
@@ -66,14 +69,21 @@ const MarketsTableActions = ({
           onMouseEnter={isSToken ? onMintMouseEnter : onBorrowMouseEnter}
           onClick={(e) => {
             e.stopPropagation();
+            if (borrowDisabled) return;
             if (isSToken && onMintClick) {
               onMintClick(asset, poolId, marketRowKey);
-            } else if (!borrowDisabled) {
+            } else {
               onBorrowClick(asset, poolId, marketRowKey);
             }
           }}
-          disabled={!isSToken && borrowDisabled}
-          title={!isSToken && borrowDisabled ? "Market at borrow cap" : undefined}
+          disabled={borrowDisabled}
+          title={
+            borrowDisabled
+              ? isSToken
+                ? MINT_BORROW_CAP_TOOLTIP
+                : "Market at borrow cap"
+              : undefined
+          }
           className={isSToken ? "min-w-[140px] flex-1" : ""}
         >
           {isSToken ? "Mint" : "Borrow"}

--- a/src/components/markets/STokenCard.tsx
+++ b/src/components/markets/STokenCard.tsx
@@ -11,6 +11,10 @@ import {
   borrowApyBadgeClassName,
   BORROW_APY_BADGE_STOKEN,
 } from "@/constants/marketUi";
+import {
+  isAtBorrowCap,
+  MINT_BORROW_CAP_TOOLTIP,
+} from "@/constants/lendingCaps";
 import { MarketRowTokenIcon } from "./MarketRowTokenIcon";
 
 interface STokenCardProps {
@@ -35,6 +39,11 @@ const STokenCard = ({
 }: STokenCardProps) => {
   const { formatCurrency, formatPercent } = useNumberI18n();
   const { currentNetwork } = useNetwork();
+  const borrowCapReached = isAtBorrowCap(
+    Number(market.totalBorrow ?? 0),
+    Number(market.borrowCap ?? 0)
+  );
+
   return (
     <DorkFiCard
       key={market.asset}
@@ -105,7 +114,13 @@ const STokenCard = ({
       <div className="flex gap-2 pt-1 justify-center md:justify-start">
         <DorkFiButton
           variant="secondary"
-          onClick={e => { e.stopPropagation(); onMintClick?.(market.asset, market.marketInfo?.poolId); }}
+          onClick={e => {
+            e.stopPropagation();
+            if (borrowCapReached) return;
+            onMintClick?.(market.asset, market.marketInfo?.poolId);
+          }}
+          disabled={borrowCapReached}
+          title={borrowCapReached ? MINT_BORROW_CAP_TOOLTIP : undefined}
           className="w-full bg-purple-100 hover:bg-purple-200 text-purple-800 dark:bg-purple-900 dark:hover:bg-purple-800 dark:text-purple-200"
         >
           Mint

--- a/src/components/markets/STokenRow.tsx
+++ b/src/components/markets/STokenRow.tsx
@@ -17,6 +17,7 @@ import {
   borrowApyBadgeClassName,
   BORROW_APY_BADGE_STOKEN,
 } from "@/constants/marketUi";
+import { isAtBorrowCap } from "@/constants/lendingCaps";
 import { MarketRowTokenIcon } from "./MarketRowTokenIcon";
 
 interface STokenRowProps {
@@ -69,6 +70,10 @@ const STokenRow = ({
 }: STokenRowProps) => {
   const { formatNumber, formatCurrency } = useNumberI18n();
   const { currentNetwork } = useNetwork();
+  const borrowCapReached = isAtBorrowCap(
+    Number(market.totalBorrow ?? 0),
+    Number(market.borrowCap ?? 0)
+  );
 
   return (
     <TableRow
@@ -172,6 +177,7 @@ const STokenRow = ({
           onMintClick={onMintClick}
           isLoadingBalance={isLoadingBalance}
           isSToken={true}
+          borrowDisabled={borrowCapReached}
           onDepositMouseEnter={
             getMarketActionHoverHandlers?.(
               market.asset,

--- a/src/components/markets/STokenTabletRow.tsx
+++ b/src/components/markets/STokenTabletRow.tsx
@@ -14,6 +14,7 @@ import {
   borrowApyBadgeClassName,
   BORROW_APY_BADGE_STOKEN,
 } from "@/constants/marketUi";
+import { isAtBorrowCap } from "@/constants/lendingCaps";
 import { MarketRowTokenIcon } from "./MarketRowTokenIcon";
 
 interface STokenTabletRowProps {
@@ -53,7 +54,11 @@ const STokenTabletRow = ({
   marketIndex,
 }: STokenTabletRowProps) => {
   const { currentNetwork } = useNetwork();
-  
+  const borrowCapReached = isAtBorrowCap(
+    Number(market.totalBorrow ?? 0),
+    Number(market.borrowCap ?? 0)
+  );
+
   return (
     <TableRow
       key={market.asset}
@@ -132,6 +137,7 @@ const STokenTabletRow = ({
           onMintClick={onMintClick}
           isLoadingBalance={isLoadingBalance}
           isSToken={true}
+          borrowDisabled={borrowCapReached}
         />
       </TableCell>
     </TableRow>

--- a/src/constants/lendingCaps.ts
+++ b/src/constants/lendingCaps.ts
@@ -5,6 +5,10 @@
  */
 export const CAP_UTILIZATION_THRESHOLD = 0.95;
 
+/** Tooltip when mint is disabled because borrow cap utilization is near capacity. */
+export const MINT_BORROW_CAP_TOOLTIP =
+  "Minting temporarily unavailable due to borrow cap utilization";
+
 /**
  * True when market supply is at or over the deposit cap (≥ threshold of max).
  * Both args must be in the same units (e.g. human-readable token amount).


### PR DESCRIPTION
## Summary
- Disables the Mint button on mintable (sToken) markets when borrow cap utilization reaches the existing 95% threshold (`CAP_UTILIZATION_THRESHOLD`), matching Supply/Borrow cap protection behavior.
- Applies across desktop, tablet, and mobile Markets views via `MarketsTableActions`, `STokenRow`, `STokenTabletRow`, and `STokenCard`.
- Adds tooltip copy: "Minting temporarily unavailable due to borrow cap utilization" and shows borrow cap status badges for mintable markets.

Closes https://github.com/DorkFi/dorkfi-app/issues/384

## Test plan
- [ ] Open Markets page on a mintable market (e.g. WAD A Market) with borrow utilization below 95% — Mint button is enabled
- [ ] When `totalBorrow / borrowCap >= 0.95`, Mint button is disabled with tooltip on hover
- [ ] Verify disabled styling matches Supply/Borrow disabled states
- [ ] Confirm behavior on desktop table, tablet table, and mobile card views
- [ ] Confirm borrow cap badge appears for mintable markets near capacity

Made with [Cursor](https://cursor.com)