### PR TITLE
Enable WAD/UNIT pool lending supply and withdraw on Pools page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.770",
+  "version": "0.1.771",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constants/__tests__/liquidityPools.test.ts
+++ b/src/constants/__tests__/liquidityPools.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURATED_LIQUIDITY_POOLS,
+  pairHasPoolsPageLendingPosition,
+  pairHasWadLpLendingMarket,
+  resolvePoolsPageLendingMarket,
+} from "@/constants/liquidityPools";
+
+const NETWORK = "algorand-mainnet" as const;
+const POOL_C = "3578814346";
+const LP_WAD_UNIT = "3577783311";
+
+function pairById(id: string) {
+  const pair = CURATED_LIQUIDITY_POOLS.find((p) => p.id === id);
+  if (!pair) throw new Error(`Missing curated pair: ${id}`);
+  return pair;
+}
+
+describe("resolvePoolsPageLendingMarket", () => {
+  it("resolves UNIT LP collateral pairs (UNIT/ALGO, UNIT/goBTC)", () => {
+    for (const id of ["unit-algo", "unit-gobtc"]) {
+      const pair = pairById(id);
+      expect(pairHasPoolsPageLendingPosition(NETWORK, pair)).toBe(true);
+      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toMatchObject({
+        poolId: POOL_C,
+        configSymbol: expect.stringMatching(/^LP_TMPOOL2_UNIT_/),
+      });
+    }
+  });
+
+  it("resolves WAD/UNIT via WAD LP market (not UNIT collateral)", () => {
+    const pair = pairById("wad-unit");
+    expect(pairHasPoolsPageLendingPosition(NETWORK, pair)).toBe(false);
+    expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(true);
+    expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toEqual({
+      configSymbol: "LP_TMPOOL2_WAD_UNIT",
+      poolId: POOL_C,
+      marketId: LP_WAD_UNIT,
+      displaySymbol: "TMPOOL2",
+      displayName: "TinymanPool2.0 WAD-UNIT",
+      logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_UNIT.png",
+      decimals: 6,
+      assetId: "3334546641",
+    });
+  });
+
+  it("returns null for WAD pairs without configured LP_TMPOOL2_WAD_* markets", () => {
+    for (const id of ["wad-usdc", "wad-gobtc", "wad-goeth", "wad-algo"]) {
+      const pair = pairById(id);
+      expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(false);
+      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toBeNull();
+    }
+  });
+});

--- a/src/constants/liquidityPools.ts
+++ b/src/constants/liquidityPools.ts
@@ -361,12 +361,15 @@ export function pairHasPoolsPageLendingPosition(
   return pairHasUnitLpLendingMarket(networkId, pair);
 }
 
-/** Lending market row for Pools page supply/withdraw (UNIT→WAD association only). */
+/** Lending market row for Pools page supply/withdraw (UNIT LP collateral or WAD LP markets). */
 export function resolvePoolsPageLendingMarket(
   networkId: NetworkId,
   pair: LiquidityPoolPairConfig
 ): LiquidityPoolLendingMarket | null {
-  if (!pairHasPoolsPageLendingPosition(networkId, pair)) return null;
+  const hasLending =
+    pairHasPoolsPageLendingPosition(networkId, pair) ||
+    pairHasWadLpLendingMarket(networkId, pair);
+  if (!hasLending) return null;
   return resolveLiquidityPoolLendingMarket(networkId, pair);
 }
 


### PR DESCRIPTION
## Summary
- Extend `resolvePoolsPageLendingMarket` to include WAD LP markets (`LP_TMPOOL2_WAD_*`), not only UNIT LP collateral pairs
- Fixes WAD/UNIT pool card missing Supply/Withdraw actions despite `LP_TMPOOL2_WAD_UNIT` being configured on Pool C
- Add unit tests covering UNIT collateral pairs, WAD/UNIT resolution, and unconfigured WAD pairs

## Test plan
- [x] `npm test -- src/constants/__tests__/liquidityPools.test.ts`
- [ ] On Pools page (Algorand mainnet), confirm WAD/UNIT card shows Supply/Withdraw when wallet holds LP or has supplied balance
- [ ] Confirm UNIT/ALGO and UNIT/goBTC pool cards still show Supply/Withdraw as before
- [ ] Confirm other WAD pairs without `LP_TMPOOL2_WAD_*` config still omit lending actions


Made with [Cursor](https://cursor.com)