### PR TITLE
Add Tinyman liquidity pools page and LP lending markets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.766",
+  "version": "0.1.767",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.753",
+  "version": "0.1.766",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import CountdownPage from "./pages/Countdown";
 import MarketsTable from "./components/MarketsTable";
 import Dashboard from "./components/Dashboard";
 import Portfolio from "./components/Portfolio";
+import PoolsPage from "./pages/Pools";
 import PortfolioPage from "./pages/PortfolioPage";
 //const LAUNCH_TIMESTAMP = Date.UTC(2025, 10, 21, 2, 0, 0); // Nov 20, 2025 6:00 PM PST (Nov 21, 2025 2:00 AM UTC)
 const LAUNCH_TIMESTAMP = Date.now();
@@ -118,6 +119,17 @@ function App() {
                 <Route
                   path="/governance"
                   element={<Governance />}
+                />
+              )}
+              {isFeatureEnabled("enablePools") && (
+                <Route
+                  path="/pools"
+                  element={
+                    <PoolsPage
+                      activeTab={activeTab}
+                      onTabChange={setActiveTab}
+                    />
+                  }
                 />
               )}
               <Route path="/portfolio" element={<PortfolioPage />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,6 +23,7 @@ const Header = ({ activeTab, onTabChange }: HeaderProps = {}) => {
 
   // Determine activeTab from location if not provided
   const currentActiveTab = activeTab || (() => {
+    if (location.pathname === "/pools") return "pools";
     if (location.pathname === "/analytics") return "analytics";
     if (location.pathname === "/liquidation-markets") return "liquidations";
     if (location.pathname === "/gas-station") return "gas-station";
@@ -46,6 +47,8 @@ const Header = ({ activeTab, onTabChange }: HeaderProps = {}) => {
       navigate("/analytics");
     } else if (value === "governance") {
       navigate("/governance");
+    } else if (value === "pools") {
+      navigate("/pools");
     } else if (value === "portfolio") {
       navigate("/portfolio");
     } else if (value === "markets") {
@@ -75,6 +78,8 @@ const Header = ({ activeTab, onTabChange }: HeaderProps = {}) => {
         onTabChange("gas-station");
       } else if (location.pathname === "/governance") {
         onTabChange("governance");
+      } else if (location.pathname === "/pools") {
+        onTabChange("pools");
       } else if (location.pathname === "/portfolio" || location.pathname.startsWith("/portfolio/")) {
         onTabChange("portfolio");
       } else if (location.pathname === "/market") {
@@ -93,6 +98,9 @@ const Header = ({ activeTab, onTabChange }: HeaderProps = {}) => {
       ? [{ value: "prefi", label: "PreFi" }]
       : []),
     { value: "markets", label: "Markets" },
+    ...(isFeatureEnabled("enablePools")
+      ? [{ value: "pools", label: "Pools" }]
+      : []),
     ...(activeAccount ? [{ value: "portfolio", label: "Portfolio" }] : []),
     ...(isFeatureEnabled("enableLiquidations")
       ? [{ value: "liquidations", label: "Liquidations" }]

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -395,6 +395,8 @@ interface SupplyBorrowModalProps {
   isLoadingWalletBalance?: boolean;
   /** Parent is loading borrow global data after optimistic modal open. */
   isLoadingBorrowGlobalData?: boolean;
+  /** Optional deposit-mode notice (e.g. Tinyman farm reward disqualification). */
+  depositNotice?: string;
 }
 
 const SupplyBorrowModal = ({
@@ -422,6 +424,7 @@ const SupplyBorrowModal = ({
   walletBalanceMarketToken,
   isLoadingWalletBalance = false,
   isLoadingBorrowGlobalData = false,
+  depositNotice,
 }: SupplyBorrowModalProps) => {
   const [amount, setAmount] = useState("");
   const [fiatValue, setFiatValue] = useState(0);
@@ -3620,6 +3623,14 @@ const SupplyBorrowModal = ({
                   </p>
                 </div>
               )}
+
+              {mode === "deposit" && depositNotice ? (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 mb-4">
+                  <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-100">
+                    {depositNotice}
+                  </p>
+                </div>
+              ) : null}
 
               <SupplyBorrowForm
                 key={

--- a/src/components/pools/LiquidityPoolCardContainer.tsx
+++ b/src/components/pools/LiquidityPoolCardContainer.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useState } from "react";
+import { useWallet } from "@txnlab/use-wallet-react";
+import {
+  resolveLiquidityPoolLendingMarket,
+  poolHasTinymanFarm,
+  type LiquidityPoolPairConfig,
+} from "@/constants/liquidityPools";
+import {
+  useInvalidateLiquidityPools,
+  useLiquidityPoolPosition,
+  useLiquidityPoolSnapshot,
+} from "@/hooks/useLiquidityPoolData";
+import { fetchUserDepositBalance } from "@/services/lendingService";
+import { isFeatureEnabled } from "@/config";
+import PoolPairCard from "./PoolPairCard";
+import PoolLiquidityModal, { type PoolLiquidityMode } from "./PoolLiquidityModal";
+import PoolLendingModals from "./PoolLendingModals";
+
+interface LiquidityPoolCardContainerProps {
+  pair: LiquidityPoolPairConfig;
+}
+
+const LiquidityPoolCardContainer = ({ pair }: LiquidityPoolCardContainerProps) => {
+  const { activeAccount } = useWallet();
+  const { data: snapshot, isLoading, refetch } = useLiquidityPoolSnapshot(pair);
+  const { data: position, refetch: refetchPosition } = useLiquidityPoolPosition(
+    pair,
+    activeAccount?.address
+  );
+  const invalidatePools = useInvalidateLiquidityPools([pair]);
+  const showDepositWithdraw = isFeatureEnabled("enablePoolDepositWithdraw");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<PoolLiquidityMode>("deposit");
+  const [supplyOpen, setSupplyOpen] = useState(false);
+  const [lendingWithdrawOpen, setLendingWithdrawOpen] = useState(false);
+  const [suppliedBalance, setSuppliedBalance] = useState(0);
+
+  const lendingMarket = useMemo(
+    () => resolveLiquidityPoolLendingMarket(pair.networkId, pair),
+    [pair]
+  );
+
+  const walletLpBalanceHuman = useMemo(() => {
+    if (!position?.poolTokenBalance) return 0;
+    return Number(position.poolTokenBalance) / 1e6;
+  }, [position?.poolTokenBalance]);
+
+  useEffect(() => {
+    if (!lendingMarket || !activeAccount?.address) {
+      setSuppliedBalance(0);
+      return;
+    }
+
+    let cancelled = false;
+    void fetchUserDepositBalance(
+      activeAccount.address,
+      lendingMarket.poolId,
+      lendingMarket.marketId,
+      pair.networkId
+    ).then((balance) => {
+      if (!cancelled) {
+        setSuppliedBalance(balance ?? 0);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeAccount?.address,
+    lendingMarket,
+    pair.networkId,
+    supplyOpen,
+    lendingWithdrawOpen,
+    modalOpen,
+  ]);
+
+  const openModal = (mode: PoolLiquidityMode) => {
+    setModalMode(mode);
+    setModalOpen(true);
+  };
+
+  const refreshAfterLending = () => {
+    invalidatePools();
+    void refetch();
+    void refetchPosition();
+  };
+
+  return (
+    <>
+      <PoolPairCard
+        pair={pair}
+        snapshot={snapshot}
+        position={position}
+        loading={isLoading}
+        onDeposit={() => openModal("deposit")}
+        onWithdraw={() => openModal("withdraw")}
+        showDepositWithdraw={showDepositWithdraw}
+        lendingMarket={lendingMarket}
+        onSupply={() => setSupplyOpen(true)}
+        onLendingWithdraw={() => setLendingWithdrawOpen(true)}
+        lendingSupplyDisabled={walletLpBalanceHuman <= 0}
+        lendingWithdrawDisabled={suppliedBalance <= 0}
+      />
+      {showDepositWithdraw && snapshot ? (
+        <PoolLiquidityModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          mode={modalMode}
+          pair={pair}
+          snapshot={snapshot}
+          onSuccess={() => {
+            invalidatePools();
+            void refetch();
+            void refetchPosition();
+          }}
+        />
+      ) : null}
+      {lendingMarket ? (
+        <PoolLendingModals
+          lendingMarket={lendingMarket}
+          supplyOpen={supplyOpen}
+          withdrawOpen={lendingWithdrawOpen}
+          onCloseSupply={() => setSupplyOpen(false)}
+          onCloseWithdraw={() => setLendingWithdrawOpen(false)}
+          onSuccess={refreshAfterLending}
+          initialWalletLpBalance={walletLpBalanceHuman}
+          lpAssetId={pair.lpTokenId}
+          hasFarm={poolHasTinymanFarm(pair)}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default LiquidityPoolCardContainer;

--- a/src/components/pools/PoolFarmSupplyNotice.tsx
+++ b/src/components/pools/PoolFarmSupplyNotice.tsx
@@ -1,0 +1,21 @@
+import { POOL_FARM_SUPPLY_NOTICE } from "@/constants/liquidityPools";
+import { cn } from "@/lib/utils";
+
+interface PoolFarmSupplyNoticeProps {
+  className?: string;
+}
+
+const PoolFarmSupplyNotice = ({ className }: PoolFarmSupplyNoticeProps) => (
+  <div
+    className={cn(
+      "rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2",
+      className
+    )}
+  >
+    <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-100">
+      {POOL_FARM_SUPPLY_NOTICE}
+    </p>
+  </div>
+);
+
+export default PoolFarmSupplyNotice;

--- a/src/components/pools/PoolLendingModals.tsx
+++ b/src/components/pools/PoolLendingModals.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/services/lendingService";
 import algorandService from "@/services/algorandService";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
+import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
 import { waitForConfirmation } from "algosdk";
 
 type PoolLendingModalsProps = {
@@ -52,6 +53,8 @@ type LendingMarketStats = {
   liquidationThreshold?: number;
   liquidity: number;
   liquidityUSD: number;
+  /** USD per 1 human token (oracle-adjusted). */
+  tokenPrice: number;
   apyParameters?: {
     borrowRateBps: number;
     slopeBps: number;
@@ -61,9 +64,13 @@ type LendingMarketStats = {
 
 function marketInfoToAssetData(
   marketInfo: NonNullable<Awaited<ReturnType<typeof fetchMarketInfo>>>,
-  logoPath: string
+  logoPath: string,
+  tokenDecimals: number
 ): LendingMarketStats {
-  const tokenPrice = parseFloat(marketInfo.price) || 0;
+  const usdPerToken = usdPerTokenFromMarketInfoPrice(
+    marketInfo.price,
+    tokenDecimals
+  );
   const totalSupply = parseFloat(marketInfo.totalDeposits) || 0;
   const totalBorrow = parseFloat(marketInfo.totalBorrows) || 0;
   const supplyAPY =
@@ -80,21 +87,20 @@ function marketInfoToAssetData(
       : typeof marketInfo.borrowRateCurrent === "number"
         ? marketInfo.borrowRateCurrent * 100
         : 0) ?? 0;
-  const decScale = Math.pow(10, marketInfo.decimals + 6) / Math.pow(10, 12);
-
   return {
     icon: logoPath,
     totalSupply,
-    totalSupplyUSD: totalSupply * tokenPrice * decScale,
+    totalSupplyUSD: totalSupply * usdPerToken,
     supplyAPY,
     totalBorrow,
-    totalBorrowUSD: totalBorrow * tokenPrice * decScale,
+    totalBorrowUSD: totalBorrow * usdPerToken,
     borrowAPY,
     utilization: (marketInfo.utilizationRate ?? 0) * 100,
     collateralFactor: (marketInfo.collateralFactor ?? 0) * 100,
     liquidationThreshold: (marketInfo.liquidationThreshold ?? 0) * 100,
     liquidity: Math.max(0, totalSupply - totalBorrow),
-    liquidityUSD: Math.max(0, totalSupply - totalBorrow) * tokenPrice * decScale,
+    liquidityUSD: Math.max(0, totalSupply - totalBorrow) * usdPerToken,
+    tokenPrice: usdPerToken,
     apyParameters: {
       borrowRateBps: Math.round((marketInfo.borrowRate ?? 0) * 10000),
       slopeBps: Math.round((marketInfo.slope ?? 0) * 10000),
@@ -182,7 +188,13 @@ const PoolLendingModals = ({
         networkId
       );
       if (marketInfo) {
-        setAssetData(marketInfoToAssetData(marketInfo, lendingMarket.logoPath));
+        setAssetData(
+          marketInfoToAssetData(
+            marketInfo,
+            lendingMarket.logoPath,
+            lendingMarket.decimals
+          )
+        );
       }
     } finally {
       setLoadingMarket(false);
@@ -292,15 +304,13 @@ const PoolLendingModals = ({
       collateralFactor: 0,
       liquidity: 0,
       liquidityUSD: 0,
+      tokenPrice: 0,
     }),
     [lendingMarket.logoPath]
   );
 
   const resolvedAssetData = assetData ?? emptyAssetData;
-  const tokenPrice =
-    resolvedAssetData.totalSupply > 0
-      ? resolvedAssetData.totalSupplyUSD / resolvedAssetData.totalSupply
-      : 0;
+  const tokenPrice = resolvedAssetData.tokenPrice;
 
   return (
     <>

--- a/src/components/pools/PoolLendingModals.tsx
+++ b/src/components/pools/PoolLendingModals.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useWallet } from "@txnlab/use-wallet-react";
+import SupplyBorrowModal from "@/components/SupplyBorrowModal";
+import WithdrawModal, {
+  type WithdrawModalSubmitResult,
+  type WithdrawPhasedSignPayload,
+  type WithdrawSubmitOptions,
+} from "@/components/WithdrawModal";
+import {
+  POOL_FARM_SUPPLY_NOTICE,
+  type LiquidityPoolLendingMarket,
+} from "@/constants/liquidityPools";
+import { useNetwork } from "@/contexts/NetworkContext";
+import {
+  getAlgorandNetworkFromNetworkId,
+  getTokenConfig,
+  type NetworkId,
+} from "@/config";
+import { marketRowCacheKey } from "@/hooks/useOnDemandMarketData";
+import {
+  fetchMarketInfo,
+  fetchUserDepositBalance,
+  withdraw,
+} from "@/services/lendingService";
+import algorandService from "@/services/algorandService";
+import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
+import { waitForConfirmation } from "algosdk";
+
+type PoolLendingModalsProps = {
+  lendingMarket: LiquidityPoolLendingMarket;
+  supplyOpen: boolean;
+  withdrawOpen: boolean;
+  onCloseSupply: () => void;
+  onCloseWithdraw: () => void;
+  onSuccess?: () => void;
+  /** Wallet LP balance (human units) — refreshed when supply modal opens. */
+  initialWalletLpBalance?: number;
+  lpAssetId: number;
+  hasFarm?: boolean;
+};
+
+type LendingMarketStats = {
+  icon: string;
+  totalSupply: number;
+  totalSupplyUSD: number;
+  supplyAPY: number;
+  totalBorrow: number;
+  totalBorrowUSD: number;
+  borrowAPY: number;
+  utilization: number;
+  collateralFactor: number;
+  liquidationThreshold?: number;
+  liquidity: number;
+  liquidityUSD: number;
+  apyParameters?: {
+    borrowRateBps: number;
+    slopeBps: number;
+    reserveFactorBps: number;
+  };
+};
+
+function marketInfoToAssetData(
+  marketInfo: NonNullable<Awaited<ReturnType<typeof fetchMarketInfo>>>,
+  logoPath: string
+): LendingMarketStats {
+  const tokenPrice = parseFloat(marketInfo.price) || 0;
+  const totalSupply = parseFloat(marketInfo.totalDeposits) || 0;
+  const totalBorrow = parseFloat(marketInfo.totalBorrows) || 0;
+  const supplyAPY =
+    (typeof marketInfo.apyCalculation?.apy === "number" &&
+    !Number.isNaN(marketInfo.apyCalculation.apy)
+      ? marketInfo.apyCalculation.apy
+      : typeof marketInfo.supplyRate === "number"
+        ? marketInfo.supplyRate * 100
+        : 0) ?? 0;
+  const borrowAPY =
+    (typeof marketInfo.borrowApyCalculation?.apy === "number" &&
+    !Number.isNaN(marketInfo.borrowApyCalculation.apy)
+      ? marketInfo.borrowApyCalculation.apy
+      : typeof marketInfo.borrowRateCurrent === "number"
+        ? marketInfo.borrowRateCurrent * 100
+        : 0) ?? 0;
+  const decScale = Math.pow(10, marketInfo.decimals + 6) / Math.pow(10, 12);
+
+  return {
+    icon: logoPath,
+    totalSupply,
+    totalSupplyUSD: totalSupply * tokenPrice * decScale,
+    supplyAPY,
+    totalBorrow,
+    totalBorrowUSD: totalBorrow * tokenPrice * decScale,
+    borrowAPY,
+    utilization: (marketInfo.utilizationRate ?? 0) * 100,
+    collateralFactor: (marketInfo.collateralFactor ?? 0) * 100,
+    liquidationThreshold: (marketInfo.liquidationThreshold ?? 0) * 100,
+    liquidity: Math.max(0, totalSupply - totalBorrow),
+    liquidityUSD: Math.max(0, totalSupply - totalBorrow) * tokenPrice * decScale,
+    apyParameters: {
+      borrowRateBps: Math.round((marketInfo.borrowRate ?? 0) * 10000),
+      slopeBps: Math.round((marketInfo.slope ?? 0) * 10000),
+      reserveFactorBps: Math.round((marketInfo.reserveFactor ?? 0) * 10000),
+    },
+  };
+}
+
+const PoolLendingModals = ({
+  lendingMarket,
+  supplyOpen,
+  withdrawOpen,
+  onCloseSupply,
+  onCloseWithdraw,
+  onSuccess,
+  initialWalletLpBalance = 0,
+  lpAssetId,
+  hasFarm = false,
+}: PoolLendingModalsProps) => {
+  const { currentNetwork } = useNetwork();
+  const { activeAccount } = useWallet();
+  const networkId = currentNetwork as NetworkId;
+
+  const [assetData, setAssetData] = useState<LendingMarketStats | null>(null);
+  const [walletBalance, setWalletBalance] = useState(initialWalletLpBalance);
+  const [suppliedBalance, setSuppliedBalance] = useState(0);
+  const [loadingMarket, setLoadingMarket] = useState(false);
+
+  const marketRowKey = useMemo(
+    () =>
+      marketRowCacheKey({
+        originalSymbol: lendingMarket.displaySymbol,
+        symbol: lendingMarket.displaySymbol,
+        poolId: lendingMarket.poolId,
+        underlyingContractId: lendingMarket.marketId,
+      }),
+    [lendingMarket]
+  );
+
+  const refreshBalances = useCallback(async () => {
+    if (!activeAccount?.address) {
+      setWalletBalance(0);
+      setSuppliedBalance(0);
+      return;
+    }
+
+    const algorandNetwork = getAlgorandNetworkFromNetworkId(networkId);
+    if (algorandNetwork) {
+      try {
+        const { algod } = algorandService.initializeClients(algorandNetwork);
+        const holding = await algod
+          .accountAssetInformation(activeAccount.address, lpAssetId)
+          .do();
+        const raw = getAccountAssetHoldingAmountAtomic(holding);
+        const human =
+          raw != null ? Number(raw) / 10 ** lendingMarket.decimals : 0;
+        setWalletBalance(human);
+      } catch {
+        setWalletBalance(0);
+      }
+    }
+
+    const deposited = await fetchUserDepositBalance(
+      activeAccount.address,
+      lendingMarket.poolId,
+      lendingMarket.marketId,
+      networkId
+    );
+    setSuppliedBalance(deposited ?? 0);
+  }, [
+    activeAccount?.address,
+    lendingMarket.decimals,
+    lendingMarket.marketId,
+    lendingMarket.poolId,
+    lpAssetId,
+    networkId,
+  ]);
+
+  const loadMarketData = useCallback(async () => {
+    setLoadingMarket(true);
+    try {
+      const marketInfo = await fetchMarketInfo(
+        lendingMarket.poolId,
+        lendingMarket.marketId,
+        networkId
+      );
+      if (marketInfo) {
+        setAssetData(marketInfoToAssetData(marketInfo, lendingMarket.logoPath));
+      }
+    } finally {
+      setLoadingMarket(false);
+    }
+  }, [lendingMarket, networkId]);
+
+  useEffect(() => {
+    if (!supplyOpen && !withdrawOpen) return;
+    void loadMarketData();
+    void refreshBalances();
+  }, [supplyOpen, withdrawOpen, loadMarketData, refreshBalances]);
+
+  useEffect(() => {
+    if (supplyOpen) {
+      setWalletBalance(initialWalletLpBalance);
+    }
+  }, [supplyOpen, initialWalletLpBalance]);
+
+  const tokenConfig = useMemo(() => {
+    const raw = getTokenConfig(networkId, lendingMarket.configSymbol);
+    return Array.isArray(raw) ? raw[0] : raw;
+  }, [lendingMarket.configSymbol, networkId]);
+
+  const buildWithdrawUnsigned = useCallback(
+    async (
+      amount: string,
+      options?: WithdrawSubmitOptions
+    ): Promise<WithdrawPhasedSignPayload> => {
+      if (!activeAccount?.address || !tokenConfig) {
+        throw new Error("Connect your wallet to withdraw.");
+      }
+
+      const result = await withdraw(
+        lendingMarket.poolId,
+        lendingMarket.marketId,
+        tokenConfig.tokenStandard,
+        amount,
+        activeAccount.address,
+        networkId,
+        {
+          withdrawAll: Boolean(options?.withdrawAllConfirmed),
+        }
+      );
+
+      if (!result.success || !("txns" in result) || !result.txns?.length) {
+        throw new Error(
+          "error" in result && result.error
+            ? String(result.error)
+            : "Withdraw failed"
+        );
+      }
+
+      return {
+        txnsB64: result.txns,
+        poolAppId: lendingMarket.poolId,
+        marketContractId: lendingMarket.marketId,
+        underlyingAssetId: lendingMarket.assetId,
+        networkId,
+        txSignPreviewVariant: "lending",
+        assetDisplaySymbol: lendingMarket.displaySymbol,
+        amountHuman: amount,
+      };
+    },
+    [activeAccount?.address, lendingMarket, networkId, tokenConfig]
+  );
+
+  const finalizeWithdrawSigned = useCallback(
+    async (
+      stxns: Uint8Array[],
+      built: WithdrawPhasedSignPayload
+    ): Promise<WithdrawModalSubmitResult> => {
+      const algorandNetwork = getAlgorandNetworkFromNetworkId(
+        built.networkId as NetworkId
+      );
+      if (!algorandNetwork) {
+        throw new Error(`Invalid network: ${built.networkId}`);
+      }
+      const clients =
+        await algorandService.initializeClientsForTransactions(algorandNetwork);
+      const res = await clients.algod.sendRawTransaction(stxns).do();
+      await waitForConfirmation(clients.algod, res.txid, 4);
+      onSuccess?.();
+      void refreshBalances();
+      return { txId: res.txid };
+    },
+    [onSuccess, refreshBalances]
+  );
+
+  const withdrawPhased = useMemo(
+    () => ({
+      buildUnsignedGroup: buildWithdrawUnsigned,
+      finalizeSignedGroup: finalizeWithdrawSigned,
+    }),
+    [buildWithdrawUnsigned, finalizeWithdrawSigned]
+  );
+
+  const emptyAssetData: LendingMarketStats = useMemo(
+    () => ({
+      icon: lendingMarket.logoPath,
+      totalSupply: 0,
+      totalSupplyUSD: 0,
+      supplyAPY: 0,
+      totalBorrow: 0,
+      totalBorrowUSD: 0,
+      borrowAPY: 0,
+      utilization: 0,
+      collateralFactor: 0,
+      liquidity: 0,
+      liquidityUSD: 0,
+    }),
+    [lendingMarket.logoPath]
+  );
+
+  const resolvedAssetData = assetData ?? emptyAssetData;
+  const tokenPrice =
+    resolvedAssetData.totalSupply > 0
+      ? resolvedAssetData.totalSupplyUSD / resolvedAssetData.totalSupply
+      : 0;
+
+  return (
+    <>
+      {supplyOpen ? (
+        <SupplyBorrowModal
+          isOpen={supplyOpen}
+          onClose={onCloseSupply}
+          asset={lendingMarket.displaySymbol}
+          poolId={lendingMarket.poolId}
+          configSymbol={lendingMarket.configSymbol}
+          marketId={lendingMarket.marketId}
+          marketRowKey={marketRowKey}
+          network={networkId}
+          mode="deposit"
+          assetData={resolvedAssetData}
+          walletBalance={walletBalance}
+          walletBalanceUSD={walletBalance * tokenPrice}
+          isLoadingWalletBalance={loadingMarket}
+          onRefreshWalletBalance={() => {
+            void refreshBalances();
+          }}
+          onTransactionSuccess={() => {
+            onSuccess?.();
+            void refreshBalances();
+          }}
+          depositNotice={hasFarm ? POOL_FARM_SUPPLY_NOTICE : undefined}
+        />
+      ) : null}
+
+      {withdrawOpen ? (
+        <WithdrawModal
+          isOpen={withdrawOpen}
+          onClose={onCloseWithdraw}
+          tokenSymbol={lendingMarket.displaySymbol}
+          tokenIcon={lendingMarket.logoPath}
+          tokenDecimals={lendingMarket.decimals}
+          currentlyDeposited={suppliedBalance}
+          poolId={lendingMarket.poolId}
+          network={networkId}
+          selectedMarketId={lendingMarket.marketId}
+          selectedConfigSymbol={lendingMarket.configSymbol}
+          poolHasNoBorrows
+          marketStats={{
+            supplyAPY: resolvedAssetData.supplyAPY,
+            borrowAPY: resolvedAssetData.borrowAPY,
+            utilization: resolvedAssetData.utilization,
+            collateralFactor: resolvedAssetData.collateralFactor,
+            liquidationThreshold: resolvedAssetData.liquidationThreshold,
+            tokenPrice,
+            totalDeposits: resolvedAssetData.totalSupply,
+            totalBorrows: resolvedAssetData.totalBorrow,
+            apyParameters: resolvedAssetData.apyParameters,
+          }}
+          withdrawPhased={withdrawPhased}
+          onRefreshBalance={() => {
+            void refreshBalances();
+          }}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default PoolLendingModals;

--- a/src/components/pools/PoolLiquidityModal.tsx
+++ b/src/components/pools/PoolLiquidityModal.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useWallet } from "@txnlab/use-wallet-react";
+import { useToast } from "@/hooks/use-toast";
+import { useAlgorandAssetBalance, useNt200Arc200Balance } from "@/hooks/useLiquidityPoolData";
+import { Loader2 } from "lucide-react";
+import { waitForConfirmation } from "algosdk";
+import type { LiquidityPoolPairConfig } from "@/constants/liquidityPools";
+import {
+  buildNt200LpDepositTransactions,
+  buildNt200LpWithdrawTransactions,
+  buildRemoveLiquidityTransactions,
+  encodeSignerTxnsForWallet,
+  formatLiquidityAtomic,
+  quoteRemoveLiquidity,
+  type LiquidityPoolSnapshot,
+} from "@/services/tinymanLiquidityService";
+import { getAlgorandNetworkFromNetworkId } from "@/config";
+import algorandService from "@/services/algorandService";
+import {
+  isRainbowkitXchainWallet,
+  withRainbowkitHostDialogDismissed,
+} from "@/wallet/xchainSignUi";
+
+export type PoolLiquidityMode = "deposit" | "withdraw";
+
+interface PoolLiquidityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode: PoolLiquidityMode;
+  pair: LiquidityPoolPairConfig;
+  snapshot: LiquidityPoolSnapshot | null;
+  onSuccess?: () => void;
+}
+
+const PoolLiquidityModal = ({
+  isOpen,
+  onClose,
+  mode,
+  pair,
+  snapshot,
+  onSuccess,
+}: PoolLiquidityModalProps) => {
+  const { activeAccount, signTransactions, activeWallet } = useWallet();
+  const { toast } = useToast();
+  const [tab, setTab] = useState<PoolLiquidityMode>(mode);
+  const [amount, setAmount] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [rainbowkitSignDialogSuppressed, setRainbowkitSignDialogSuppressed] =
+    useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTab(mode);
+      setAmount("");
+      setRainbowkitSignDialogSuppressed(false);
+    }
+  }, [isOpen, mode]);
+
+  const label =
+    pair.label ??
+    (snapshot
+      ? `${snapshot.asset1.symbol} / ${snapshot.asset2.symbol}`
+      : "Liquidity pool");
+
+  const lpAssetId = snapshot?.poolTokenId ?? pair.lpTokenId;
+
+  const { data: lpTokenBalance, isLoading: lpBalanceLoading } = useAlgorandAssetBalance(
+    pair.networkId,
+    activeAccount?.address,
+    lpAssetId,
+    isOpen
+  );
+
+  const { data: nt200LpBalance, isLoading: nt200BalanceLoading } =
+    useNt200Arc200Balance(
+      pair.networkId,
+      pair.lpContractId,
+      activeAccount?.address,
+      isOpen
+    );
+
+  const lpBalanceHuman = formatLiquidityAtomic(lpTokenBalance ?? 0n, 6);
+  const nt200LpBalanceHuman = formatLiquidityAtomic(nt200LpBalance ?? 0n, 6);
+  const hasLpBalance = Boolean(lpTokenBalance && lpTokenBalance > 0n);
+  const hasNt200Balance = Boolean(nt200LpBalance && nt200LpBalance > 0n);
+  const canDeposit = hasLpBalance;
+  const canWithdraw = hasNt200Balance || hasLpBalance;
+  const balancesLoading = lpBalanceLoading || nt200BalanceLoading;
+
+  const withdrawUsesNt200 = tab === "withdraw" && hasNt200Balance;
+
+  const withdrawQuote = useMemo(() => {
+    if (!snapshot || tab !== "withdraw" || withdrawUsesNt200) return null;
+    return quoteRemoveLiquidity(snapshot, amount);
+  }, [snapshot, tab, amount, withdrawUsesNt200]);
+
+  const handleMaxAmount = () => {
+    if (tab === "deposit") {
+      if (lpTokenBalance && lpTokenBalance > 0n) {
+        setAmount(lpBalanceHuman);
+      }
+      return;
+    }
+    if (nt200LpBalance && nt200LpBalance > 0n) {
+      setAmount(nt200LpBalanceHuman);
+    } else if (lpTokenBalance && lpTokenBalance > 0n) {
+      setAmount(lpBalanceHuman);
+    }
+  };
+
+  const showAmountInput =
+    tab === "deposit" ? canDeposit : canWithdraw;
+
+  const handleSubmit = useCallback(async () => {
+    if (!activeAccount?.address || !signTransactions || !snapshot) {
+      toast({
+        title: "Connect wallet",
+        description: "Connect an Algorand wallet to continue.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+    if (!algodNetwork) {
+      toast({
+        title: "Unsupported network",
+        description: "Switch to Algorand mainnet to use liquidity pools.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const walletName = activeWallet?.metadata?.name || "your wallet";
+      toast({
+        title: tab === "deposit" ? "Sign deposit" : "Sign withdrawal",
+        description: `Approve the transaction in ${walletName}.`,
+        duration: 12_000,
+      });
+
+      let signed: Uint8Array[];
+      if (tab === "deposit") {
+        const txnsB64 = await buildNt200LpDepositTransactions({
+          pair,
+          userAddress: activeAccount.address,
+          poolTokenAmountHuman: amount,
+        });
+        const unsigned = txnsB64.map((txn) =>
+          Uint8Array.from(Buffer.from(txn, "base64"))
+        );
+        signed = await withRainbowkitHostDialogDismissed({
+          wallet: activeWallet,
+          setSuppressed: setRainbowkitSignDialogSuppressed,
+          leaveOverlayDismissedOnSuccess: true,
+          run: () => signTransactions(unsigned),
+        });
+      } else if (hasNt200Balance) {
+        const txnsB64 = await buildNt200LpWithdrawTransactions({
+          pair,
+          userAddress: activeAccount.address,
+          poolTokenAmountHuman: amount,
+        });
+        const unsigned = txnsB64.map((txn) =>
+          Uint8Array.from(Buffer.from(txn, "base64"))
+        );
+        signed = await withRainbowkitHostDialogDismissed({
+          wallet: activeWallet,
+          setSuppressed: setRainbowkitSignDialogSuppressed,
+          leaveOverlayDismissedOnSuccess: true,
+          run: () => signTransactions(unsigned),
+        });
+      } else {
+        const txGroup = await buildRemoveLiquidityTransactions({
+          pair,
+          userAddress: activeAccount.address,
+          poolTokenAmountHuman: amount,
+        });
+        const unsigned = encodeSignerTxnsForWallet(txGroup);
+        signed = await withRainbowkitHostDialogDismissed({
+          wallet: activeWallet,
+          setSuppressed: setRainbowkitSignDialogSuppressed,
+          leaveOverlayDismissedOnSuccess: true,
+          run: () => signTransactions(unsigned),
+        });
+      }
+
+      const { algod } = await algorandService.initializeClientsForTransactions(
+        algodNetwork
+      );
+      const res = await algod.sendRawTransaction(signed).do();
+      await waitForConfirmation(algod, res.txid, 4);
+
+      toast({
+        title: tab === "deposit" ? "LP deposited" : "Liquidity withdrawn",
+        description: `Transaction ${res.txid.slice(0, 10)}… confirmed.`,
+      });
+      onSuccess?.();
+      onClose();
+    } catch (e: unknown) {
+      if (isRainbowkitXchainWallet(activeWallet)) {
+        setRainbowkitSignDialogSuppressed(false);
+      }
+      toast({
+        title: "Transaction failed",
+        description: e instanceof Error ? e.message : "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    tab,
+    activeAccount?.address,
+    signTransactions,
+    snapshot,
+    pair,
+    amount,
+    activeWallet,
+    hasNt200Balance,
+    toast,
+    onSuccess,
+    onClose,
+  ]);
+
+  const lpBalanceSection = (
+    <div className="rounded-lg border bg-muted/30 px-3 py-2 text-sm space-y-1.5">
+      <div>
+        <p className="text-muted-foreground">Wallet LP balance</p>
+        <p className="font-medium tabular-nums">
+          {balancesLoading ? "…" : lpBalanceHuman}
+        </p>
+      </div>
+      <div>
+        <p className="text-muted-foreground">In platform</p>
+        <p className="font-medium tabular-nums">
+          {balancesLoading ? "…" : nt200LpBalanceHuman}
+        </p>
+      </div>
+    </div>
+  );
+
+  const lpAmountInput = showAmountInput ? (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor="pool-lp-amount">LP amount</Label>
+        <button
+          type="button"
+          className="text-xs font-medium text-ocean-teal hover:underline disabled:opacity-50"
+          onClick={handleMaxAmount}
+        >
+          Max
+        </button>
+      </div>
+      <Input
+        id="pool-lp-amount"
+        type="text"
+        inputMode="decimal"
+        placeholder="0.00"
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+      />
+    </div>
+  ) : null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-w-md flex-col gap-4 p-6">
+        <DialogHeader>
+          <DialogTitle>{label}</DialogTitle>
+          <DialogDescription>
+            {tab === "deposit"
+              ? "Deposit LP tokens into the platform market for this pool."
+              : hasNt200Balance
+                ? "Withdraw LP from the platform back to your wallet."
+                : "Burn wallet LP tokens to withdraw your share of both pool assets."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!snapshot ? (
+          <p className="text-sm text-muted-foreground">Pool data is not available.</p>
+        ) : (
+          <Tabs value={tab} onValueChange={(v) => setTab(v as PoolLiquidityMode)}>
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="deposit">Deposit</TabsTrigger>
+              <TabsTrigger value="withdraw" disabled={!canWithdraw}>
+                Withdraw
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="deposit" className="space-y-4 pt-2">
+              {lpBalanceSection}
+              {lpAmountInput}
+            </TabsContent>
+
+            <TabsContent value="withdraw" className="space-y-4 pt-2">
+              {lpBalanceSection}
+              {lpAmountInput}
+              {withdrawQuote ? (
+                <div className="rounded-lg border bg-muted/30 px-3 py-2 text-sm">
+                  <p>
+                    {snapshot.asset1.symbol}:{" "}
+                    <span className="font-medium tabular-nums">
+                      {formatLiquidityAtomic(
+                        withdrawQuote.asset1Out.amount,
+                        snapshot.asset1.decimals
+                      )}
+                    </span>
+                  </p>
+                  <p>
+                    {snapshot.asset2.symbol}:{" "}
+                    <span className="font-medium tabular-nums">
+                      {formatLiquidityAtomic(
+                        withdrawQuote.asset2Out.amount,
+                        snapshot.asset2.decimals
+                      )}
+                    </span>
+                  </p>
+                </div>
+              ) : null}
+            </TabsContent>
+          </Tabs>
+        )}
+
+        <Button
+          className="w-full bg-ocean-teal hover:bg-ocean-teal/90"
+          disabled={
+            busy ||
+            !snapshot ||
+            !amount.trim() ||
+            !activeAccount?.address ||
+            (tab === "deposit" ? !canDeposit : !canWithdraw)
+          }
+          onClick={() => void handleSubmit()}
+        >
+          {busy ? (
+            <span className="flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Processing…
+            </span>
+          ) : tab === "deposit" ? (
+            "Deposit liquidity"
+          ) : (
+            "Withdraw liquidity"
+          )}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PoolLiquidityModal;

--- a/src/components/pools/PoolPairCard.tsx
+++ b/src/components/pools/PoolPairCard.tsx
@@ -1,0 +1,291 @@
+import DorkFiCard from "@/components/ui/DorkFiCard";
+import DorkFiButton from "@/components/ui/DorkFiButton";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getDexAddLiquidityUrl,
+  getDexFarmingProgramUrl,
+  LIQUIDITY_PLATFORM_LABELS,
+  poolHasTinymanFarm,
+  type LiquidityPoolLendingMarket,
+  type LiquidityPoolPairConfig,
+} from "@/constants/liquidityPools";
+import {
+  formatLiquidityAtomic,
+  resolveLiquidityAssetMeta,
+  type LiquidityPoolSnapshot,
+  type LiquidityPoolUserPosition,
+} from "@/services/tinymanLiquidityService";
+import { cn } from "@/lib/utils";
+import { Droplets, ArrowDownToLine, ArrowUpFromLine, ExternalLink } from "lucide-react";
+import { useMemo } from "react";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import PoolFarmSupplyNotice from "./PoolFarmSupplyNotice";
+
+interface PoolPairCardProps {
+  pair: LiquidityPoolPairConfig;
+  snapshot?: LiquidityPoolSnapshot | null;
+  position?: LiquidityPoolUserPosition | null;
+  loading?: boolean;
+  onDeposit: () => void;
+  onWithdraw: () => void;
+  showDepositWithdraw?: boolean;
+  lendingMarket?: LiquidityPoolLendingMarket | null;
+  onSupply?: () => void;
+  onLendingWithdraw?: () => void;
+  lendingSupplyDisabled?: boolean;
+  lendingWithdrawDisabled?: boolean;
+}
+
+function PoolAssetIcon({
+  assetId,
+  symbol,
+  logoPath,
+}: {
+  assetId: number;
+  symbol: string;
+  logoPath?: string;
+}) {
+  if (logoPath) {
+    return (
+      <img
+        src={logoPath}
+        alt={symbol}
+        className="h-8 w-8 rounded-full border border-border/50 object-contain bg-white"
+      />
+    );
+  }
+  return (
+    <div className="flex h-8 w-8 items-center justify-center rounded-full border border-border/50 bg-muted text-[10px] font-semibold">
+      {symbol.slice(0, 3)}
+    </div>
+  );
+}
+
+const PoolPairCard = ({
+  pair,
+  snapshot,
+  position,
+  loading = false,
+  onDeposit,
+  onWithdraw,
+  showDepositWithdraw = false,
+  lendingMarket,
+  onSupply,
+  onLendingWithdraw,
+  lendingSupplyDisabled = true,
+  lendingWithdrawDisabled = true,
+}: PoolPairCardProps) => {
+  const { formatPercent, formatCurrency } = useNumberI18n();
+  const asset1 = snapshot?.asset1 ?? resolveLiquidityAssetMeta(pair.networkId, pair.asset1Id);
+  const asset2 = snapshot?.asset2 ?? resolveLiquidityAssetMeta(pair.networkId, pair.asset2Id);
+  const label = pair.label ?? `${asset1.symbol} / ${asset2.symbol}`;
+  const farms = pair.farms ?? [];
+  const hasFarm = poolHasTinymanFarm(pair);
+  const hasPosition = Boolean(
+    position &&
+      (position.poolTokenBalance > 0n ||
+        position.nt200LpBalance > 0n ||
+        position.farmLpBalance > 0n)
+  );
+  const apr = snapshot?.apr;
+  const displayApr = apr?.totalAprPercent ?? apr?.feeAprPercent ?? null;
+  const platformLabel = LIQUIDITY_PLATFORM_LABELS[pair.platform];
+  const dexLink = useMemo(() => {
+    if (!pair.poolAddr) return null;
+
+    const farmId = farms[0];
+    if (farmId != null) {
+      const farmUrl = getDexFarmingProgramUrl(pair.platform, pair.poolAddr, farmId);
+      if (!farmUrl) return null;
+      return {
+        url: farmUrl,
+        label: `Farm on ${platformLabel}`,
+        isFarm: true,
+      };
+    }
+
+    const addUrl = getDexAddLiquidityUrl(pair.platform, pair.poolAddr);
+    if (!addUrl) return null;
+    return {
+      url: addUrl,
+      label: `Add on ${platformLabel}`,
+      isFarm: false,
+    };
+  }, [farms, pair.platform, pair.poolAddr, platformLabel]);
+
+  return (
+    <DorkFiCard className="flex flex-col gap-4 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex -space-x-2">
+            <PoolAssetIcon
+              assetId={asset1.assetId}
+              symbol={asset1.symbol}
+              logoPath={asset1.logoPath}
+            />
+            <PoolAssetIcon
+              assetId={asset2.assetId}
+              symbol={asset2.symbol}
+              logoPath={asset2.logoPath}
+            />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-ink-blue dark:text-white">{label}</h3>
+            <p className="text-xs text-muted-foreground">{platformLabel} liquidity pool</p>
+          </div>
+        </div>
+        <Badge variant="outline" className="shrink-0">
+          <Droplets className="mr-1 h-3 w-3" aria-hidden />
+          LP
+        </Badge>
+      </div>
+
+      {displayApr != null ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge className="border-ocean-teal/30 bg-ocean-teal/15 text-ocean-teal hover:bg-ocean-teal/20">
+                {formatPercent(displayApr / 100, { maximumFractionDigits: 2 })} APR
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs text-xs">
+              {apr?.totalAprPercent != null && apr?.feeAprPercent != null ? (
+                <>
+                  Total APR includes swap fees (
+                  {formatPercent(apr.feeAprPercent / 100, {
+                    maximumFractionDigits: 2,
+                  })}
+                  ) plus active Tinyman staking rewards. Sourced from Tinyman analytics.
+                </>
+              ) : (
+                <>Estimated APR from Tinyman analytics (fees and rewards).</>
+              )}
+            </TooltipContent>
+          </Tooltip>
+          {apr?.liquidityUsd != null ? (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {formatCurrency(apr.liquidityUsd, "USD", { maximumFractionDigits: 0 })} TVL
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="mt-1 h-[5.75rem] w-full rounded-lg" />
+        </div>
+      ) : snapshot ? (
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-xs text-muted-foreground">{asset1.symbol} in pool</p>
+            <p className="font-medium tabular-nums">{snapshot.asset1ReserveHuman}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">{asset2.symbol} in pool</p>
+            <p className="font-medium tabular-nums">{snapshot.asset2ReserveHuman}</p>
+          </div>
+          <div className="col-span-2 min-h-[5.75rem]">
+            {hasPosition && position ? (
+              <div className="rounded-lg border border-ocean-teal/20 bg-ocean-teal/5 px-3 py-2 space-y-1">
+                <p className="text-xs text-muted-foreground">Your position</p>
+                <p className="font-medium tabular-nums text-sm">
+                  {formatLiquidityAtomic(position.poolTokenBalance, 6)} LP in wallet
+                </p>
+                <p className="font-medium tabular-nums text-sm">
+                  {formatLiquidityAtomic(position.nt200LpBalance, 6)} LP in platform
+                </p>
+                {position.poolTokenBalance > 0n ? (
+                  <p className="text-xs text-muted-foreground tabular-nums">
+                    {position.poolSharePercent.toFixed(4)}% pool share (wallet LP)
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Pool data unavailable. Confirm the pair uses underlying ASA ids (not the LP
+          token id) and that the Tinyman v2 pool is bootstrapped.
+        </p>
+      )}
+
+      <div className="mt-auto flex flex-col gap-2">
+        {dexLink ? (
+          <DorkFiButton
+            variant="secondary"
+            type="button"
+            className={cn(
+              "w-full",
+              dexLink.isFarm &&
+                "border-amber-500/40 text-amber-800 hover:bg-amber-50 dark:text-amber-200 dark:hover:bg-amber-950/40"
+            )}
+            onClick={() => {
+              window.open(dexLink.url, "_blank", "noopener,noreferrer");
+            }}
+          >
+            <ExternalLink className="mr-2 h-4 w-4 shrink-0" aria-hidden />
+            {dexLink.label}
+          </DorkFiButton>
+        ) : null}
+        {lendingMarket ? (
+          <>
+            {hasFarm ? <PoolFarmSupplyNotice /> : null}
+            <div className="flex gap-2">
+            <DorkFiButton
+              variant="secondary"
+              className="flex-1"
+              disabled={!snapshot || lendingSupplyDisabled}
+              onClick={onSupply}
+            >
+              <ArrowDownToLine className="mr-2 h-4 w-4" aria-hidden />
+              Supply
+            </DorkFiButton>
+            <DorkFiButton
+              variant="borrow-outline"
+              className="flex-1"
+              disabled={!snapshot || lendingWithdrawDisabled}
+              onClick={onLendingWithdraw}
+            >
+              <ArrowUpFromLine className="mr-2 h-4 w-4" aria-hidden />
+              Withdraw
+            </DorkFiButton>
+          </div>
+          </>
+        ) : null}
+        {showDepositWithdraw ? (
+        <div className="flex gap-2">
+        <DorkFiButton
+          variant="secondary"
+          className="flex-1"
+          disabled={!snapshot}
+          onClick={onDeposit}
+        >
+          <ArrowDownToLine className="mr-2 h-4 w-4" aria-hidden />
+          Deposit
+        </DorkFiButton>
+        <DorkFiButton
+          variant="borrow-outline"
+          className="flex-1"
+          disabled={!snapshot || !hasPosition}
+          onClick={onWithdraw}
+        >
+          <ArrowUpFromLine className="mr-2 h-4 w-4" aria-hidden />
+          Withdraw
+        </DorkFiButton>
+        </div>
+        ) : null}
+      </div>
+    </DorkFiCard>
+  );
+};
+
+export default PoolPairCard;

--- a/src/components/pools/PoolsTokenFilter.tsx
+++ b/src/components/pools/PoolsTokenFilter.tsx
@@ -1,0 +1,83 @@
+import { cn } from "@/lib/utils";
+import {
+  POOL_BASE_TOKEN_FILTERS,
+  type PoolBaseTokenFilterId,
+} from "@/constants/liquidityPools";
+import { getTokenImagePath } from "@/utils/tokenImageUtils";
+
+interface PoolsTokenFilterProps {
+  value: PoolBaseTokenFilterId;
+  onChange: (value: PoolBaseTokenFilterId) => void;
+  counts?: Partial<Record<PoolBaseTokenFilterId, number>>;
+  className?: string;
+}
+
+function FilterChip({
+  active,
+  onClick,
+  label,
+  iconSrc,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  iconSrc?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "border-ocean-teal/50 bg-ocean-teal/15 text-ocean-teal"
+          : "border-border bg-background/80 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      )}
+    >
+      {iconSrc ? (
+        <img
+          src={iconSrc}
+          alt=""
+          className="h-5 w-5 rounded-full border border-border/50 object-contain bg-white"
+        />
+      ) : null}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+const PoolsTokenFilter = ({
+  value,
+  onChange,
+  counts,
+  className,
+}: PoolsTokenFilterProps) => {
+  const allCount = counts?.all;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      <FilterChip
+        active={value === "all"}
+        onClick={() => onChange("all")}
+        label={allCount != null ? `All (${allCount})` : "All"}
+      />
+      {POOL_BASE_TOKEN_FILTERS.map((filter) => {
+        const count = counts?.[filter.id];
+        return (
+          <FilterChip
+            key={filter.id}
+            active={value === filter.id}
+            onClick={() => onChange(filter.id)}
+            label={count != null ? `${filter.symbol} (${count})` : filter.symbol}
+            iconSrc={getTokenImagePath(filter.symbol)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default PoolsTokenFilter;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1033,6 +1033,10 @@ export interface GlobalConfig {
     enableAgentClaim: boolean;
     /** Dev/staging: skip NFT holder eligibility checks before pay-agent (never enable in production). */
     bypassAgentClaimEligibility: boolean;
+    /** Tinyman v2 liquidity pools — curated pairs page (browse / APR). */
+    enablePools: boolean;
+    /** In-app Deposit / Withdraw LP actions on pool cards (off until Tinyman LP flows are production-ready). Supply / Withdraw lending stays enabled. */
+    enablePoolDepositWithdraw: boolean;
   };
 }
 
@@ -2102,6 +2106,7 @@ const algorandMainnetPrefiConfig: NetworkConfig = {
 };
 const algorandProdAMarket = "3333688282";
 const algorandProdBMarket = "3345940978";
+const algorandProdCMarket = "3578814346";
 const algorandProdDMarket = "3526240577";
 const algorandProdPriceOracle = "3333688500";
 const algorandProdLiquidationEngine = undefined;
@@ -2118,10 +2123,11 @@ const algorandProdMarketController = "3333688332";
 const algorandProdSToken = "3333688448";
 const algorandProdBeacon = "3209233839";
 const algorandProdAppStorageId = "3333688254";
-// A, B, D markets (C market slot not used on prod)
+// A, B, C, D lending pools on prod
 const algorandProdLendingPools = [
   algorandProdAMarket,
   algorandProdBMarket,
+  algorandProdCMarket,
   algorandProdDMarket,
 ];
 const algorandProdContracts: ContractConfig = {
@@ -3014,6 +3020,57 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
       dataAddedAt: "2026-04-19T00:00:00.000Z",
     },
   ],
+  // TMPOOL2 3157974960 6 3577729953
+  // name: "TinymanPool2.0 UNIT-ALGO",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3577729953
+  LP_TMPOOL2_UNIT_ALGO: {
+    assetId: "3157974960",
+    contractId: "3577729953",
+    poolId: "3578814346",
+    nTokenId: "3579176126",
+    decimals: 6,
+    name: "TinymanPool2.0 UNIT-ALGO",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_UNIT_ALGO.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-05-29T00:00:00.000Z",
+  },
+  // TMPOOL2 3159132330 6 3577777819
+  // name: "TinymanPool2.0 UNIT-goBTC",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3577777819
+  LP_TMPOOL2_UNIT_GOBTC: {
+    assetId: "3159132330",
+    contractId: "3577777819",
+    poolId: "3578814346",
+    nTokenId: "3579373167",
+    decimals: 6,
+    name: "TinymanPool2.0 UNIT-goBTC",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_UNIT_GOBTC.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-05-29T00:00:00.000Z",
+  },
+  // TMPOOL2 3334546641 6 3577783311
+  // name: "TinymanPool2.0 WAD-UNIT",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3577783311
+  LP_TMPOOL2_WAD_UNIT: {
+    assetId: "3334546641",
+    contractId: "3577783311",
+    poolId: "3578814346",
+    nTokenId: "3579418200",
+    decimals: 6,
+    name: "TinymanPool2.0 WAD-UNIT",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_UNIT.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-05-29T00:00:00.000Z",
+  },
 };
 const algorandMainnetProdConfig: NetworkConfig = {
   networkId: "algorand-mainnet",
@@ -3294,6 +3351,8 @@ export const config: GlobalConfig = {
     enableLiquidatablePositions: true, // Enable liquidatable positions section in portfolio
     enableAgentClaim: true, // NFT holder reward claim — Base x402 pay-agent section
     bypassAgentClaimEligibility: false,
+    enablePools: true,
+    enablePoolDepositWithdraw: false,
   },
 };
 
@@ -3308,7 +3367,8 @@ export const marketLabelMap: Record<string, string> = {
   // Algorand Mainnet (prod pools in this file)
   "algorand-mainnet-3333688282": "A",
   "algorand-mainnet-3345940978": "B",
-  /** Third prod lending pool (array order is A, B, D — no “C” market id). */
+  "algorand-mainnet-3578814346": "C",
+  /** Third prod lending pool (array order is A, B, C, D). */
   "algorand-mainnet-3526240577": "D",
 };
 
@@ -3452,13 +3512,15 @@ export const getMarketLabel = (
     return marketLabelMap[key];
   }
 
-  // Fallback: try to get from network config
+  // Fallback: derive label from lending pool order (A = index 0, B = 1, …)
   try {
     const networkConfig = getNetworkConfig(normalizedNetworkId as NetworkId);
     const lendingPools = networkConfig?.contracts?.lendingPools || [];
-    if (lendingPools.length >= 2) {
-      if (String(poolId) === String(lendingPools[0])) return "A";
-      if (String(poolId) === String(lendingPools[1])) return "B";
+    const poolIndex = lendingPools.findIndex(
+      (pool) => String(pool) === normalizedPoolId
+    );
+    if (poolIndex >= 0) {
+      return String.fromCharCode(65 + poolIndex);
     }
   } catch (e) {
     // Network not found in config, return null
@@ -3466,6 +3528,37 @@ export const getMarketLabel = (
 
   return null;
 };
+
+/** Market letter for a lending pool id (A, B, C, …), with index fallback. */
+export const getLendingPoolLabel = (
+  networkId: NetworkId | string | null | undefined,
+  poolId: string | null | undefined
+): string => {
+  const label = getMarketLabel(networkId, poolId);
+  return label ?? "?";
+};
+
+/**
+ * Lending pools omitted from the Markets table (still in config for Pools, Portfolio, Admin).
+ * Algorand prod C pool holds Tinyman LP nt200 markets — surfaced on the Pools page instead.
+ */
+const MARKETS_TABLE_EXCLUDED_POOL_IDS: Partial<
+  Record<NetworkId, readonly string[]>
+> = {
+  "algorand-mainnet": [algorandProdCMarket],
+};
+
+/** True when a pool's markets should not appear on the Markets table. */
+export function isMarketsTableExcludedPool(
+  networkId: NetworkId | string | null | undefined,
+  poolId: string | number | null | undefined
+): boolean {
+  if (!networkId || poolId == null || String(poolId) === "") return false;
+  const excluded = MARKETS_TABLE_EXCLUDED_POOL_IDS[networkId as NetworkId];
+  if (!excluded?.length) return false;
+  const pid = String(poolId);
+  return excluded.some((id) => String(id) === pid);
+}
 
 /**
  * Pool id when the row object has not yet populated `marketInfo` / `poolId` (same rules as markets table `getPoolIdForSorting`).
@@ -4464,6 +4557,18 @@ export const getEnvironmentConfig = (): Partial<GlobalConfig> => {
     envFeatures.bypassAgentClaimEligibility =
       import.meta.env.VITE_BYPASS_AGENT_CLAIM_ELIGIBILITY === "true" ||
       import.meta.env.VITE_BYPASS_AGENT_CLAIM_ELIGIBILITY === "1";
+  }
+
+  if (typeof import.meta.env.VITE_ENABLE_POOLS !== "undefined") {
+    envFeatures.enablePools =
+      import.meta.env.VITE_ENABLE_POOLS === "true" ||
+      import.meta.env.VITE_ENABLE_POOLS === "1";
+  }
+
+  if (typeof import.meta.env.VITE_ENABLE_POOL_DEPOSIT_WITHDRAW !== "undefined") {
+    envFeatures.enablePoolDepositWithdraw =
+      import.meta.env.VITE_ENABLE_POOL_DEPOSIT_WITHDRAW === "true" ||
+      import.meta.env.VITE_ENABLE_POOL_DEPOSIT_WITHDRAW === "1";
   }
 
   if (env === "development") {

--- a/src/constants/liquidityPools.ts
+++ b/src/constants/liquidityPools.ts
@@ -1,0 +1,297 @@
+import {
+  getNetworkConfig,
+  getTokenDisplayInfo,
+  type NetworkId,
+  type TokenConfig,
+} from "@/config";
+
+/** Supported liquidity DEX integrations on the Pools page. */
+export type LiquidityPlatformId = "tinyman";
+
+export const LIQUIDITY_PLATFORM_LABELS: Record<LiquidityPlatformId, string> = {
+  tinyman: "Tinyman",
+};
+
+/** Curated liquidity pair on a supported AVM network + DEX platform. */
+export interface LiquidityPoolPairConfig {
+  id: string;
+  platform: LiquidityPlatformId;
+  networkId: NetworkId;
+  asset1Id: number;
+  asset2Id: number;
+  /** Optional display label (defaults to `SYM1 / SYM2`). */
+  label?: string;
+  /** When the pool ASA id differs from lending token config (e.g. Tinyman UNIT). */
+  asset2Symbol?: string;
+  asset2Decimals?: number;
+  asset2LogoPath?: string;
+  /** Tinyman LP token ASA id for this pool (TMPOOL2). */
+  lpTokenId: number;
+  /** nt200 market application id for the LP token (ASA deposit target). */
+  lpContractId: number;
+  /** DEX pool account address (add liquidity / farm deep links). */
+  poolAddr?: string;
+  /** LP farm program ids on the platform — uses {@link poolAddr}. */
+  farms?: number[];
+}
+
+/** True when the curated pair has at least one Tinyman farm program configured. */
+export function poolHasTinymanFarm(
+  pair: Pick<LiquidityPoolPairConfig, "farms">
+): boolean {
+  return (pair.farms?.length ?? 0) > 0;
+}
+
+/** Shown on pool cards and supply modal when {@link poolHasTinymanFarm} is true. */
+export const POOL_FARM_SUPPLY_NOTICE =
+  "If pool has an active Tinyman farm. Supplying LP to the platform may disqualify your LP from farm rewards.";
+
+/** Base-token filters for the Pools page (UNIT / WAD curated pairs). */
+export const POOL_BASE_TOKEN_FILTERS = [
+  { id: "unit", symbol: "UNIT", assetId: 3121954282 },
+  { id: "wad", symbol: "WAD", assetId: 3334160924 },
+] as const;
+
+export type PoolBaseTokenFilterId =
+  | (typeof POOL_BASE_TOKEN_FILTERS)[number]["id"]
+  | "all";
+
+export function getPoolBaseTokenFilterAssetId(
+  filterId: PoolBaseTokenFilterId
+): number | null {
+  if (filterId === "all") return null;
+  return (
+    POOL_BASE_TOKEN_FILTERS.find((filter) => filter.id === filterId)?.assetId ??
+    null
+  );
+}
+
+export function poolMatchesBaseTokenFilter(
+  pair: LiquidityPoolPairConfig,
+  filterAssetId: number | null
+): boolean {
+  if (filterAssetId == null) return true;
+  return pair.asset1Id === filterAssetId || pair.asset2Id === filterAssetId;
+}
+
+export function countPoolsByBaseTokenFilter(
+  pairs: LiquidityPoolPairConfig[]
+): Record<PoolBaseTokenFilterId, number> {
+  const counts: Record<PoolBaseTokenFilterId, number> = {
+    all: pairs.length,
+    unit: 0,
+    wad: 0,
+  };
+
+  for (const filter of POOL_BASE_TOKEN_FILTERS) {
+    counts[filter.id] = pairs.filter((pair) =>
+      poolMatchesBaseTokenFilter(pair, filter.assetId)
+    ).length;
+  }
+
+  return counts;
+}
+
+export const TINYMAN_APP_POOL_BASE = "https://app.tinyman.org/pool";
+
+export function getTinymanPoolUrl(poolAddr: string): string {
+  return `${TINYMAN_APP_POOL_BASE}/${poolAddr}`;
+}
+
+/** Tinyman pool page with add-liquidity tab active. */
+export function getTinymanAddLiquidityUrl(poolAddr: string): string {
+  return `${TINYMAN_APP_POOL_BASE}/${poolAddr}/add-liquidity`;
+}
+
+export function getTinymanFarmingProgramUrl(
+  poolAddr: string,
+  farmId: number
+): string {
+  return `${TINYMAN_APP_POOL_BASE}/${poolAddr}/farming-programs/${farmId}`;
+}
+
+export function getDexAddLiquidityUrl(
+  platform: LiquidityPlatformId,
+  poolAddr: string
+): string | null {
+  switch (platform) {
+    case "tinyman":
+      return getTinymanAddLiquidityUrl(poolAddr);
+    default:
+      return null;
+  }
+}
+
+export function getDexFarmingProgramUrl(
+  platform: LiquidityPlatformId,
+  poolAddr: string,
+  farmId: number
+): string | null {
+  switch (platform) {
+    case "tinyman":
+      return getTinymanFarmingProgramUrl(poolAddr, farmId);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Select liquidity pairs exposed on the Pools page.
+ * Use underlying ASA ids for asset1Id/asset2Id (ALGO = 0); lpTokenId / lpContractId are Tinyman LP metadata.
+ */
+export const CURATED_LIQUIDITY_POOLS: LiquidityPoolPairConfig[] = [
+  // TMPOOL2 3157974960 6 3577729953
+  {
+    id: "unit-algo",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3157974960,
+    lpContractId: 3577729953,
+    asset1Id: 3121954282,
+    asset2Id: 0,
+    label: "UNIT / ALGO",
+    poolAddr:
+      "5T5VBTBOPW2ZRJX6QJYCBMZ24VAW7IWFGV7GHCBKFNKIN2XYHP5OLOSQJQ",
+    farms: [252],
+  },
+  // TMPOOL2 3159132330 6 3577777819
+  {
+    id: "unit-gobtc",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3159132330,
+    lpContractId: 3577777819,
+    asset1Id: 3121954282,
+    asset2Id: 386192725,
+    label: "UNIT / goBTC",
+    poolAddr:
+      "YQJ7QB4AWGA6XDHABFI5JXSDQUMM4JVG7EG4FXT4WQXUKVA44BGSSN2BZA",
+    farms: [],
+  },
+  // TMPOOL2 3334546641 6 3577783311
+  {
+    id: "wad-unit",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3334546641,
+    lpContractId: 3577783311,
+    asset1Id: 3334160924,
+    asset2Id: 3121954282,
+    label: "WAD / UNIT",
+    poolAddr:
+      "77FCRUX5B4AKC3SQ4KB6SP6SIXUQFU3QYYTZSJWMOSDJO3AO4E6P4Z6EXE",
+    farms: [],
+  },
+  // TMPOOL2 3334448440 6 3577799583
+  {
+    id: "wad-usdc",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3334448440,
+    lpContractId: 3577799583,
+    asset1Id: 3334160924,
+    asset2Id: 31566704,
+    label: "WAD / USDC",
+    poolAddr:
+      "NDQE23CVD5R2ZE3VKAZK6JEJUGYGM7A2VARYEOOWXOVA4GYAOV74PS7ALI",
+    farms: [],
+  },
+  // TMPOOL2 3355755995 6 3578387558
+  {
+    id: "wad-gobtc",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3355755995,
+    lpContractId: 3578387558,
+    asset1Id: 3334160924,
+    asset2Id: 386192725,
+    label: "WAD / goBTC",
+    poolAddr:
+      "T7ZSLWI462QQCDAERZ4TEBL3U3WSA2R4WBVL62LQ33WV2XVYT2YEWN75Q4",
+    farms: [],
+  },
+  // TMPOOL2 3495913115 6 3578394082
+  {
+    id: "wad-goeth",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3495913115,
+    lpContractId: 3578394082,
+    asset1Id: 3334160924,
+    asset2Id: 386195940,
+    label: "WAD / goETH",
+    poolAddr:
+      "Q5HKO22ZGLV7R6WHYOCKRD5SZFLXNMI2HX6DCZ4YAAOSNPV2HLMVOYB7CA",
+    farms: [],
+  },
+  // TMPOOL2 3346320836 6 3578405588
+  {
+    id: "wad-algo",
+    platform: "tinyman",
+    networkId: "algorand-mainnet",
+    lpTokenId: 3346320836,
+    lpContractId: 3578405588,
+    asset1Id: 3334160924,
+    asset2Id: 0,
+    label: "WAD / ALGO",
+    poolAddr:
+      "T4VXZUUONE2DS7G5QXGVBDR27G32MCM25KEQLBITC4ENOK6N7CMM5VLRSM",
+    farms: [],
+  },
+];
+
+export function getCuratedLiquidityPoolsForNetwork(
+  networkId: NetworkId
+): LiquidityPoolPairConfig[] {
+  return CURATED_LIQUIDITY_POOLS.filter((p) => p.networkId === networkId);
+}
+
+/** Lending market row in config (`LP_*`) matching a curated Tinyman pool. */
+export interface LiquidityPoolLendingMarket {
+  configSymbol: string;
+  poolId: string;
+  marketId: string;
+  displaySymbol: string;
+  displayName: string;
+  logoPath: string;
+  decimals: number;
+  assetId: string;
+}
+
+/**
+ * Resolve a platform lending market for this pool when `network.tokens` contains
+ * an `LP_*` entry whose ASA + nt200 contract match the pair's LP metadata.
+ */
+export function resolveLiquidityPoolLendingMarket(
+  networkId: NetworkId,
+  pair: LiquidityPoolPairConfig
+): LiquidityPoolLendingMarket | null {
+  const tokens = getNetworkConfig(networkId).tokens;
+  if (!tokens) return null;
+
+  for (const [key, tokenConfig] of Object.entries(tokens)) {
+    if (!key.startsWith("LP_")) continue;
+    const tc: TokenConfig = Array.isArray(tokenConfig)
+      ? tokenConfig[0]
+      : tokenConfig;
+    if (!tc?.assetId || !tc.contractId) continue;
+    if (
+      String(tc.assetId) !== String(pair.lpTokenId) ||
+      String(tc.contractId) !== String(pair.lpContractId)
+    ) {
+      continue;
+    }
+    const display = getTokenDisplayInfo(networkId, key);
+    return {
+      configSymbol: key,
+      poolId: String(tc.poolId ?? ""),
+      marketId: String(tc.contractId),
+      displaySymbol: display?.symbol ?? tc.symbol,
+      displayName: display?.name ?? tc.name,
+      logoPath: tc.logoPath,
+      decimals: tc.decimals ?? 6,
+      assetId: String(tc.assetId),
+    };
+  }
+  return null;
+}

--- a/src/hooks/useLiquidityPoolData.ts
+++ b/src/hooks/useLiquidityPoolData.ts
@@ -1,0 +1,112 @@
+import { useQuery, useQueries, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { LiquidityPoolPairConfig } from "@/constants/liquidityPools";
+import {
+  fetchLiquidityPoolSnapshot,
+  fetchLiquidityPoolUserPosition,
+  fetchAlgorandAssetBalance,
+  fetchNt200Arc200Balance,
+  type LiquidityPoolApr,
+} from "@/services/tinymanLiquidityService";
+
+export function getLiquidityPoolDisplayAprPercent(
+  apr: LiquidityPoolApr | null | undefined
+): number | null {
+  if (!apr) return null;
+  return apr.totalAprPercent ?? apr.feeAprPercent ?? null;
+}
+
+export function useLiquidityPoolsOrderedByApr(
+  pairs: LiquidityPoolPairConfig[]
+) {
+  const snapshots = useQueries({
+    queries: pairs.map((pair) => ({
+      queryKey: ["liquidity-pool-snapshot", pair.id, pair.networkId],
+      queryFn: () => fetchLiquidityPoolSnapshot(pair),
+      staleTime: 30_000,
+    })),
+  });
+
+  return useMemo(() => {
+    return pairs
+      .map((pair, index) => ({
+        pair,
+        apr: getLiquidityPoolDisplayAprPercent(snapshots[index]?.data?.apr),
+      }))
+      .sort((a, b) => {
+        if (a.apr == null && b.apr == null) return 0;
+        if (a.apr == null) return 1;
+        if (b.apr == null) return -1;
+        return b.apr - a.apr;
+      })
+      .map(({ pair }) => pair);
+  }, [pairs, snapshots]);
+}
+
+export function useLiquidityPoolSnapshot(pair: LiquidityPoolPairConfig) {
+  return useQuery({
+    queryKey: ["liquidity-pool-snapshot", pair.id, pair.networkId],
+    queryFn: () => fetchLiquidityPoolSnapshot(pair),
+    staleTime: 30_000,
+  });
+}
+
+export function useLiquidityPoolPosition(
+  pair: LiquidityPoolPairConfig,
+  userAddress: string | undefined
+) {
+  return useQuery({
+    queryKey: ["liquidity-pool-position", pair.id, userAddress],
+    queryFn: () => fetchLiquidityPoolUserPosition(pair, userAddress!),
+    enabled: Boolean(userAddress),
+    staleTime: 20_000,
+  });
+}
+
+export function useAlgorandAssetBalance(
+  networkId: LiquidityPoolPairConfig["networkId"],
+  userAddress: string | undefined,
+  assetId: number,
+  enabled = true
+) {
+  return useQuery({
+    queryKey: ["algorand-asset-balance", networkId, userAddress, assetId],
+    queryFn: () => fetchAlgorandAssetBalance(networkId, userAddress!, assetId),
+    enabled: Boolean(userAddress) && enabled,
+    staleTime: 20_000,
+  });
+}
+
+export function useNt200Arc200Balance(
+  networkId: LiquidityPoolPairConfig["networkId"],
+  contractId: number,
+  userAddress: string | undefined,
+  enabled = true
+) {
+  return useQuery({
+    queryKey: ["nt200-arc200-balance", networkId, contractId, userAddress],
+    queryFn: () => fetchNt200Arc200Balance(networkId, contractId, userAddress!),
+    enabled: Boolean(userAddress) && enabled,
+    staleTime: 20_000,
+  });
+}
+
+export function useInvalidateLiquidityPools(pairs: LiquidityPoolPairConfig[]) {
+  const queryClient = useQueryClient();
+  return () => {
+    pairs.forEach((pair) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["liquidity-pool-snapshot", pair.id, pair.networkId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["liquidity-pool-position", pair.id],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["algorand-asset-balance", pair.networkId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["nt200-arc200-balance", pair.networkId, pair.lpContractId],
+      });
+    });
+  };
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import { useNetwork } from "@/contexts/NetworkContext";
 import {
   getAllTokensWithDisplayInfo,
+  isMarketsTableExcludedPool,
   NetworkId,
   getNetworkConfig,
   getLendingPools,
@@ -354,9 +355,13 @@ export const useOnDemandMarketData = ({
     ]
   );
 
-  // Get token configuration for current network
+  // Get token configuration for current network (omit pools excluded from Markets table)
   const tokens = useMemo(
-    () => getAllTokensWithDisplayInfo(currentNetwork),
+    () =>
+      getAllTokensWithDisplayInfo(currentNetwork).filter(
+        (token) =>
+          !isMarketsTableExcludedPool(currentNetwork, token.poolId)
+      ),
     [currentNetwork]
   );
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -93,6 +93,7 @@ import {
   isCurrentNetworkEVM,
   NetworkId,
   getLendingPools,
+  getLendingPoolLabel,
   getAllTokensWithDisplayInfo,
   getPreFiParameters,
   getAlgorandConfigForReads,
@@ -365,8 +366,8 @@ export default function AdminDashboard() {
   // Generate pool options with class labels
   const getPoolOptions = () => {
     const lendingPools = getLendingPools(currentNetwork);
-    return lendingPools.map((poolId, index) => {
-      const classLabel = String.fromCharCode(65 + index); // A, B, C, etc.
+    return lendingPools.map((poolId) => {
+      const classLabel = getLendingPoolLabel(currentNetwork, poolId);
       return {
         value: poolId,
         label: `${classLabel} Market (${poolId})`,
@@ -1273,7 +1274,7 @@ export default function AdminDashboard() {
     setIsLoadingCurrentUserRoles(true);
     try {
       const roleChecks = await checkAllRoles(activeAccount.address);
-      setCurrentUserRoles(roleChecks);
+      setCurrentUserRoles(roleChecks ?? []);
     } catch (error) {
       console.error("Error checking current user roles:", error);
       setCurrentUserRoles([]);
@@ -1295,9 +1296,16 @@ export default function AdminDashboard() {
       const clients = algorandService.initializeClients(
         networkConfig.walletNetworkId as AlgorandNetwork
       );
-      // get lending pool id from selected pool or fallback to first pool
-      const lendingPoolId =
-        selectedLendingPool || networkConfig.contracts.lendingPools[0];
+      // get lending pool id from selected pool
+      if (!selectedLendingPool) {
+        toast.error("Select a lending pool first", {
+          description:
+            "Choose the target pool (e.g. C Market) in the Roles tab before revoking roles.",
+        });
+        return;
+      }
+      const lendingPoolId = selectedLendingPool;
+      const poolLabel = getLendingPoolLabel(currentNetwork, lendingPoolId);
       // get lending pool contract
       const ci = new CONTRACT(
         Number(lendingPoolId),
@@ -1337,8 +1345,8 @@ export default function AdminDashboard() {
       const res = await clients.algod.sendRawTransaction(stxns).do();
       await waitForConfirmation(clients.algod, res.txid, 4);
       toast.success("Role revoked successfully", {
-        description: `Successfully revoked ${roles.find((r) => r.id === roleId)?.name || "selected role"
-          } role from ${address}.`,
+        description: `Revoked ${roles.find((r) => r.id === roleId)?.name || "selected role"
+          } on Pool ${poolLabel} (${lendingPoolId}) from ${address}.`,
       });
 
       // Refresh current user roles if the revoked role was for the current user
@@ -1358,7 +1366,18 @@ export default function AdminDashboard() {
   const checkAllRoles = async (address: string) => {
     if (!address.trim()) {
       toast.error("Please provide an address to check roles");
-      return;
+      return [];
+    }
+    if (!activeAccount?.address) {
+      toast.error("Connect your wallet to check roles on-chain");
+      return [];
+    }
+    if (!selectedLendingPool) {
+      toast.error("Select a lending pool first", {
+        description:
+          "Choose the target pool (e.g. C Market) in the Roles tab before checking roles.",
+      });
+      return [];
     }
 
     setIsCheckingRoles(true);
@@ -1368,16 +1387,15 @@ export default function AdminDashboard() {
       const clients = algorandService.initializeClients(
         networkConfig.walletNetworkId as AlgorandNetwork
       );
-      // get lending pool id from selected pool or fallback to first pool
-      const lendingPoolId =
-        selectedLendingPool || networkConfig.contracts.lendingPools[0];
-      // get lending pool contract
+      const lendingPoolId = selectedLendingPool;
+      const poolLabel = getLendingPoolLabel(currentNetwork, lendingPoolId);
+      // get lending pool contract — caller must be connected wallet (not target address)
       const ci = new CONTRACT(
         Number(lendingPoolId),
         clients.algod,
         undefined,
         { ...LendingPoolAppSpec.contract, events: [] },
-        { addr: address, sk: new Uint8Array() }
+        { addr: activeAccount.address, sk: new Uint8Array() }
       );
       ci.setEnableRawBytes(true);
 
@@ -1428,11 +1446,11 @@ export default function AdminDashboard() {
 
       if (hasAnyRole) {
         toast.success("Role Check Complete", {
-          description: `${address} has the following roles: ${roleSummary}`,
+          description: `Pool ${poolLabel}: ${address} has ${roleSummary}`,
         });
       } else {
         toast.info("Role Check Complete", {
-          description: `${address} does not have any of the predefined roles.`,
+          description: `Pool ${poolLabel}: ${address} does not have any predefined roles.`,
         });
       }
 
@@ -1706,7 +1724,7 @@ export default function AdminDashboard() {
 
   // Check if current user has price feed manager role
   const hasPriceFeedManagerRole = () => {
-    return currentUserRoles.some(
+    return (currentUserRoles ?? []).some(
       (role) => role.roleId === "price-feed-manager" && role.hasRole
     );
   };
@@ -2740,11 +2758,6 @@ export default function AdminDashboard() {
   // Load Envoi name when component mounts or account changes
   React.useEffect(() => {
     loadCurrentUserEnvoiName();
-  }, [activeAccount?.address]);
-
-  // Check current user's roles when component mounts or account changes
-  React.useEffect(() => {
-    checkCurrentUserRoles();
   }, [activeAccount?.address]);
 
   // Debounced search for revoke modal Envoi names
@@ -6870,6 +6883,15 @@ export default function AdminDashboard() {
       setSelectedLendingPool(lendingPools[0]);
     }
   }, [currentNetwork, selectedLendingPool]);
+
+  // Check current user's roles when wallet or selected pool changes
+  React.useEffect(() => {
+    if (!activeAccount?.address || !selectedLendingPool) {
+      setCurrentUserRoles([]);
+      return;
+    }
+    void checkCurrentUserRoles();
+  }, [activeAccount?.address, selectedLendingPool]);
 
   // Load paused states for all pools when network changes
   React.useEffect(() => {
@@ -11437,18 +11459,17 @@ export default function AdminDashboard() {
                           <SelectValue placeholder="Select a lending pool" />
                         </SelectTrigger>
                         <SelectContent>
-                          {getLendingPools(currentNetwork).map(
-                            (poolId, index) => {
-                              const classLabel = String.fromCharCode(
-                                65 + index
-                              ); // A, B, C, etc.
-                              return (
-                                <SelectItem key={poolId} value={poolId}>
-                                  Pool {classLabel} ({poolId})
-                                </SelectItem>
-                              );
-                            }
-                          )}
+                          {getLendingPools(currentNetwork).map((poolId) => {
+                            const classLabel = getLendingPoolLabel(
+                              currentNetwork,
+                              poolId
+                            );
+                            return (
+                              <SelectItem key={poolId} value={poolId}>
+                                Pool {classLabel} ({poolId})
+                              </SelectItem>
+                            );
+                          })}
                         </SelectContent>
                       </Select>
                     </div>
@@ -11458,13 +11479,13 @@ export default function AdminDashboard() {
                       <p className="text-sm text-blue-800 dark:text-blue-200">
                         <strong>Active Pool:</strong> All role operations (assign,
                         revoke, check) will be performed on Pool{" "}
-                        {String.fromCharCode(
-                          65 +
-                          getLendingPools(currentNetwork).indexOf(
-                            selectedLendingPool
-                          )
-                        )}{" "}
+                        {getLendingPoolLabel(currentNetwork, selectedLendingPool)}{" "}
                         ({selectedLendingPool})
+                      </p>
+                      <p className="text-xs text-blue-700/80 dark:text-blue-300/80 mt-1">
+                        Roles are per lending pool contract. Your wallet must
+                        already hold Market Controller (or deployer admin) on
+                        this pool to assign roles here.
                       </p>
                     </div>
                   )}
@@ -11609,13 +11630,13 @@ export default function AdminDashboard() {
                           Checking roles...
                         </span>
                       </div>
-                    ) : currentUserRoles.length > 0 ? (
+                    ) : (currentUserRoles ?? []).length > 0 ? (
                       <div className="space-y-3">
                         <h4 className="font-medium text-sm">
                           Smart Contract Roles:
                         </h4>
                         <div className="grid gap-2">
-                          {currentUserRoles
+                          {(currentUserRoles ?? [])
                             .filter((role) => role.hasRole)
                             .map((role) => (
                               <div
@@ -11653,15 +11674,15 @@ export default function AdminDashboard() {
                     )}
 
                     {/* Role Summary */}
-                    {currentUserRoles.length > 0 && (
+                    {(currentUserRoles ?? []).length > 0 && (
                       <div className="mt-4 p-3 bg-muted/30 rounded-lg">
                         <p className="text-sm text-muted-foreground">
                           <strong>Role Summary:</strong> You have{" "}
                           {
-                            currentUserRoles.filter((role) => role.hasRole)
+                            (currentUserRoles ?? []).filter((role) => role.hasRole)
                               .length
                           }{" "}
-                          of {currentUserRoles.length} predefined roles
+                          of {(currentUserRoles ?? []).length} predefined roles
                           assigned.
                         </p>
                       </div>
@@ -18224,7 +18245,11 @@ export default function AdminDashboard() {
               Assign {selectedRole?.name} Role
             </DialogTitle>
             <DialogDescription>
-              Grant this role to an address to provide system permissions.
+              Grant this role to an address on Pool{" "}
+              {selectedLendingPool
+                ? `${getLendingPoolLabel(currentNetwork, selectedLendingPool)} (${selectedLendingPool})`
+                : "— select a lending pool in the Roles tab first"}
+              .
             </DialogDescription>
           </DialogHeader>
 
@@ -18412,12 +18437,19 @@ export default function AdminDashboard() {
                   // Check if this is a Price Oracle role assignment
                   const isPriceOracleRole = selectedRole.id === "price-oracle";
 
-                  // All roles (including PriceOracle) are assigned on the LendingPool contract
-                  // The PriceOracle role on the LendingPool contract grants permission to update prices
-                  // Use selected lending pool or fallback to first pool
-                  const lendingPoolId =
-                    selectedLendingPool ||
-                    networkConfig.contracts.lendingPools[0];
+                  // All roles are assigned on the selected lending pool contract
+                  if (!selectedLendingPool) {
+                    toast.error("Select a lending pool first", {
+                      description:
+                        "Choose Pool C (or another pool) in the Roles tab before assigning.",
+                    });
+                    return;
+                  }
+                  const lendingPoolId = selectedLendingPool;
+                  const poolLabel = getLendingPoolLabel(
+                    currentNetwork,
+                    lendingPoolId
+                  );
                   const contractId = Number(lendingPoolId);
                   const targetAddress = assignAddress;
                   const contractSpec = {
@@ -18447,8 +18479,10 @@ export default function AdminDashboard() {
                   console.log("role_keyR", role_keyR);
                   if (!role_keyR.success) {
                     toast.error("Failed to get role key", {
-                      description: `Could not retrieve role key for ${selectedRole?.name || "selected role"
-                        }. Please try again.`,
+                      description: String(
+                        (role_keyR as { error?: string }).error ??
+                          `Could not retrieve role key on Pool ${poolLabel} (${lendingPoolId}).`
+                      ),
                     });
                     return;
                   }
@@ -18460,8 +18494,10 @@ export default function AdminDashboard() {
                   );
                   if (!set_roleR.success) {
                     toast.error("Failed to set role", {
-                      description: `Could not set role for ${selectedRole?.name || "selected role"
-                        }. Please try again.`,
+                      description: String(
+                        (set_roleR as { error?: string }).error ??
+                          `Could not set role on Pool ${poolLabel}. Your wallet may lack Market Controller on this pool.`
+                      ),
                     });
                     return;
                   }
@@ -18477,8 +18513,8 @@ export default function AdminDashboard() {
                   await waitForConfirmation(clients.algod, res.txid, 4);
 
                   toast.success("Role assigned successfully", {
-                    description: `Successfully assigned ${selectedRole?.name || "selected role"
-                      } role to ${targetAddress}.`,
+                    description: `Assigned ${selectedRole?.name || "selected role"
+                      } on Pool ${poolLabel} (${lendingPoolId}) to ${targetAddress}.`,
                   });
 
                   // Refresh oracle contract info if this was a Price Oracle role assignment

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -107,7 +107,7 @@ import {
   type TokenStandard,
 } from "@/config";
 import { useNetwork } from "@/contexts/NetworkContext";
-import { APP_SPEC as LendingPoolAppSpec } from "@/clients/DorkFiLendingPoolClient";
+import { APP_SPEC as LendingPoolAppSpec, GlobalUserData } from "@/clients/DorkFiLendingPoolClient";
 import { APP_SPEC as UNITGovernanceAppSpec } from "@/clients/UNITGovernanceClient";
 import { APP_SPEC as PriceOracleAppSpec } from "@/clients/PriceOracleClient";
 import algorandService, { AlgorandNetwork } from "@/services/algorandService";
@@ -480,6 +480,33 @@ export default function AdminDashboard() {
   const [poolBoxError, setPoolBoxError] = useState<string | null>(null);
   const [poolBoxQuickPick, setPoolBoxQuickPick] = useState("__manual__");
 
+  /** Tools: on-chain get_global_user per lending pool */
+  type GlobalUserToolRow = {
+    poolId: string;
+    poolLabel: string;
+    ok: boolean;
+    error?: string;
+    rawCollateral?: string;
+    rawBorrow?: string;
+    rawLastUpdateTime?: string;
+    collateralUsd?: number;
+    borrowUsd?: number;
+    lastUpdateTime?: number;
+    healthFactor?: number | null;
+  };
+  const [globalUserToolNetwork, setGlobalUserToolNetwork] = useState<NetworkId>(
+    () => currentNetwork as NetworkId
+  );
+  const [globalUserToolAddress, setGlobalUserToolAddress] = useState("");
+  const [globalUserToolPoolId, setGlobalUserToolPoolId] = useState("__all__");
+  const [globalUserToolLoading, setGlobalUserToolLoading] = useState(false);
+  const [globalUserToolError, setGlobalUserToolError] = useState<string | null>(
+    null
+  );
+  const [globalUserToolRows, setGlobalUserToolRows] = useState<
+    GlobalUserToolRow[]
+  >([]);
+
   const poolBoxTokenOptions = useMemo(() => {
     return getAllTokensWithDisplayInfo(poolBoxNetwork).filter(
       (t) => t.underlyingContractId && t.poolId
@@ -505,6 +532,119 @@ export default function AdminDashboard() {
   useEffect(() => {
     setPoolBoxQuickPick("__manual__");
   }, [poolBoxNetwork]);
+
+  useEffect(() => {
+    if (activeAccount?.address && !globalUserToolAddress) {
+      setGlobalUserToolAddress(activeAccount.address);
+    }
+  }, [activeAccount?.address, globalUserToolAddress]);
+
+  const handleGlobalUserToolLoad = useCallback(async () => {
+    const addr = globalUserToolAddress.trim();
+    if (!addr) {
+      toast.error("Enter a user address.");
+      return;
+    }
+    if (!isAlgorandCompatibleNetwork(globalUserToolNetwork)) {
+      toast.error("This tool only supports Algorand-compatible networks.");
+      return;
+    }
+
+    setGlobalUserToolLoading(true);
+    setGlobalUserToolError(null);
+    setGlobalUserToolRows([]);
+
+    try {
+      const networkConfig = getNetworkConfig(globalUserToolNetwork);
+      const clients = await algorandService.initializeClientsForReads(
+        networkConfig.walletNetworkId as AlgorandNetwork
+      );
+
+      const poolIds =
+        globalUserToolPoolId.trim() && globalUserToolPoolId !== "__all__"
+          ? [globalUserToolPoolId.trim()]
+          : networkConfig.contracts.lendingPools.map(String);
+
+      const rows: GlobalUserToolRow[] = [];
+
+      for (const poolId of poolIds) {
+        const poolLabel = getLendingPoolLabel(globalUserToolNetwork, poolId);
+        try {
+          const poolIdNum = Number(poolId);
+          const ci = new CONTRACT(
+            poolIdNum,
+            clients.algod,
+            undefined,
+            { ...LendingPoolAppSpec.contract, events: [] },
+            {
+              addr: algosdk.encodeAddress(
+                algosdk.getApplicationAddress(poolIdNum).publicKey
+              ),
+              sk: new Uint8Array(),
+            }
+          );
+          ci.setFee(2000);
+          const globalUserR = await ci.get_global_user(addr);
+          if (!globalUserR.success) {
+            rows.push({
+              poolId,
+              poolLabel,
+              ok: false,
+              error: "get_global_user failed (missing user box or RPC error)",
+            });
+            continue;
+          }
+
+          const globalUser = GlobalUserData(globalUserR.returnValue);
+          const collateralUsd = new BigNumber(
+            globalUser.totalCollateralValue.toString()
+          )
+            .div(1e12)
+            .toNumber();
+          const borrowUsd = new BigNumber(globalUser.totalBorrowValue.toString())
+            .div(1e12)
+            .toNumber();
+          const lastUpdateTime = Number(globalUser.lastUpdateTime);
+          const healthFactor =
+            borrowUsd > 0 ? Math.min(collateralUsd / borrowUsd, 3) : null;
+
+          rows.push({
+            poolId,
+            poolLabel,
+            ok: true,
+            rawCollateral: globalUser.totalCollateralValue.toString(),
+            rawBorrow: globalUser.totalBorrowValue.toString(),
+            rawLastUpdateTime: globalUser.lastUpdateTime.toString(),
+            collateralUsd,
+            borrowUsd,
+            lastUpdateTime,
+            healthFactor,
+          });
+        } catch (e) {
+          rows.push({
+            poolId,
+            poolLabel,
+            ok: false,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+
+      setGlobalUserToolRows(rows);
+      const okCount = rows.filter((r) => r.ok).length;
+      if (okCount === 0) {
+        toast.error("No global user data returned for any pool.");
+      } else {
+        toast.success(`Loaded global user data for ${okCount} pool(s).`);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setGlobalUserToolError(msg);
+      toast.error(msg);
+    } finally {
+      setGlobalUserToolLoading(false);
+    }
+  }, [globalUserToolAddress, globalUserToolNetwork, globalUserToolPoolId]);
 
   const handleSyncUserForPriceChange = useCallback(async () => {
     const u = pcSyncUserAddress.trim();
@@ -12066,6 +12206,228 @@ export default function AdminDashboard() {
                   <p className="text-sm font-mono text-muted-foreground">
                     Last txid: {poolBoxLastTxid}
                   </p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-blue-500/25 bg-blue-500/[0.03]">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                  Global user data (get_global_user)
+                </CardTitle>
+                <CardDescription>
+                  Reads lending pool{" "}
+                  <code className="text-xs">get_global_user</code> on-chain for
+                  a wallet. Returns per-pool collateral and borrow totals (scaled
+                  ÷ 1e12 → USD) and last update time — same source as Portfolio
+                  health factor.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+                  <div className="space-y-2">
+                    <Label>Network</Label>
+                    <Select
+                      value={globalUserToolNetwork}
+                      onValueChange={(v) =>
+                        setGlobalUserToolNetwork(v as NetworkId)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Network" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {getEnabledNetworks().map((nid) => (
+                          <SelectItem key={nid} value={nid}>
+                            {nid}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2 md:col-span-2">
+                    <Label>User address</Label>
+                    <Input
+                      className="font-mono text-xs"
+                      placeholder="Algorand address"
+                      value={globalUserToolAddress}
+                      onChange={(e) =>
+                        setGlobalUserToolAddress(e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Lending pool</Label>
+                    <Select
+                      value={globalUserToolPoolId}
+                      onValueChange={setGlobalUserToolPoolId}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="All pools" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__all__">All pools</SelectItem>
+                        {getLendingPools(globalUserToolNetwork).map((poolId) => (
+                          <SelectItem key={poolId} value={poolId}>
+                            Pool {getLendingPoolLabel(globalUserToolNetwork, poolId)}{" "}
+                            ({poolId})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="default"
+                  onClick={() => void handleGlobalUserToolLoad()}
+                  disabled={globalUserToolLoading}
+                >
+                  {globalUserToolLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Reading chain…
+                    </>
+                  ) : (
+                    <>
+                      <Database className="h-4 w-4 mr-2" />
+                      Load global user data
+                    </>
+                  )}
+                </Button>
+                {globalUserToolError && (
+                  <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                    {globalUserToolError}
+                  </div>
+                )}
+                {globalUserToolRows.length > 0 && (
+                  <div className="space-y-3">
+                    {globalUserToolRows.some((r) => r.ok) && (
+                      <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm">
+                        <p className="font-semibold text-foreground mb-2">
+                          Network totals (successful pools)
+                        </p>
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 font-mono text-xs">
+                          <div>
+                            <span className="text-muted-foreground">
+                              Collateral USD
+                            </span>
+                            <p className="font-medium tabular-nums">
+                              $
+                              {globalUserToolRows
+                                .filter((r) => r.ok)
+                                .reduce(
+                                  (sum, r) => sum + (r.collateralUsd ?? 0),
+                                  0
+                                )
+                                .toLocaleString(undefined, {
+                                  maximumFractionDigits: 2,
+                                })}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-muted-foreground">
+                              Borrow USD
+                            </span>
+                            <p className="font-medium tabular-nums">
+                              $
+                              {globalUserToolRows
+                                .filter((r) => r.ok)
+                                .reduce(
+                                  (sum, r) => sum + (r.borrowUsd ?? 0),
+                                  0
+                                )
+                                .toLocaleString(undefined, {
+                                  maximumFractionDigits: 2,
+                                })}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-muted-foreground">
+                              Worst HF (C÷B, cap 3)
+                            </span>
+                            <p className="font-medium tabular-nums">
+                              {(() => {
+                                const hfs = globalUserToolRows
+                                  .filter(
+                                    (r) =>
+                                      r.ok &&
+                                      r.healthFactor != null &&
+                                      Number.isFinite(r.healthFactor)
+                                  )
+                                  .map((r) => r.healthFactor as number);
+                                if (hfs.length === 0) return "—";
+                                return Math.min(...hfs).toFixed(4);
+                              })()}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    {globalUserToolRows.map((row) => (
+                      <div
+                        key={row.poolId}
+                        className="rounded-lg border border-border bg-muted/20 p-3 space-y-2 text-sm"
+                      >
+                        <p className="font-semibold text-foreground">
+                          Pool {row.poolLabel} ({row.poolId})
+                        </p>
+                        {!row.ok ? (
+                          <p className="text-destructive text-xs">{row.error}</p>
+                        ) : (
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 font-mono text-xs">
+                            <span className="text-muted-foreground">
+                              totalCollateralValue (raw)
+                            </span>
+                            <span className="break-all">{row.rawCollateral}</span>
+                            <span className="text-muted-foreground">
+                              totalBorrowValue (raw)
+                            </span>
+                            <span className="break-all">{row.rawBorrow}</span>
+                            <span className="text-muted-foreground">
+                              Collateral USD (÷ 1e12)
+                            </span>
+                            <span>
+                              $
+                              {(row.collateralUsd ?? 0).toLocaleString(
+                                undefined,
+                                { maximumFractionDigits: 4 }
+                              )}
+                            </span>
+                            <span className="text-muted-foreground">
+                              Borrow USD (÷ 1e12)
+                            </span>
+                            <span>
+                              $
+                              {(row.borrowUsd ?? 0).toLocaleString(undefined, {
+                                maximumFractionDigits: 4,
+                              })}
+                            </span>
+                            <span className="text-muted-foreground">
+                              lastUpdateTime
+                            </span>
+                            <span>
+                              {row.lastUpdateTime}{" "}
+                              {row.lastUpdateTime
+                                ? `(${new Date(
+                                    row.lastUpdateTime * 1000
+                                  ).toISOString()})`
+                                : ""}
+                            </span>
+                            <span className="text-muted-foreground">
+                              Health factor (C÷B, cap 3)
+                            </span>
+                            <span>
+                              {row.healthFactor != null
+                                ? row.healthFactor.toFixed(4)
+                                : "— (no borrows)"}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
                 )}
               </CardContent>
             </Card>

--- a/src/pages/Governance.tsx
+++ b/src/pages/Governance.tsx
@@ -68,6 +68,9 @@ const Governance = () => {
 
   // Calculate effective voting power (same logic as GovernanceDashboardCard)
   const effectiveVotingPower = useMemo(() => {
+
+    console.log("userVoterInfo", { userVoterInfo });
+
     // Calculate base power
     const basePower = userVoterInfo 
       ? Number(userVoterInfo.voteBasePower) / 1e8 

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import { Droplets, RefreshCw } from "lucide-react";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import DorkFiButton from "@/components/ui/DorkFiButton";
+import { H1, Body } from "@/components/ui/Typography";
+import LiquidityPoolCardContainer from "@/components/pools/LiquidityPoolCardContainer";
+import PoolsTokenFilter from "@/components/pools/PoolsTokenFilter";
+import {
+  countPoolsByBaseTokenFilter,
+  getCuratedLiquidityPoolsForNetwork,
+  getPoolBaseTokenFilterAssetId,
+  poolMatchesBaseTokenFilter,
+  type PoolBaseTokenFilterId,
+} from "@/constants/liquidityPools";
+import {
+  useInvalidateLiquidityPools,
+  useLiquidityPoolsOrderedByApr,
+} from "@/hooks/useLiquidityPoolData";
+import { useNetwork } from "@/contexts/NetworkContext";
+import { tinymanNetworkFromNetworkId } from "@/services/tinymanLiquidityService";
+
+interface PoolsPageProps {
+  activeTab: string;
+  onTabChange: (value: string) => void;
+}
+
+const PoolsPage = ({ activeTab, onTabChange }: PoolsPageProps) => {
+  const { currentNetwork } = useNetwork();
+  const [tokenFilter, setTokenFilter] = useState<PoolBaseTokenFilterId>("all");
+  const pairs = useMemo(
+    () => getCuratedLiquidityPoolsForNetwork(currentNetwork),
+    [currentNetwork]
+  );
+  const filterCounts = useMemo(() => countPoolsByBaseTokenFilter(pairs), [pairs]);
+  const filteredPairs = useMemo(() => {
+    const filterAssetId = getPoolBaseTokenFilterAssetId(tokenFilter);
+    return pairs.filter((pair) => poolMatchesBaseTokenFilter(pair, filterAssetId));
+  }, [pairs, tokenFilter]);
+  const orderedPairs = useLiquidityPoolsOrderedByApr(filteredPairs);
+  const invalidatePools = useInvalidateLiquidityPools(pairs);
+  const tinymanSupported = tinymanNetworkFromNetworkId(currentNetwork) != null;
+
+  useEffect(() => {
+    setTokenFilter("all");
+  }, [currentNetwork]);
+
+  return (
+    <div className="relative min-h-screen bg-background">
+      <div className="absolute inset-0 light-mode-beach-bg dark:hidden" />
+      <div className="absolute inset-0 beach-overlay dark:hidden" />
+      <div className="absolute inset-0 z-0 hidden dark:block dorkfi-dark-bg-with-overlay" />
+
+      <Header activeTab={activeTab} onTabChange={onTabChange} />
+
+      <main className="relative z-10 mx-auto max-w-[1200px] px-4 py-6 md:py-8">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-ocean-teal">
+              <Droplets className="h-6 w-6" aria-hidden />
+              <span className="text-sm font-semibold uppercase tracking-wide">
+                Liquidity
+              </span>
+            </div>
+            <H1>Liquidity Pools</H1>
+            <Body className="max-w-2xl text-muted-foreground">
+              Deposit into curated Tinyman v2 pairs to earn trading fees. Withdraw
+              anytime by burning your LP tokens.
+            </Body>
+          </div>
+          <DorkFiButton
+            variant="secondary"
+            onClick={invalidatePools}
+            disabled={!tinymanSupported || pairs.length === 0}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" aria-hidden />
+            Refresh
+          </DorkFiButton>
+        </div>
+
+        {!tinymanSupported ? (
+          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-6 text-center">
+            <p className="font-medium text-amber-900 dark:text-amber-100">
+              Liquidity pools are available on Algorand mainnet and testnet.
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Switch your network to Algorand to view and manage pool positions.
+            </p>
+          </div>
+        ) : pairs.length === 0 ? (
+          <div className="rounded-xl border px-4 py-6 text-center text-muted-foreground">
+            No curated pools are configured for this network yet.
+          </div>
+        ) : (
+          <>
+            <PoolsTokenFilter
+              value={tokenFilter}
+              onChange={setTokenFilter}
+              counts={filterCounts}
+              className="mb-4"
+            />
+            {orderedPairs.length === 0 ? (
+              <div className="rounded-xl border px-4 py-6 text-center text-muted-foreground">
+                No pools match this token filter.
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {orderedPairs.map((pair) => (
+                  <LiquidityPoolCardContainer key={pair.id} pair={pair} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default PoolsPage;

--- a/src/services/tinymanLiquidityService.ts
+++ b/src/services/tinymanLiquidityService.ts
@@ -1,0 +1,769 @@
+import {
+  AddLiquidity,
+  RemoveLiquidity,
+  combineAndRegroupSignerTxns,
+  generateOptIntoAssetTxns,
+  poolUtils,
+  tinymanJSSDKConfig,
+  type PoolReserves,
+  type SignerTransaction,
+  type SupportedNetwork,
+  type V2PoolInfo,
+} from "@tinymanorg/tinyman-js-sdk";
+import algosdk from "algosdk";
+import BigNumber from "bignumber.js";
+import { abi, CONTRACT } from "ulujs";
+import {
+  getAlgorandNetworkFromNetworkId,
+  getAllTokens,
+  type NetworkId,
+} from "@/config";
+import algorandService from "@/services/algorandService";
+import { folksMintTxnsToArccjsExtraTxns } from "@/services/folksDepositAdapter";
+import { tinymanRateFractionToPercentPoints } from "@/services/tinymanLiquidStakingService";
+import type { LiquidityPoolPairConfig } from "@/constants/liquidityPools";
+import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
+import { spendableAlgoMicroAlgosFromAccount } from "@/utils/algorandWalletBalance";
+
+const DEFAULT_SLIPPAGE = 0.01;
+
+const TINYMAN_POOL_ANALYTICS_BASE: Record<SupportedNetwork, string> = {
+  mainnet: "https://mainnet.analytics.tinyman.org/api/v1/pools",
+  testnet: "https://testnet.analytics.tinyman.org/api/v1/pools",
+};
+
+const TINYMAN_STAKING_ANALYTICS_BASE: Record<SupportedNetwork, string> = {
+  mainnet: "https://mainnet.analytics.tinyman.org/api/v1/staking/pool-programs",
+  testnet: "https://testnet.analytics.tinyman.org/api/v1/staking/pool-programs",
+};
+
+export interface LiquidityPoolAssetMeta {
+  assetId: number;
+  symbol: string;
+  decimals: number;
+  logoPath?: string;
+}
+
+export interface LiquidityPoolApr {
+  /** Swap-fee APR from Tinyman analytics (percentage points). */
+  feeAprPercent: number | null;
+  feeApyPercent: number | null;
+  /** Fees + active staking programs (percentage points). */
+  totalAprPercent: number | null;
+  totalApyPercent: number | null;
+  liquidityUsd: number | null;
+  volume24hUsd: number | null;
+}
+
+export interface LiquidityPoolSnapshot {
+  pair: LiquidityPoolPairConfig;
+  pool: V2PoolInfo;
+  reserves: PoolReserves;
+  asset1: LiquidityPoolAssetMeta;
+  asset2: LiquidityPoolAssetMeta;
+  poolTokenId: number;
+  totalLiquidity: bigint;
+  asset1ReserveHuman: string;
+  asset2ReserveHuman: string;
+  apr: LiquidityPoolApr | null;
+  poolAddress: string;
+}
+
+export interface LiquidityPoolUserPosition {
+  /** Wallet-held LP token (ASA) balance. */
+  poolTokenBalance: bigint;
+  /** LP balance deposited in the nt200 market (`lpContractId`). */
+  nt200LpBalance: bigint;
+  /** LP committed to a Tinyman farm program (wallet-held, tracked by Tinyman). */
+  farmLpBalance: bigint;
+  poolSharePercent: number;
+}
+
+export function tinymanNetworkFromNetworkId(
+  networkId: NetworkId
+): SupportedNetwork | null {
+  if (networkId === "algorand-mainnet") return "mainnet";
+  if (networkId === "algorand-testnet") return "testnet";
+  return null;
+}
+
+export function resolveLiquidityAssetMeta(
+  networkId: NetworkId,
+  assetId: number
+): LiquidityPoolAssetMeta {
+  if (assetId === 0) {
+    return {
+      assetId: 0,
+      symbol: "ALGO",
+      decimals: 6,
+      logoPath: "/lovable-uploads/Algo.webp",
+    };
+  }
+  const tokens = getAllTokens(networkId);
+  for (const t of tokens) {
+    if (t.isStoken) continue;
+    const raw = t.assetId;
+    if (!raw || !/^\d+$/.test(raw)) continue;
+    if (Number(raw) === assetId) {
+      return {
+        assetId,
+        symbol: t.marketOverride?.displaySymbol ?? t.symbol,
+        decimals: t.decimals,
+        logoPath: t.logoPath,
+      };
+    }
+  }
+  return {
+    assetId,
+    symbol: `ASA ${assetId}`,
+    decimals: 6,
+  };
+}
+
+function toAtomic(human: string, decimals: number): bigint {
+  const trimmed = human.trim();
+  if (!trimmed || trimmed === ".") return 0n;
+  const atomic = new BigNumber(trimmed)
+    .times(new BigNumber(10).pow(decimals))
+    .integerValue(BigNumber.ROUND_FLOOR)
+    .toFixed(0);
+  return BigInt(atomic);
+}
+
+function applyPairAssetOverrides(
+  pair: LiquidityPoolPairConfig,
+  assetId: number,
+  meta: LiquidityPoolAssetMeta
+): LiquidityPoolAssetMeta {
+  if (assetId !== pair.asset2Id) return meta;
+  return {
+    ...meta,
+    ...(pair.asset2Symbol ? { symbol: pair.asset2Symbol } : {}),
+    ...(pair.asset2Decimals != null ? { decimals: pair.asset2Decimals } : {}),
+    ...(pair.asset2LogoPath ? { logoPath: pair.asset2LogoPath } : {}),
+  };
+}
+
+function snapshotAssetsInPairOrder(
+  pair: LiquidityPoolPairConfig,
+  pool: V2PoolInfo,
+  reserves: PoolReserves
+) {
+  const poolAsset1 = applyPairAssetOverrides(
+    pair,
+    pool.asset1ID,
+    resolveLiquidityAssetMeta(pair.networkId, pool.asset1ID)
+  );
+  const poolAsset2 = applyPairAssetOverrides(
+    pair,
+    pool.asset2ID,
+    resolveLiquidityAssetMeta(pair.networkId, pool.asset2ID)
+  );
+
+  if (pair.asset1Id === pool.asset1ID) {
+    return {
+      asset1: poolAsset1,
+      asset2: poolAsset2,
+      asset1Reserve: reserves.asset1,
+      asset2Reserve: reserves.asset2,
+    };
+  }
+
+  return {
+    asset1: poolAsset2,
+    asset2: poolAsset1,
+    asset1Reserve: reserves.asset2,
+    asset2Reserve: reserves.asset1,
+  };
+}
+
+async function fetchPoolApr(
+  network: SupportedNetwork,
+  poolAddress: string
+): Promise<LiquidityPoolApr | null> {
+  try {
+    const res = await fetch(
+      `${TINYMAN_POOL_ANALYTICS_BASE[network]}/${encodeURIComponent(poolAddress)}/`
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      annual_percentage_rate?: string;
+      annual_percentage_yield?: string;
+      total_annual_percentage_rate?: string;
+      total_annual_percentage_yield?: string;
+      liquidity_in_usd?: string;
+      last_day_volume_in_usd?: string;
+    };
+    const liquidityUsd = Number.parseFloat(data.liquidity_in_usd ?? "");
+    const volume24hUsd = Number.parseFloat(data.last_day_volume_in_usd ?? "");
+    return {
+      feeAprPercent: tinymanRateFractionToPercentPoints(
+        data.annual_percentage_rate
+      ),
+      feeApyPercent: tinymanRateFractionToPercentPoints(
+        data.annual_percentage_yield
+      ),
+      totalAprPercent: tinymanRateFractionToPercentPoints(
+        data.total_annual_percentage_rate
+      ),
+      totalApyPercent: tinymanRateFractionToPercentPoints(
+        data.total_annual_percentage_yield
+      ),
+      liquidityUsd: Number.isFinite(liquidityUsd) ? liquidityUsd : null,
+      volume24hUsd: Number.isFinite(volume24hUsd) ? volume24hUsd : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function fromAtomic(amount: bigint, decimals: number): string {
+  return new BigNumber(amount.toString())
+    .shiftedBy(-decimals)
+    .decimalPlaces(Math.min(decimals, 6), BigNumber.ROUND_DOWN)
+    .toFixed();
+}
+
+export async function fetchLiquidityPoolSnapshot(
+  pair: LiquidityPoolPairConfig
+): Promise<LiquidityPoolSnapshot | null> {
+  if (pair.platform !== "tinyman") return null;
+
+  const tinymanNet = tinymanNetworkFromNetworkId(pair.networkId);
+  const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+  if (!tinymanNet || !algodNetwork) return null;
+
+  const { algod } = await algorandService.initializeClientsForReads(algodNetwork);
+  const pool = await poolUtils.v2.getPoolInfo({
+    client: algod,
+    network: tinymanNet,
+    asset1ID: pair.asset1Id,
+    asset2ID: pair.asset2Id,
+  });
+
+  if (poolUtils.v2.isPoolNotCreated(pool)) {
+    return null;
+  }
+
+  if (!poolUtils.v2.isPoolReady(pool) || !pool.poolTokenID) {
+    return null;
+  }
+
+  const reserves = await poolUtils.v2.getPoolReserves(algod, pool);
+  const ordered = snapshotAssetsInPairOrder(pair, pool, reserves);
+  const poolAddress = pool.account.address().toString();
+  const apr = await fetchPoolApr(tinymanNet, poolAddress);
+
+  return {
+    pair,
+    pool,
+    reserves,
+    asset1: ordered.asset1,
+    asset2: ordered.asset2,
+    poolTokenId: pool.poolTokenID ?? pair.lpTokenId,
+    totalLiquidity: reserves.issuedLiquidity,
+    asset1ReserveHuman: fromAtomic(ordered.asset1Reserve, ordered.asset1.decimals),
+    asset2ReserveHuman: fromAtomic(ordered.asset2Reserve, ordered.asset2.decimals),
+    apr,
+    poolAddress,
+  };
+}
+
+export async function fetchAlgorandAssetBalance(
+  networkId: NetworkId,
+  userAddress: string,
+  assetId: number
+): Promise<bigint> {
+  const algodNetwork = getAlgorandNetworkFromNetworkId(networkId);
+  if (!algodNetwork) return 0n;
+
+  const { algod } = await algorandService.initializeClientsForReads(algodNetwork);
+
+  if (assetId === 0) {
+    const account = await algod.accountInformation(userAddress).do();
+    return spendableAlgoMicroAlgosFromAccount(account);
+  }
+
+  try {
+    const holding = await algod.accountAssetInformation(userAddress, assetId).do();
+    return getAccountAssetHoldingAmountAtomic(holding) ?? 0n;
+  } catch {
+    return 0n;
+  }
+}
+
+async function fetchTinymanFarmLpCommitment(
+  pair: LiquidityPoolPairConfig,
+  userAddress: string,
+  poolAddress: string,
+  farmProgramId: number
+): Promise<bigint> {
+  const tinymanNet = tinymanNetworkFromNetworkId(pair.networkId);
+  if (!tinymanNet) return 0n;
+
+  try {
+    const url = new URL(
+      `${TINYMAN_STAKING_ANALYTICS_BASE[tinymanNet]}/${encodeURIComponent(poolAddress)}/${farmProgramId}/`
+    );
+    url.searchParams.set("pooler_address", userAddress);
+    const res = await fetch(url.toString());
+    if (!res.ok) return 0n;
+
+    const data = (await res.json()) as {
+      pooler?: {
+        current_cycle_commitment?: { amount?: string } | null;
+        next_cycle_commitment?: { amount?: string } | null;
+      } | null;
+    };
+
+    const amountStr =
+      data.pooler?.next_cycle_commitment?.amount ??
+      data.pooler?.current_cycle_commitment?.amount;
+    if (!amountStr || !/^\d+$/.test(amountStr)) return 0n;
+    return BigInt(amountStr);
+  } catch {
+    return 0n;
+  }
+}
+
+export async function fetchNt200Arc200Balance(
+  networkId: NetworkId,
+  contractId: number,
+  userAddress: string
+): Promise<bigint> {
+  const algodNetwork = getAlgorandNetworkFromNetworkId(networkId);
+  if (!algodNetwork) return 0n;
+
+  try {
+    const { algod } = await algorandService.initializeClientsForReads(algodNetwork);
+    const ci = new CONTRACT(
+      contractId,
+      algod,
+      undefined,
+      abi.nt200,
+      { addr: userAddress, sk: new Uint8Array() }
+    );
+    const result = await ci.arc200_balanceOf(userAddress);
+    if (!result.success) return 0n;
+    return BigInt(result.returnValue ?? 0);
+  } catch {
+    return 0n;
+  }
+}
+
+export async function fetchLiquidityPoolUserPosition(
+  pair: LiquidityPoolPairConfig,
+  userAddress: string
+): Promise<LiquidityPoolUserPosition | null> {
+  const snapshot = await fetchLiquidityPoolSnapshot(pair);
+  if (!snapshot) return null;
+
+  const farmProgramId = pair.farms?.[0];
+  const poolAddress = pair.poolAddr ?? snapshot.poolAddress;
+
+  const [poolTokenBalance, nt200LpBalance, farmLpBalance] = await Promise.all([
+    fetchAlgorandAssetBalance(pair.networkId, userAddress, snapshot.poolTokenId),
+    fetchNt200Arc200Balance(pair.networkId, pair.lpContractId, userAddress),
+    farmProgramId != null && poolAddress
+      ? fetchTinymanFarmLpCommitment(
+          pair,
+          userAddress,
+          poolAddress,
+          farmProgramId
+        )
+      : Promise.resolve(0n),
+  ]);
+  const poolSharePercent = poolUtils.v2.getPoolShare(
+    snapshot.totalLiquidity,
+    poolTokenBalance
+  );
+
+  return { poolTokenBalance, nt200LpBalance, farmLpBalance, poolSharePercent };
+}
+
+async function isAccountOptedIntoAsset(
+  algod: algosdk.Algodv2,
+  address: string,
+  assetId: number
+): Promise<boolean> {
+  if (assetId === 0) return true;
+  try {
+    await algod.accountAssetInformation(address, assetId).do();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function encodeSignerTxnsForWallet(txGroup: SignerTransaction[]): Uint8Array[] {
+  return txGroup.map(({ txn }) =>
+    Uint8Array.from(algosdk.encodeUnsignedTransaction(txn))
+  );
+}
+
+export async function buildAddLiquidityTransactions(params: {
+  pair: LiquidityPoolPairConfig;
+  userAddress: string;
+  assetInId: number;
+  amountHuman: string;
+  slippage?: number;
+}): Promise<SignerTransaction[]> {
+  const { pair, userAddress, assetInId, amountHuman } = params;
+  const slippage = params.slippage ?? DEFAULT_SLIPPAGE;
+  const tinymanNet = tinymanNetworkFromNetworkId(pair.networkId);
+  const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+  if (!tinymanNet || !algodNetwork) {
+    throw new Error("Liquidity pools are only available on Algorand networks.");
+  }
+
+  tinymanJSSDKConfig.setClientName("DorkFi-PreFi");
+  const snapshot = await fetchLiquidityPoolSnapshot(pair);
+  if (!snapshot) throw new Error("Pool is not ready for deposits.");
+
+  const assetIn =
+    assetInId === snapshot.asset1.assetId ? snapshot.asset1 : snapshot.asset2;
+  const atomic = toAtomic(amountHuman, assetIn.decimals);
+  if (atomic <= 0n) throw new Error("Enter an amount greater than zero.");
+
+  const { algod } = await algorandService.initializeClientsForTransactions(
+    algodNetwork
+  );
+
+  const quote = AddLiquidity.v2.withSingleAsset.getQuote({
+    pool: snapshot.pool,
+    assetIn: { id: assetIn.assetId, amount: atomic },
+    decimals: {
+      asset1: snapshot.asset1.decimals,
+      asset2: snapshot.asset2.decimals,
+    },
+    slippage,
+  });
+
+  let txGroup = await AddLiquidity.v2.withSingleAsset.generateTxns({
+    network: tinymanNet,
+    client: algod,
+    initiatorAddr: userAddress,
+    poolAddress: snapshot.pool.account.address().toString(),
+    assetIn: quote.assetIn,
+    poolTokenId: snapshot.poolTokenId,
+    minPoolTokenAssetAmount: quote.minPoolTokenAssetAmountWithSlippage,
+  });
+
+  const optedIn = await isAccountOptedIntoAsset(
+    algod,
+    userAddress,
+    snapshot.poolTokenId
+  );
+  if (!optedIn) {
+    txGroup = combineAndRegroupSignerTxns(
+      await generateOptIntoAssetTxns({
+        client: algod,
+        assetID: snapshot.poolTokenId,
+        initiatorAddr: userAddress,
+      }),
+      txGroup
+    );
+  }
+
+  return txGroup;
+}
+
+const MAINNET_CUSTOM_BEACON_ID = 3209233839;
+
+/** nt200 ASA deposit of LP tokens into the pool's nt200 market (`lpContractId`). */
+export async function buildNt200LpDepositTransactions(params: {
+  pair: LiquidityPoolPairConfig;
+  userAddress: string;
+  poolTokenAmountHuman: string;
+}): Promise<string[]> {
+  const { pair, userAddress, poolTokenAmountHuman } = params;
+  const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+  if (!algodNetwork) {
+    throw new Error("Liquidity pools are only available on Algorand networks.");
+  }
+
+  const depositAmount = toAtomic(poolTokenAmountHuman, 6);
+  if (depositAmount <= 0n) {
+    throw new Error("Enter an LP amount greater than zero.");
+  }
+
+  const { algod } = await algorandService.initializeClientsForTransactions(
+    algodNetwork
+  );
+
+  const preamble: Record<string, unknown>[] = [];
+  const optedIn = await isAccountOptedIntoAsset(
+    algod,
+    userAddress,
+    pair.lpTokenId
+  );
+  if (!optedIn) {
+    const suggestedParams = await algod.getTransactionParams().do();
+    const optInTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
+      sender: userAddress,
+      receiver: userAddress,
+      amount: 0,
+      assetIndex: pair.lpTokenId,
+      suggestedParams: {
+        ...suggestedParams,
+        flatFee: true,
+        fee: 1000n,
+      },
+      note: new TextEncoder().encode("dorkfi: LP token opt-in"),
+    });
+    preamble.push(...folksMintTxnsToArccjsExtraTxns([optInTxn]));
+  }
+
+  const tokenContract = new CONTRACT(
+    pair.lpContractId,
+    algod,
+    undefined,
+    abi.nt200,
+    {
+      addr: userAddress,
+      sk: new Uint8Array(),
+    },
+    true,
+    false,
+    true
+  );
+
+  const ci = new CONTRACT(
+    pair.lpContractId,
+    algod,
+    undefined,
+    abi.custom,
+    {
+      addr: userAddress,
+      sk: new Uint8Array(),
+    }
+  );
+
+  let lastError = "nt200 LP deposit failed";
+  for (const needsBalanceBox of [false, true]) {
+    const buildN: Record<string, unknown>[] = [...preamble];
+    if (needsBalanceBox) {
+      const txnO = (await tokenContract.createBalanceBox(userAddress)).obj as Record<
+        string,
+        unknown
+      >;
+      buildN.push({
+        ...txnO,
+        payment: 28501,
+        note: new TextEncoder().encode("nt200 createBalanceBox"),
+      });
+    }
+
+    const depositTxnO = (await tokenContract.deposit(depositAmount)).obj as Record<
+      string,
+      unknown
+    >;
+    buildN.push({
+      ...depositTxnO,
+      aamt: depositAmount,
+      xaid: pair.lpTokenId,
+      payment: 0,
+      note: new TextEncoder().encode(
+        `nt200 deposit ${poolTokenAmountHuman} LP`
+      ),
+    });
+
+    ci.setFee(20000);
+    ci.setEnableGroupResourceSharing(true);
+    ci.setExtraTxns(buildN);
+    if (pair.networkId === "algorand-mainnet") {
+      ci.setBeaconId(MAINNET_CUSTOM_BEACON_ID);
+    }
+
+    const result = await ci.custom();
+    if (result.success && result.txns) {
+      return result.txns as string[];
+    }
+    lastError = String((result as { error?: string }).error ?? lastError);
+  }
+
+  throw new Error(lastError);
+}
+
+/** nt200 ASA withdraw of LP tokens back to the wallet from `lpContractId`. */
+export async function buildNt200LpWithdrawTransactions(params: {
+  pair: LiquidityPoolPairConfig;
+  userAddress: string;
+  poolTokenAmountHuman: string;
+}): Promise<string[]> {
+  const { pair, userAddress, poolTokenAmountHuman } = params;
+  const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+  if (!algodNetwork) {
+    throw new Error("Liquidity pools are only available on Algorand networks.");
+  }
+
+  const withdrawAmount = toAtomic(poolTokenAmountHuman, 6);
+  if (withdrawAmount <= 0n) {
+    throw new Error("Enter an LP amount greater than zero.");
+  }
+
+  const { algod } = await algorandService.initializeClientsForTransactions(
+    algodNetwork
+  );
+
+  let optInAxfer: Record<string, unknown> = {};
+  const optedIn = await isAccountOptedIntoAsset(
+    algod,
+    userAddress,
+    pair.lpTokenId
+  );
+  if (!optedIn) {
+    optInAxfer = {
+      xaid: pair.lpTokenId,
+      snd: userAddress,
+      arcv: userAddress,
+    };
+  }
+
+  const tokenContract = new CONTRACT(
+    pair.lpContractId,
+    algod,
+    undefined,
+    abi.nt200,
+    {
+      addr: userAddress,
+      sk: new Uint8Array(),
+    },
+    true,
+    false,
+    true
+  );
+
+  const ci = new CONTRACT(
+    pair.lpContractId,
+    algod,
+    undefined,
+    abi.custom,
+    {
+      addr: userAddress,
+      sk: new Uint8Array(),
+    }
+  );
+
+  const withdrawTxnO = (await tokenContract.withdraw(withdrawAmount)).obj as Record<
+    string,
+    unknown
+  >;
+  const buildN: Record<string, unknown>[] = [
+    {
+      ...withdrawTxnO,
+      ...optInAxfer,
+      note: new TextEncoder().encode(
+        `nt200 withdraw ${poolTokenAmountHuman} LP`
+      ),
+    },
+  ];
+
+  ci.setFee(20000);
+  ci.setEnableGroupResourceSharing(true);
+  ci.setExtraTxns(buildN);
+  if (pair.networkId === "algorand-mainnet") {
+    ci.setBeaconId(MAINNET_CUSTOM_BEACON_ID);
+  }
+
+  const result = await ci.custom();
+  if (result.success && result.txns) {
+    return result.txns as string[];
+  }
+
+  throw new Error(
+    String((result as { error?: string }).error ?? "nt200 LP withdraw failed")
+  );
+}
+
+export async function buildRemoveLiquidityTransactions(params: {
+  pair: LiquidityPoolPairConfig;
+  userAddress: string;
+  poolTokenAmountHuman: string;
+  slippage?: number;
+}): Promise<SignerTransaction[]> {
+  const { pair, userAddress, poolTokenAmountHuman } = params;
+  const slippage = params.slippage ?? DEFAULT_SLIPPAGE;
+  const tinymanNet = tinymanNetworkFromNetworkId(pair.networkId);
+  const algodNetwork = getAlgorandNetworkFromNetworkId(pair.networkId);
+  if (!tinymanNet || !algodNetwork) {
+    throw new Error("Liquidity pools are only available on Algorand networks.");
+  }
+
+  tinymanJSSDKConfig.setClientName("DorkFi-PreFi");
+  const snapshot = await fetchLiquidityPoolSnapshot(pair);
+  if (!snapshot) throw new Error("Pool is not ready for withdrawals.");
+
+  const poolTokenDecimals = 6;
+  const poolTokenIn = toAtomic(poolTokenAmountHuman, poolTokenDecimals);
+  if (poolTokenIn <= 0n) throw new Error("Enter an LP amount greater than zero.");
+
+  const { algod } = await algorandService.initializeClientsForTransactions(
+    algodNetwork
+  );
+
+  const quote = RemoveLiquidity.v2.getQuote({
+    pool: snapshot.pool,
+    reserves: snapshot.reserves,
+    poolTokenIn,
+  });
+
+  return RemoveLiquidity.v2.generateTxns({
+    client: algod,
+    pool: snapshot.pool,
+    initiatorAddr: userAddress,
+    poolTokenIn: quote.poolTokenIn.amount,
+    minAsset1Amount: quote.asset1Out.amount,
+    minAsset2Amount: quote.asset2Out.amount,
+    slippage,
+  });
+}
+
+export function quoteAddLiquidity(
+  snapshot: LiquidityPoolSnapshot,
+  assetInId: number,
+  amountHuman: string,
+  slippage = DEFAULT_SLIPPAGE
+) {
+  const assetIn =
+    assetInId === snapshot.asset1.assetId ? snapshot.asset1 : snapshot.asset2;
+  const atomic = toAtomic(amountHuman, assetIn.decimals);
+  if (atomic <= 0n) return null;
+  return AddLiquidity.v2.withSingleAsset.getQuote({
+    pool: snapshot.pool,
+    assetIn: { id: assetIn.assetId, amount: atomic },
+    decimals: {
+      asset1: snapshot.asset1.decimals,
+      asset2: snapshot.asset2.decimals,
+    },
+    slippage,
+  });
+}
+
+export function quoteRemoveLiquidity(
+  snapshot: LiquidityPoolSnapshot,
+  poolTokenAmountHuman: string
+) {
+  const poolTokenIn = toAtomic(poolTokenAmountHuman, 6);
+  if (poolTokenIn <= 0n) return null;
+  return RemoveLiquidity.v2.getQuote({
+    pool: snapshot.pool,
+    reserves: snapshot.reserves,
+    poolTokenIn,
+  });
+}
+
+export async function submitSignedLiquidityTransactions(
+  networkId: NetworkId,
+  signed: Uint8Array[]
+): Promise<string> {
+  const algodNetwork = getAlgorandNetworkFromNetworkId(networkId);
+  if (!algodNetwork) throw new Error("Unsupported network.");
+  const { algod } = await algorandService.initializeClientsForTransactions(
+    algodNetwork
+  );
+  const res = await algod.sendRawTransaction(signed).do();
+  return res.txid;
+}
+
+export { encodeSignerTxnsForWallet, fromAtomic as formatLiquidityAtomic };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -23,4 +23,8 @@ interface ImportMetaEnv {
   readonly VITE_ENABLE_AGENT_CLAIM?: string;
   /** When `true` or `1`, skip NFT holder eligibility checks before pay-agent (dev/staging only). */
   readonly VITE_BYPASS_AGENT_CLAIM_ELIGIBILITY?: string;
+  /** When `false` or `0`, hide the Liquidity Pools page. */
+  readonly VITE_ENABLE_POOLS?: string;
+  /** When `true` or `1`, show Deposit / Withdraw LP actions on pool cards (Supply / Withdraw always shown). */
+  readonly VITE_ENABLE_POOL_DEPOSIT_WITHDRAW?: string;
 }


### PR DESCRIPTION
## Summary

- Add a **Pools** page for curated Tinyman v2 LP pairs on Algorand mainnet: view pool stats, supply LP into nt200 lending markets, and withdraw (platform nt200 or direct Tinyman burn when enabled via `VITE_ENABLE_POOL_DEPOSIT_WITHDRAW`).
- Register **pool C** and **TMPOOL2** LP tokens in prod config, hide C-pool rows from the Markets table, and wire pool cards to `PoolLendingModals` / `PoolLiquidityModal`.
- Fix **LP USD display** in pool supply/withdraw modals by using `usdPerTokenFromMarketInfoPrice` instead of the incorrect `decScale` formula (~1e6 inflation for 6-decimal LP tokens).
- Add an **Admin Tools** card to load `get_global_user` per lending pool (or all pools) with raw collateral/borrow, USD totals, and health factor.

## Test plan

- [ ] On Algorand mainnet, open **Pools** and confirm listed pairs load snapshots and balances.
- [ ] **Supply** LP from wallet into a pool’s nt200 market; confirm balance updates after confirmation.
- [ ] **Withdraw** supplied LP via lending withdraw modal; confirm token amounts and **USD values** look reasonable (not millions of dollars for small balances).
- [ ] With `VITE_ENABLE_POOL_DEPOSIT_WITHDRAW=true`, test wallet LP deposit/withdraw (Tinyman burn) and underlying asset quote on withdraw.
- [ ] Confirm pool C / TMPOOL2 markets do not appear as duplicate rows on the Markets page.
- [ ] Admin → Tools: load global user data for a known address (single pool and all pools).
- [ ] Note: `Governance.tsx` includes a temporary `console.log` for voter info debugging — remove before merge if unintended.


Made with [Cursor](https://cursor.com)