### PR TITLE
fix: mobile market filters not applying on Android Chrome (#412)

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -3817,6 +3817,7 @@ const MarketsTable = () => {
             </div>
           ) : (
             <MarketsTableContent
+              marketFilter={marketFilter}
               markets={markets}
               sortField={sortField}
               sortOrder={sortOrder}

--- a/src/components/markets/MarketsTierFilter.tsx
+++ b/src/components/markets/MarketsTierFilter.tsx
@@ -130,6 +130,7 @@ const MarketsTierFilter = ({
               aria-label={o.label}
               title={o.description}
               onClick={() => onChange(o.value)}
+              style={{ touchAction: "manipulation" }}
               className={cn(
                 "inline-flex shrink-0 items-center justify-center font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-teal/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 isLetterOnly


### PR DESCRIPTION
## Problem

Closes #412

On Android Chrome, tapping the A/B/D market filter buttons visually highlights the selected filter but does not update the displayed market list.

## Root Cause

Two bugs found:

### 1. Touch event conflict with `overflow-x-auto` (primary)

In `MarketsTierFilter.tsx`, filter buttons on mobile are wrapped in an `overflow-x-auto` container. On Android Chrome, this causes the browser's touch handler to be ambiguous — it can't immediately tell if the gesture is a horizontal scroll or a tap. Without explicit `touch-action` CSS, Chrome can delay or suppress the `onClick` event entirely.

The visual state (button highlight) can still update, giving the false impression that the filter registered, while the `onChange` callback never fires reliably.

**Fix:** Added `style={{ touchAction: 'manipulation' }}` to each filter button. This tells Chrome the element is a tap target, not a scroll handle — `onClick` fires immediately without delay or cancellation.

### 2. `marketFilter` prop not passed to `MarketsTableContent` (secondary)

`MarketsTable` renders `MarketsTableContent` without the `marketFilter` prop, so `MarketCardView` (the mobile card layout) always receives `key="all"` and never force-remounts when the filter changes. The data IS correctly filtered via the hook's `paginatedData`, but the intended remount-on-filter behavior is broken.

**Fix:** Pass `marketFilter={marketFilter}` from `MarketsTable` to `MarketsTableContent`.

## Changes

- `MarketsTierFilter.tsx`: Add `touch-action: manipulation` to filter buttons
- `MarketsTable.tsx`: Pass `marketFilter` prop to `MarketsTableContent`

## Testing

- [ ] Android Chrome: tap A/B/D filters — market list updates correctly
- [ ] iOS Safari: tap A/B/D filters — market list updates correctly
- [ ] Desktop: filter behavior unchanged
- [ ] All filter combinations work (A→B, B→D, D→all, etc.)