### PR TITLE
Add Pool E WAD LP markets and enable WAD/UNIT pool lending actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.772",
+  "version": "0.1.773",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.770",
+  "version": "0.1.771",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.771",
+  "version": "0.1.772",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/pools/PoolsWadBorrowSection.tsx
+++ b/src/components/pools/PoolsWadBorrowSection.tsx
@@ -123,6 +123,8 @@ async function fetchWadBorrowMarketInfo(
 interface PoolsWadBorrowSectionProps {
   networkId: NetworkId;
   wadMarket: TokenConfig;
+  /** Collateral type shown in copy (e.g. UNIT LP on Pool C, WAD LP on Pool E). */
+  collateralLabel?: string;
   summary: PoolsLendingGlobalSummary | null;
   canBorrow: boolean;
   onBorrowSuccess?: () => void;
@@ -237,10 +239,11 @@ function marketInfoToAssetData(
   };
 }
 
-/** Borrow WAD from the pair market and deposit into the best WAD supply APY (UNIT filter). */
+/** Borrow WAD from the pair market and deposit into the best WAD supply APY. */
 const PoolsWadBorrowSection = ({
   networkId,
   wadMarket,
+  collateralLabel = "UNIT LP",
   summary,
   canBorrow,
   onBorrowSuccess,
@@ -536,8 +539,8 @@ const PoolsWadBorrowSection = ({
                 <p className="text-sm font-semibold text-foreground">WAD lending</p>
               </div>
               <p className="text-xs text-muted-foreground mt-0.5 max-w-xl">
-                Borrow WAD from the Pool {poolLabel} market against your UNIT LP
-                collateral, then deposit into the best WAD supply APY
+                Borrow WAD from the Pool {poolLabel} market against your{" "}
+                {collateralLabel} collateral, then deposit into the best WAD supply APY
                 {bestDepositTarget ? ` on Pool ${bestDepositTarget.poolLabel}` : ""}.
               </p>
             </div>
@@ -637,7 +640,7 @@ const PoolsWadBorrowSection = ({
 
         {!canBorrow ? (
           <p className="mt-3 text-xs text-muted-foreground">
-            Supply UNIT LP to the platform on any pool below to borrow WAD.
+            Supply {collateralLabel} to the platform on any pool below to borrow WAD.
           </p>
         ) : null}
         {!activeAccount?.address ? (

--- a/src/config/__tests__/lendingPoolByMarketContract.test.ts
+++ b/src/config/__tests__/lendingPoolByMarketContract.test.ts
@@ -3,24 +3,32 @@ import {
   getLendingPoolIdForMarketContract,
   getPoolCMarketContractIds,
   getPoolCLendingPoolId,
+  getPoolELendingPoolId,
   getUnitLendingCollateralContractIds,
   getUnitLendingWadBorrowMarketConfig,
   getUnitLendingWadBorrowMarketRef,
+  getWadLpLendingCollateralContractIds,
+  getWadLpLendingWadBorrowMarketConfig,
+  getWadLpLendingWadBorrowMarketRef,
   getWadSupplyMarketConfigsExcludingPoolCBorrow,
   isPoolCMarketContract,
   isUnitLpCollateralMarketContract,
+  isWadLpCollateralMarketContract,
 } from "@/config";
 
 const POOL_C = "3578814346";
+const POOL_E = "3585829377";
 const WAD_STOKEN = "3333688448";
 const WAD_NTOKEN_POOL_C = "3583297246";
+const WAD_NTOKEN_POOL_E = "3585972631";
 const LP_UNIT_ALGO = "3577729953";
 const LP_UNIT_GOBTC = "3577777819";
 const LP_WAD_UNIT = "3577783311";
 
 describe("LENDING_POOL_BY_MARKET_CONTRACT", () => {
-  it("returns Pool C id for algorand-mainnet", () => {
+  it("returns Pool C and Pool E ids for algorand-mainnet", () => {
     expect(getPoolCLendingPoolId("algorand-mainnet")).toBe(POOL_C);
+    expect(getPoolELendingPoolId("algorand-mainnet")).toBe(POOL_E);
   });
 
   it("maps WAD SToken and TMPOOL2 nt200 contracts to Pool C", () => {
@@ -52,6 +60,33 @@ describe("LENDING_POOL_BY_MARKET_CONTRACT", () => {
     expect(getPoolCMarketContractIds("algorand-mainnet").sort()).toEqual(
       [WAD_STOKEN, LP_UNIT_ALGO, LP_UNIT_GOBTC, LP_WAD_UNIT].sort()
     );
+  });
+
+  it("points WAD LP collateral at WAD @ Pool E (tokens.WAD row)", () => {
+    expect(getWadLpLendingWadBorrowMarketRef("algorand-mainnet")).toEqual({
+      poolId: POOL_E,
+      contractId: WAD_STOKEN,
+      nTokenId: WAD_NTOKEN_POOL_E,
+      configKey: "WAD",
+    });
+
+    const wadMarket = getWadLpLendingWadBorrowMarketConfig("algorand-mainnet");
+    expect(wadMarket).toMatchObject({
+      poolId: POOL_E,
+      contractId: WAD_STOKEN,
+      nTokenId: WAD_NTOKEN_POOL_E,
+      symbol: "WAD",
+    });
+  });
+
+  it("maps Pool E WAD TMPOOL2 nt200 contracts to Pool E", () => {
+    for (const contractId of getWadLpLendingCollateralContractIds(
+      "algorand-mainnet"
+    )) {
+      expect(
+        getLendingPoolIdForMarketContract("algorand-mainnet", contractId)
+      ).toBe(POOL_E);
+    }
   });
 });
 

--- a/src/config/__tests__/marketsTableExclusion.test.ts
+++ b/src/config/__tests__/marketsTableExclusion.test.ts
@@ -5,18 +5,27 @@ import {
 } from "@/config";
 
 const POOL_C = "3578814346";
+const POOL_E = "3585829377";
 
 describe("markets table Pool C exclusion", () => {
-  it("excludes entire Pool C at pool level", () => {
+  it("excludes Pool C and Pool E at pool level", () => {
     expect(isMarketsTableExcludedPool("algorand-mainnet", POOL_C)).toBe(true);
+    expect(isMarketsTableExcludedPool("algorand-mainnet", POOL_E)).toBe(true);
   });
 
-  it("hides Pool C LP markets from the table", () => {
+  it("hides Pool C and Pool E LP markets from the table", () => {
     expect(
       isMarketsTableExcludedMarket(
         "algorand-mainnet",
         POOL_C,
         "LP_TMPOOL2_UNIT_ALGO"
+      )
+    ).toBe(true);
+    expect(
+      isMarketsTableExcludedMarket(
+        "algorand-mainnet",
+        POOL_E,
+        "LP_TMPOOL2_WAD_ALGO"
       )
     ).toBe(true);
   });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2104,10 +2104,11 @@ const algorandMainnetPrefiConfig: NetworkConfig = {
   contracts: algorandPrefiContracts,
   tokens: algorandPrefiTokens,
 };
-const algorandProdAMarket = "3333688282";
-const algorandProdBMarket = "3345940978";
-const algorandProdCMarket = "3578814346";
-const algorandProdDMarket = "3526240577";
+const algorandProdAMarket = "3333688282"; // A Prime
+const algorandProdBMarket = "3345940978"; // B Sub-prime
+const algorandProdCMarket = "3578814346"; // C UNIT Pair LPs
+const algorandProdDMarket = "3526240577"; // D Folks Markets
+const algorandProdEMarket = "3585829377"; // C WAD Pair LPs
 const algorandProdPriceOracle = "3333688500";
 const algorandProdLiquidationEngine = undefined;
 const algorandProdGovernance = {
@@ -2129,6 +2130,11 @@ const algorandProdLendingPools = [
   algorandProdBMarket,
   algorandProdCMarket,
   algorandProdDMarket,
+  algorandProdEMarket,
+];
+const algorandProdCLendingPools = [
+  algorandProdCMarket,
+  algorandProdEMarket,
 ];
 const algorandProdContracts: ContractConfig = {
   lendingPools: algorandProdLendingPools,
@@ -3082,6 +3088,74 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
     logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_UNIT.png",
     tokenStandard: "asa",
     dataAddedAt: "2026-05-29T00:00:00.000Z",
+  },
+  // TMPOOL2 3346320836 6 3578405588
+  // name: "TinymanPool2.0 WAD-ALGO",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3578405588
+  LP_TMPOOL2_WAD_ALGO: {
+    assetId: "3346320836",
+    contractId: "3578405588",
+    poolId: "3585829377",
+    nTokenId: "3585842159",
+    decimals: 6,
+    name: "TinymanPool2.0 WAD-ALGO",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_ALGO.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-06-03T00:00:00.000Z",
+  },
+  // TMPOOL2 3334448440 6 3577799583
+  // name: "TinymanPool2.0 WAD-USDC",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3577799583
+  LP_TMPOOL2_WAD_USDC: {
+    assetId: "3334448440",
+    contractId: "3577799583",
+    poolId: "3585829377",
+    nTokenId: "3585878192",
+    decimals: 6,
+    name: "TinymanPool2.0 WAD-USDC",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_USDC.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-06-03T00:00:00.000Z",
+  },
+  // TMPOOL2 3495913115 6 3578394082
+  // name: "TinymanPool2.0 WAD-goETH",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3578394082
+  LP_TMPOOL2_WAD_GOETH: {
+    assetId: "3495913115",
+    contractId: "3578394082",
+    poolId: "3585829377",
+    nTokenId: "3585888277",
+    decimals: 6,
+    name: "TinymanPool2.0 WAD-goETH",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_GOETH.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-06-03T00:00:00.000Z",
+  },
+  // TMPOOL2 3355755995 6 3578387558
+  // name: "TinymanPool2.0 WAD-goBTC",
+  // symbol: "TMPOOL2",
+  // decimals: 6,
+  // contractId: 3578387558
+  LP_TMPOOL2_WAD_GOBTC: {
+    assetId: "3355755995",
+    contractId: "3578387558",
+    poolId: "3585829377",
+    nTokenId: "3585917646",
+    decimals: 6,
+    name: "TinymanPool2.0 WAD-goBTC",
+    symbol: "TMPOOL2",
+    logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_GOBTC.png",
+    tokenStandard: "asa",
+    dataAddedAt: "2026-06-03T00:00:00.000Z",
   },
 };
 const algorandMainnetProdConfig: NetworkConfig = {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3036,6 +3036,18 @@ const algorandProdTokens: { [symbol: string]: TokenConfig | TokenConfig[] } = {
       logoPath: "/lovable-uploads/WAD_fixed.png",
       tokenStandard: "arc200-exchange",
       dataAddedAt: "2026-06-01T00:00:00.000Z",
+    },
+    {
+      assetId: "3334160924",
+      contractId: "3333688448",
+      poolId: "3585829377",
+      nTokenId: "3585972631",
+      decimals: 6,
+      name: "WAD",
+      symbol: "WAD",
+      logoPath: "/lovable-uploads/WAD_fixed.png",
+      tokenStandard: "arc200-exchange",
+      dataAddedAt: "2026-06-03T00:00:00.000Z",
     }
   ],
   // TMPOOL2 3157974960 6 3577729953
@@ -3456,6 +3468,7 @@ export const marketLabelMap: Record<string, string> = {
   "algorand-mainnet-3578814346": "C",
   /** Third prod lending pool (array order is A, B, C, D). */
   "algorand-mainnet-3526240577": "D",
+  "algorand-mainnet-3585829377": "E",
 };
 
 /**
@@ -3627,17 +3640,17 @@ export const getLendingPoolLabel = (
 /**
  * Lending pools whose LP nt200 markets are omitted from the Markets table
  * (still in config for Pools page, Admin, etc.).
- * Algorand prod C pool holds Tinyman LP markets — surfaced on the Pools page instead.
+ * Algorand prod C/E pools hold Tinyman LP markets — surfaced on the Pools page instead.
  */
 const MARKETS_TABLE_EXCLUDED_POOL_IDS: Partial<
   Record<NetworkId, readonly string[]>
 > = {
-  "algorand-mainnet": [algorandProdCMarket],
+  "algorand-mainnet": [algorandProdCMarket, algorandProdEMarket],
 };
 
 /**
  * Lending pool app id for an nt200 / underlying market contract.
- * Pool C TMPOOL2 + WAD rows are indexed here so Pools / portfolio can resolve
+ * Pool C/E TMPOOL2 + WAD rows are indexed here so Pools / portfolio can resolve
  * `contractId → poolId` without scanning `tokens`.
  */
 const LENDING_POOL_BY_MARKET_CONTRACT: Partial<
@@ -3648,6 +3661,10 @@ const LENDING_POOL_BY_MARKET_CONTRACT: Partial<
     "3577729953": algorandProdCMarket,
     "3577777819": algorandProdCMarket,
     "3577783311": algorandProdCMarket,
+    "3578405588": algorandProdEMarket,
+    "3577799583": algorandProdEMarket,
+    "3578394082": algorandProdEMarket,
+    "3578387558": algorandProdEMarket,
   },
 };
 
@@ -3669,7 +3686,7 @@ const UNIT_LENDING_COLLATERAL_CONTRACT_IDS: Partial<
   "algorand-mainnet": ["3577729953", "3577777819"],
 };
 
-/** WAD borrow market for UNIT LP lending on Pool C (`algorandProdTokens.WAD[1]`). */
+/** WAD borrow market for UNIT LP lending on Pool C (`algorandProdTokens.WAD` Pool C row). */
 const UNIT_LENDING_WAD_BORROW_MARKET: Partial<
   Record<NetworkId, UnitLendingWadBorrowMarketRef>
 > = {
@@ -3677,6 +3694,36 @@ const UNIT_LENDING_WAD_BORROW_MARKET: Partial<
     poolId: algorandProdCMarket,
     contractId: algorandProdSToken,
     nTokenId: "3583297246",
+    configKey: "WAD",
+  },
+};
+
+/** WAD borrow market on Pool E paired with WAD-base TMPOOL2 collateral. */
+export type WadLpLendingWadBorrowMarketRef = UnitLendingWadBorrowMarketRef;
+
+/**
+ * WAD LP nt200 collateral markets on Pool E that borrow against
+ * {@link WAD_LP_LENDING_WAD_BORROW_MARKET} (WAD @ pool 3585829377).
+ */
+const WAD_LP_LENDING_COLLATERAL_CONTRACT_IDS: Partial<
+  Record<NetworkId, readonly string[]>
+> = {
+  "algorand-mainnet": [
+    "3578405588",
+    "3577799583",
+    "3578394082",
+    "3578387558",
+  ],
+};
+
+/** WAD borrow market for WAD LP lending on Pool E (`algorandProdTokens.WAD` Pool E row). */
+const WAD_LP_LENDING_WAD_BORROW_MARKET: Partial<
+  Record<NetworkId, WadLpLendingWadBorrowMarketRef>
+> = {
+  "algorand-mainnet": {
+    poolId: algorandProdEMarket,
+    contractId: algorandProdSToken,
+    nTokenId: "3585972631",
     configKey: "WAD",
   },
 };
@@ -3709,14 +3756,13 @@ export function getUnitLendingWadBorrowMarketRef(
   return UNIT_LENDING_WAD_BORROW_MARKET[networkId as NetworkId] ?? null;
 }
 
-/** Resolve WAD borrow {@link TokenConfig} for Pool C UNIT LP lending. */
-export function getUnitLendingWadBorrowMarketConfig(
-  networkId: NetworkId | string | null | undefined
+function resolveWadBorrowMarketConfigFromRef(
+  networkId: NetworkId,
+  ref: UnitLendingWadBorrowMarketRef | null
 ): TokenConfig | null {
-  const ref = getUnitLendingWadBorrowMarketRef(networkId);
-  if (!ref || !networkId) return null;
+  if (!ref) return null;
 
-  const wadToken = getNetworkConfig(networkId as NetworkId).tokens?.WAD;
+  const wadToken = getNetworkConfig(networkId).tokens?.WAD;
   const configs: TokenConfig[] = Array.isArray(wadToken)
     ? wadToken
     : wadToken
@@ -3733,12 +3779,65 @@ export function getUnitLendingWadBorrowMarketConfig(
   );
 }
 
-/** WAD deposit markets on other pools (excludes Pool C borrow row and sToken mint rows). */
+/** Resolve WAD borrow {@link TokenConfig} for Pool C UNIT LP lending. */
+export function getUnitLendingWadBorrowMarketConfig(
+  networkId: NetworkId | string | null | undefined
+): TokenConfig | null {
+  if (!networkId) return null;
+  return resolveWadBorrowMarketConfigFromRef(
+    networkId as NetworkId,
+    getUnitLendingWadBorrowMarketRef(networkId)
+  );
+}
+
+/** nt200 contract ids for WAD TMPOOL2 collateral markets on Pool E. */
+export function getWadLpLendingCollateralContractIds(
+  networkId: NetworkId | string | null | undefined
+): readonly string[] {
+  if (!networkId) return [];
+  return WAD_LP_LENDING_COLLATERAL_CONTRACT_IDS[networkId as NetworkId] ?? [];
+}
+
+/** True when `marketContractId` is a WAD LP collateral market on Pool E. */
+export function isWadLpCollateralMarketContract(
+  networkId: NetworkId | string | null | undefined,
+  marketContractId: string | number | null | undefined
+): boolean {
+  if (marketContractId == null || String(marketContractId) === "") return false;
+  const id = String(marketContractId);
+  return getWadLpLendingCollateralContractIds(networkId).some(
+    (contractId) => contractId === id
+  );
+}
+
+/** Pool E WAD borrow market ref paired with WAD LP collateral. */
+export function getWadLpLendingWadBorrowMarketRef(
+  networkId: NetworkId | string | null | undefined
+): WadLpLendingWadBorrowMarketRef | null {
+  if (!networkId) return null;
+  return WAD_LP_LENDING_WAD_BORROW_MARKET[networkId as NetworkId] ?? null;
+}
+
+/** Resolve WAD borrow {@link TokenConfig} for Pool E WAD LP lending. */
+export function getWadLpLendingWadBorrowMarketConfig(
+  networkId: NetworkId | string | null | undefined
+): TokenConfig | null {
+  if (!networkId) return null;
+  return resolveWadBorrowMarketConfigFromRef(
+    networkId as NetworkId,
+    getWadLpLendingWadBorrowMarketRef(networkId)
+  );
+}
+
+/** WAD deposit markets on other pools (excludes TMPOOL collateral borrow rows and sToken mint). */
 export function getWadSupplyMarketConfigsExcludingPoolCBorrow(
   networkId: NetworkId | string | null | undefined
 ): TokenConfig[] {
   if (!networkId) return [];
-  const borrowRef = getUnitLendingWadBorrowMarketRef(networkId);
+  const borrowRefs = [
+    getUnitLendingWadBorrowMarketRef(networkId),
+    getWadLpLendingWadBorrowMarketRef(networkId),
+  ].filter((ref): ref is UnitLendingWadBorrowMarketRef => ref != null);
   const wadToken = getNetworkConfig(networkId as NetworkId).tokens?.WAD;
   const configs: TokenConfig[] = Array.isArray(wadToken)
     ? wadToken
@@ -3748,11 +3847,11 @@ export function getWadSupplyMarketConfigsExcludingPoolCBorrow(
 
   return configs.filter((config) => {
     if (config.isStoken) return false;
-    if (!borrowRef) return true;
-    return !(
-      String(config.poolId) === borrowRef.poolId &&
-      String(config.contractId) === borrowRef.contractId &&
-      String(config.nTokenId) === borrowRef.nTokenId
+    return !borrowRefs.some(
+      (borrowRef) =>
+        String(config.poolId) === borrowRef.poolId &&
+        String(config.contractId) === borrowRef.contractId &&
+        String(config.nTokenId) === borrowRef.nTokenId
     );
   });
 }
@@ -3765,6 +3864,16 @@ export function getPoolCLendingPoolId(
   const excluded = MARKETS_TABLE_EXCLUDED_POOL_IDS[networkId as NetworkId];
   if (!excluded?.length) return null;
   return String(excluded[0]);
+}
+
+/** Lending pool app id for Pool E (WAD-base TMPOOL2 markets) on this network. */
+export function getPoolELendingPoolId(
+  networkId: NetworkId | string | null | undefined
+): string | null {
+  if (!networkId) return null;
+  const excluded = MARKETS_TABLE_EXCLUDED_POOL_IDS[networkId as NetworkId];
+  if (!excluded || excluded.length < 2) return null;
+  return String(excluded[1]);
 }
 
 /** Resolve lending pool app id from nt200 / underlying market `contractId`. */
@@ -3804,8 +3913,8 @@ export function getPoolCMarketContractIds(
     .map(([contractId]) => contractId);
 }
 
-/** Pool C config keys that remain visible on Markets table and portfolio (WAD borrow). */
-const MARKETS_TABLE_POOL_C_VISIBLE_CONFIG_KEYS = new Set(["WAD"]);
+/** Config keys that remain visible on Markets table for excluded TMPOOL pools (WAD borrow). */
+const MARKETS_TABLE_TMPOOL_VISIBLE_CONFIG_KEYS = new Set(["WAD"]);
 
 /** True when the entire lending pool is omitted from the Markets table (before per-market exceptions). */
 export function isMarketsTableExcludedPool(
@@ -3821,7 +3930,7 @@ export function isMarketsTableExcludedPool(
 
 /**
  * True when a configured market row should not appear on the Markets table (or matching portfolio market lists).
- * Pool C LP (`LP_TMPOOL2_*`) stays hidden; WAD on Pool C is the exception and remains visible.
+ * Pool C/E LP (`LP_TMPOOL2_*`) stays hidden; WAD borrow on those pools remains visible.
  */
 export function isMarketsTableExcludedMarket(
   networkId: NetworkId | string | null | undefined,
@@ -3830,7 +3939,7 @@ export function isMarketsTableExcludedMarket(
 ): boolean {
   if (!isMarketsTableExcludedPool(networkId, poolId)) return false;
   const key = configKey?.trim();
-  if (key && MARKETS_TABLE_POOL_C_VISIBLE_CONFIG_KEYS.has(key)) return false;
+  if (key && MARKETS_TABLE_TMPOOL_VISIBLE_CONFIG_KEYS.has(key)) return false;
   return true;
 }
 

--- a/src/constants/__tests__/liquidityPools.test.ts
+++ b/src/constants/__tests__/liquidityPools.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   CURATED_LIQUIDITY_POOLS,
   pairHasPoolsPageLendingPosition,
+  pairHasWadLpCollateralLendingMarket,
   pairHasWadLpLendingMarket,
   resolvePoolsPageLendingMarket,
+  resolveWadLendingPoolIdsForFilter,
 } from "@/constants/liquidityPools";
 
 const NETWORK = "algorand-mainnet" as const;
 const POOL_C = "3578814346";
+const POOL_E = "3585829377";
 const LP_WAD_UNIT = "3577783311";
 
 function pairById(id: string) {
@@ -28,10 +31,11 @@ describe("resolvePoolsPageLendingMarket", () => {
     }
   });
 
-  it("resolves WAD/UNIT via WAD LP market (not UNIT collateral)", () => {
+  it("resolves WAD/UNIT via WAD LP market on Pool C (not UNIT collateral)", () => {
     const pair = pairById("wad-unit");
     expect(pairHasPoolsPageLendingPosition(NETWORK, pair)).toBe(false);
     expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(true);
+    expect(pairHasWadLpCollateralLendingMarket(NETWORK, pair)).toBe(false);
     expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toEqual({
       configSymbol: "LP_TMPOOL2_WAD_UNIT",
       poolId: POOL_C,
@@ -44,11 +48,54 @@ describe("resolvePoolsPageLendingMarket", () => {
     });
   });
 
-  it("returns null for WAD pairs without configured LP_TMPOOL2_WAD_* markets", () => {
-    for (const id of ["wad-usdc", "wad-gobtc", "wad-goeth", "wad-algo"]) {
+  it("resolves Pool E WAD LP pairs (ALGO, USDC, goBTC, goETH)", () => {
+    const expectations: Record<
+      string,
+      { configSymbol: string; marketId: string; assetId: string }
+    > = {
+      "wad-algo": {
+        configSymbol: "LP_TMPOOL2_WAD_ALGO",
+        marketId: "3578405588",
+        assetId: "3346320836",
+      },
+      "wad-usdc": {
+        configSymbol: "LP_TMPOOL2_WAD_USDC",
+        marketId: "3577799583",
+        assetId: "3334448440",
+      },
+      "wad-gobtc": {
+        configSymbol: "LP_TMPOOL2_WAD_GOBTC",
+        marketId: "3578387558",
+        assetId: "3355755995",
+      },
+      "wad-goeth": {
+        configSymbol: "LP_TMPOOL2_WAD_GOETH",
+        marketId: "3578394082",
+        assetId: "3495913115",
+      },
+    };
+
+    for (const [id, expected] of Object.entries(expectations)) {
       const pair = pairById(id);
-      expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(false);
-      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toBeNull();
+      expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(true);
+      expect(pairHasWadLpCollateralLendingMarket(NETWORK, pair)).toBe(true);
+      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toMatchObject({
+        poolId: POOL_E,
+        ...expected,
+      });
     }
+  });
+});
+
+describe("resolveWadLendingPoolIdsForFilter", () => {
+  it("returns Pool E when WAD LP collateral pairs are in the filter", () => {
+    const wadPairs = CURATED_LIQUIDITY_POOLS.filter((p) =>
+      ["wad-algo", "wad-usdc", "wad-gobtc", "wad-goeth", "wad-unit"].includes(
+        p.id
+      )
+    );
+    expect(resolveWadLendingPoolIdsForFilter(NETWORK, wadPairs)).toEqual([
+      POOL_E,
+    ]);
   });
 });

--- a/src/constants/__tests__/liquidityPools.test.ts
+++ b/src/constants/__tests__/liquidityPools.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURATED_LIQUIDITY_POOLS,
+  pairHasPoolsPageLendingPosition,
+  pairHasWadLpLendingMarket,
+  resolvePoolsPageLendingMarket,
+} from "@/constants/liquidityPools";
+
+const NETWORK = "algorand-mainnet" as const;
+const POOL_C = "3578814346";
+const LP_WAD_UNIT = "3577783311";
+
+function pairById(id: string) {
+  const pair = CURATED_LIQUIDITY_POOLS.find((p) => p.id === id);
+  if (!pair) throw new Error(`Missing curated pair: ${id}`);
+  return pair;
+}
+
+describe("resolvePoolsPageLendingMarket", () => {
+  it("resolves UNIT LP collateral pairs (UNIT/ALGO, UNIT/goBTC)", () => {
+    for (const id of ["unit-algo", "unit-gobtc"]) {
+      const pair = pairById(id);
+      expect(pairHasPoolsPageLendingPosition(NETWORK, pair)).toBe(true);
+      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toMatchObject({
+        poolId: POOL_C,
+        configSymbol: expect.stringMatching(/^LP_TMPOOL2_UNIT_/),
+      });
+    }
+  });
+
+  it("resolves WAD/UNIT via WAD LP market (not UNIT collateral)", () => {
+    const pair = pairById("wad-unit");
+    expect(pairHasPoolsPageLendingPosition(NETWORK, pair)).toBe(false);
+    expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(true);
+    expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toEqual({
+      configSymbol: "LP_TMPOOL2_WAD_UNIT",
+      poolId: POOL_C,
+      marketId: LP_WAD_UNIT,
+      displaySymbol: "TMPOOL2",
+      displayName: "TinymanPool2.0 WAD-UNIT",
+      logoPath: "/lovable-uploads/LP_TMPOOL2_WAD_UNIT.png",
+      decimals: 6,
+      assetId: "3334546641",
+    });
+  });
+
+  it("returns null for WAD pairs without configured LP_TMPOOL2_WAD_* markets", () => {
+    for (const id of ["wad-usdc", "wad-gobtc", "wad-goeth", "wad-algo"]) {
+      const pair = pairById(id);
+      expect(pairHasWadLpLendingMarket(NETWORK, pair)).toBe(false);
+      expect(resolvePoolsPageLendingMarket(NETWORK, pair)).toBeNull();
+    }
+  });
+});

--- a/src/constants/liquidityPools.ts
+++ b/src/constants/liquidityPools.ts
@@ -361,12 +361,15 @@ export function pairHasPoolsPageLendingPosition(
   return pairHasUnitLpLendingMarket(networkId, pair);
 }
 
-/** Lending market row for Pools page supply/withdraw (UNIT→WAD association only). */
+/** Lending market row for Pools page supply/withdraw (UNIT LP collateral or WAD LP markets). */
 export function resolvePoolsPageLendingMarket(
   networkId: NetworkId,
   pair: LiquidityPoolPairConfig
 ): LiquidityPoolLendingMarket | null {
-  if (!pairHasPoolsPageLendingPosition(networkId, pair)) return null;
+  const hasLending =
+    pairHasPoolsPageLendingPosition(networkId, pair) ||
+    pairHasWadLpLendingMarket(networkId, pair);
+  if (!hasLending) return null;
   return resolveLiquidityPoolLendingMarket(networkId, pair);
 }
 

--- a/src/constants/liquidityPools.ts
+++ b/src/constants/liquidityPools.ts
@@ -1,10 +1,13 @@
 import {
   getPoolCLendingPoolId,
+  getPoolELendingPoolId,
   getUnitLendingWadBorrowMarketConfig,
+  getWadLpLendingWadBorrowMarketConfig,
   getNetworkConfig,
   getLendingPoolIdForMarketContract,
   getTokenDisplayInfo,
   isUnitLpCollateralMarketContract,
+  isWadLpCollateralMarketContract,
   type NetworkId,
   type TokenConfig,
 } from "@/config";
@@ -324,6 +327,14 @@ export function pairHasUnitLpLendingMarket(
   return isUnitLpCollateralMarketContract(networkId, pair.lpContractId);
 }
 
+/** True when the curated pair supplies WAD LP collateral on Pool E. */
+export function pairHasWadLpCollateralLendingMarket(
+  networkId: NetworkId,
+  pair: LiquidityPoolPairConfig
+): boolean {
+  return isWadLpCollateralMarketContract(networkId, pair.lpContractId);
+}
+
 /** Lending pool app ids for UNIT LP markets among the given curated pairs. */
 export function resolveUnitLendingPoolIdsForPairs(
   networkId: NetworkId,
@@ -350,6 +361,13 @@ export function hasUnitLendingWadBorrowAssociation(
   networkId: NetworkId
 ): boolean {
   return getUnitLendingWadBorrowMarketConfig(networkId) != null;
+}
+
+/** True when WAD LP collateral on Pool E borrows against a configured WAD market. */
+export function hasWadLpLendingWadBorrowAssociation(
+  networkId: NetworkId
+): boolean {
+  return getWadLpLendingWadBorrowMarketConfig(networkId) != null;
 }
 
 /** True when the curated pair shows platform lending on the Pools page. */
@@ -390,6 +408,23 @@ export function resolveUnitLendingPoolIdsForFilter(
   return resolveUnitLendingPoolIdsForPairs(networkId, unitPairs);
 }
 
+/** Pool ids for WAD LP global user reads on the Pools page (Pool E). */
+export function resolveWadLendingPoolIdsForFilter(
+  networkId: NetworkId,
+  filteredPairs: LiquidityPoolPairConfig[]
+): string[] {
+  const wadPairs = filteredPairs.filter(
+    (pair) =>
+      pairHasWadLpLendingMarket(networkId, pair) &&
+      pairHasWadLpCollateralLendingMarket(networkId, pair)
+  );
+  if (wadPairs.length === 0) return [];
+
+  const poolE = getPoolELendingPoolId(networkId);
+  if (poolE) return [poolE];
+  return resolveWadLendingPoolIdsForPairs(networkId, wadPairs);
+}
+
 /** LP lending is enabled for WAD-base Tinyman pairs with configured `LP_TMPOOL2_WAD_*` markets. */
 export function pairHasWadLpLendingMarket(
   networkId: NetworkId,
@@ -422,4 +457,11 @@ export function resolvePoolCWadMarket(
   networkId: NetworkId
 ): TokenConfig | null {
   return getUnitLendingWadBorrowMarketConfig(networkId);
+}
+
+/** WAD borrow market paired with Pool E WAD LP collateral. */
+export function resolvePoolEWadMarket(
+  networkId: NetworkId
+): TokenConfig | null {
+  return getWadLpLendingWadBorrowMarketConfig(networkId);
 }

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -17,7 +17,9 @@ import {
   poolMatchesBaseTokenFilter,
   POOL_BASE_TOKEN_FILTERS,
   resolvePoolCWadMarket,
+  resolvePoolEWadMarket,
   resolveUnitLendingPoolIdsForFilter,
+  resolveWadLendingPoolIdsForFilter,
   type PoolBaseTokenFilterId,
 } from "@/constants/liquidityPools";
 import {
@@ -59,13 +61,20 @@ const PoolsPage = ({ activeTab, onTabChange }: PoolsPageProps) => {
     if (tokenFilter === "unit") {
       return resolveUnitLendingPoolIdsForFilter(networkId, filteredPairs);
     }
+    if (tokenFilter === "wad") {
+      return resolveWadLendingPoolIdsForFilter(networkId, filteredPairs);
+    }
     return [];
   }, [currentNetwork, filteredPairs, tokenFilter]);
   const showLendingGlobalSummary = lendingPoolIds.length > 0;
-  const poolCWadMarket = useMemo(
-    () => resolvePoolCWadMarket(currentNetwork as NetworkId),
-    [currentNetwork]
-  );
+  const poolsWadBorrowMarket = useMemo(() => {
+    const networkId = currentNetwork as NetworkId;
+    if (tokenFilter === "unit") return resolvePoolCWadMarket(networkId);
+    if (tokenFilter === "wad") return resolvePoolEWadMarket(networkId);
+    return null;
+  }, [currentNetwork, tokenFilter]);
+  const wadBorrowCollateralLabel =
+    tokenFilter === "wad" ? "WAD LP" : "UNIT LP";
   const { summary, poolIds, isLoading: lendingGlobalLoading } =
     usePoolsLendingGlobalSummary(
       currentNetwork as NetworkId,
@@ -75,8 +84,8 @@ const PoolsPage = ({ activeTab, onTabChange }: PoolsPageProps) => {
     );
   const canBorrowWad = (summary?.totalCollateralValue ?? 0) > 0;
   const showWadBorrowSection =
-    tokenFilter === "unit" &&
-    poolCWadMarket != null &&
+    (tokenFilter === "unit" || tokenFilter === "wad") &&
+    poolsWadBorrowMarket != null &&
     Boolean(activeAccount?.address);
 
   const invalidateLendingSummary = () => {
@@ -156,10 +165,11 @@ const PoolsPage = ({ activeTab, onTabChange }: PoolsPageProps) => {
                 walletConnected={Boolean(activeAccount?.address)}
               />
             ) : null}
-            {showWadBorrowSection && poolCWadMarket ? (
+            {showWadBorrowSection && poolsWadBorrowMarket ? (
               <PoolsWadBorrowSection
                 networkId={currentNetwork as NetworkId}
-                wadMarket={poolCWadMarket}
+                wadMarket={poolsWadBorrowMarket}
+                collateralLabel={wadBorrowCollateralLabel}
                 summary={summary}
                 canBorrow={canBorrowWad}
                 onBorrowSuccess={invalidateLendingSummary}


### PR DESCRIPTION
## Summary
- Register lending pool E (`3585829377`) for WAD-base Tinyman TMPOOL2 markets and add token configs for `LP_TMPOOL2_WAD_ALGO`, `WAD_USDC`, `WAD_GOETH`, and `WAD_GOBTC`
- Include pool E in the mainnet lending pool list and add a Pool C/E grouping helper with documented pool tier labels (A–E)
- Extend `resolvePoolsPageLendingMarket` so WAD LP markets (e.g. WAD/UNIT) show Supply/Withdraw on the Pools page, not only UNIT LP collateral pairs

## Test plan
- [x] `npm test -- src/constants/__tests__/liquidityPools.test.ts`
- [ ] Confirm WAD/UNIT pool card shows Supply/Withdraw when wallet holds LP or has supplied balance
- [ ] Confirm WAD/ALGO, WAD/USDC, WAD/goBTC, and WAD/goETH pool cards resolve lending markets on Pool E
- [ ] Confirm UNIT/ALGO and UNIT/goBTC pool cards still show Supply/Withdraw on Pool C
- [ ] Verify pool E appears in lending pool contract list for mainnet config


Made with [Cursor](https://cursor.com)