### PR TITLE
Fix broken LP token images in supply modal and portfolio (#473, #474)

### DIFF
--- a/src/components/DepositsList.tsx
+++ b/src/components/DepositsList.tsx
@@ -5,8 +5,8 @@ import { ArrowDown, Info, RefreshCw } from "lucide-react";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import DorkFiButton from "@/components/ui/DorkFiButton";
 import { useNetwork } from "@/contexts/NetworkContext";
-import { getNetworkConfig, getTokenConfig } from "@/config";
-import { marketPoolBadgeBgClassName } from "@/constants/marketUi";
+import { getNetworkConfig, getTokenConfig, type NetworkId } from "@/config";
+import { MarketRowTokenIcon } from "@/components/markets/MarketRowTokenIcon";
 
 interface Deposit {
   asset: string;
@@ -18,6 +18,7 @@ interface Deposit {
   tokenPrice: number;
   poolId?: string;
   network?: string;
+  configSymbol?: string;
   accruedInterest?: number;
   accruedInterestValue?: number;
 }
@@ -82,20 +83,16 @@ const DepositsList = ({ deposits, onDepositClick, onWithdrawClick, onRefresh, is
             >
               {/* Token Icon + Name (column 1) */}
               <div className="flex flex-col items-center gap-1 w-16 sm:w-20">
-                <div className="relative flex-shrink-0">
-                  <img 
-                    src={deposit.icon} 
-                    alt={deposit.asset}
-                    className="w-10 h-10 sm:w-12 sm:h-12 md:w-10 md:h-10 rounded-full"
-                  />
-                  {marketLabel && (
-                    <div className={`absolute -top-1 -right-1 w-5 h-5 rounded-full ${marketPoolBadgeBgClassName(
-                      marketLabel
-                    )} border-2 border-white dark:border-slate-800 flex items-center justify-center`}>
-                      <span className="text-xs font-bold text-white">{marketLabel}</span>
-                    </div>
-                  )}
-                </div>
+                <MarketRowTokenIcon
+                  market={{
+                    icon: deposit.icon,
+                    asset: deposit.asset,
+                  }}
+                  poolLetterLabel={marketLabel}
+                  imgClassName="w-10 h-10 sm:w-12 sm:h-12 md:w-10 md:h-10 rounded-full object-contain"
+                  configSymbol={deposit.configSymbol}
+                  networkId={(deposit.network ?? currentNetwork) as NetworkId}
+                />
                 <div className="font-bold text-base text-slate-800 dark:text-white text-center truncate w-full">{deposit.asset}</div>
               </div>
             {/* $ value, APY, Balances & Price Info (column 2) */}

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -3801,6 +3801,7 @@ const MarketsTable = () => {
               }}
               hasActiveFilters={hasActiveFilters}
               onClearAll={clearAllMarketFilters}
+              filteredMarketCount={isMobile ? totalItems : undefined}
             />
           </div>
 
@@ -3817,6 +3818,7 @@ const MarketsTable = () => {
             </div>
           ) : (
             <MarketsTableContent
+              marketFilter={isMobile ? marketFilter : undefined}
               markets={markets}
               sortField={sortField}
               sortOrder={sortOrder}

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -7411,6 +7411,13 @@ const Portfolio = () => {
                                           depositMarketLabel ?? null
                                         }
                                         imgClassName="w-8 h-8 shrink-0 rounded-full object-contain"
+                                        configSymbol={
+                                          (deposit as ItemWithNetwork).configSymbol
+                                        }
+                                        networkId={
+                                          ((deposit as ItemWithNetwork).network ??
+                                            currentNetwork) as NetworkId
+                                        }
                                       />
                                       <span className="font-medium truncate text-center">
                                         {deposit.asset}
@@ -8146,6 +8153,13 @@ const Portfolio = () => {
                                             }}
                                             poolLetterLabel={marketLabel}
                                             imgClassName="h-6 w-6 shrink-0 rounded-full object-contain"
+                                            configSymbol={
+                                              (asset as ItemWithNetwork).configSymbol
+                                            }
+                                            networkId={
+                                              ((asset as ItemWithNetwork).network ??
+                                                currentNetwork) as NetworkId
+                                            }
                                           />
                                           <span className="font-medium">
                                             {asset.asset}
@@ -9154,6 +9168,13 @@ const Portfolio = () => {
                                           borrowMarketLabel ?? null
                                         }
                                         imgClassName="w-8 h-8 shrink-0 rounded-full object-contain"
+                                        configSymbol={
+                                          (borrow as ItemWithNetwork).configSymbol
+                                        }
+                                        networkId={
+                                          ((borrow as ItemWithNetwork).network ??
+                                            currentNetwork) as NetworkId
+                                        }
                                       />
                                       <span className="font-medium truncate text-center">
                                         {borrow.asset}
@@ -9909,6 +9930,13 @@ const Portfolio = () => {
                                           accruedMarketLabel ?? null
                                         }
                                         imgClassName="w-8 h-8 shrink-0 rounded-full object-contain"
+                                        configSymbol={
+                                          (item as ItemWithNetwork).configSymbol
+                                        }
+                                        networkId={
+                                          ((item as ItemWithNetwork).network ??
+                                            currentNetwork) as NetworkId
+                                        }
                                       />
                                       <span className="font-medium truncate text-center">
                                         {item.asset}
@@ -10178,6 +10206,13 @@ const Portfolio = () => {
                           }}
                           poolLetterLabel={null}
                           imgClassName="h-6 w-6 shrink-0 rounded-full object-contain"
+                          configSymbol={
+                            (borrow as ItemWithNetwork).configSymbol
+                          }
+                          networkId={
+                            ((borrow as ItemWithNetwork).network ??
+                              currentNetwork) as NetworkId
+                          }
                         />
                         <div>
                           <div className="text-sm font-medium text-red-400">

--- a/src/components/SupplyBorrowCongrats.tsx
+++ b/src/components/SupplyBorrowCongrats.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { CheckCircle2, Sparkles } from "lucide-react";
 import DorkFiButton from "@/components/ui/DorkFiButton";
+import LpPairIconStack from "@/components/pools/LpPairIconStack";
+import { handleTokenImageError } from "@/utils/tokenImageUtils";
 
 interface SupplyBorrowCongratsProps {
   transactionType: "deposit" | "borrow" | "withdraw" | "repay";
@@ -13,6 +15,8 @@ interface SupplyBorrowCongratsProps {
   onClose: () => void;
   /** When true, disables “View transaction” (e.g. no tx id yet). */
   viewTransactionDisabled?: boolean;
+  /** Underlying pair icons for Tinyman LP tokens (preferred over `assetIcon`). */
+  assetPairIcons?: { asset1Icon: string; asset2Icon: string };
 }
 
 const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
@@ -25,6 +29,7 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
   onMakeAnother,
   onClose,
   viewTransactionDisabled = false,
+  assetPairIcons,
 }) => {
   const getTransactionMessage = () => {
     switch (transactionType) {
@@ -43,6 +48,25 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
 
   const { action, preposition } = getTransactionMessage();
 
+  const assetIconNode =
+    assetPairIcons?.asset1Icon && assetPairIcons?.asset2Icon ? (
+      <LpPairIconStack
+        asset1Icon={assetPairIcons.asset1Icon}
+        asset2Icon={assetPairIcons.asset2Icon}
+        fallbackIcon={assetIcon}
+        alt={asset}
+        size="xl"
+        className="mt-[-30px] rounded-xl border-4 border-whale-gold bg-bubble-white dark:bg-slate-800 p-2 shadow-md mx-auto"
+      />
+    ) : (
+      <img
+        src={assetIcon}
+        alt={`${asset} icon`}
+        className="mt-[-30px] w-32 h-32 rounded-xl shadow-md border-4 border-whale-gold mx-auto bg-bubble-white dark:bg-slate-800 object-cover"
+        onError={handleTokenImageError}
+      />
+    );
+
   return (
     <div className="flex flex-col items-center justify-center gap-4 animate-fade-in">
       {/* Confetti & Sparkles */}
@@ -50,11 +74,7 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
         <Sparkles className="absolute -top-3 -left-3 text-whale-gold w-7 h-7 animate-bounce" />
         <Sparkles className="absolute -top-3 -right-3 text-highlight-aqua w-7 h-7 animate-bounce animation-delay-300" />
         <CheckCircle2 className="w-16 h-16 text-green-500 drop-shadow-xl bg-white dark:bg-slate-800 rounded-full p-1 border-4 border-whale-gold z-10" />
-        <img
-          src={assetIcon}
-          alt={`${asset} icon`}
-          className="mt-[-30px] w-32 h-32 rounded-xl shadow-md border-4 border-whale-gold mx-auto bg-bubble-white dark:bg-slate-800 object-cover"
-        />
+        {assetIconNode}
       </div>
 
       <h2 className="text-xl font-bold text-center mb-1">
@@ -78,14 +98,6 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
         >
           View Transaction
         </DorkFiButton>
-
-        {/*<DorkFiButton
-          variant="secondary"
-          className="w-full border-ocean-teal text-ocean-teal dark:border-whale-gold dark:text-whale-gold"
-          onClick={onGoToPortfolio}
-        >
-          Go to Portfolio
-        </DorkFiButton>*/}
 
         <DorkFiButton
           variant="secondary"

--- a/src/components/SupplyBorrowHeader.tsx
+++ b/src/components/SupplyBorrowHeader.tsx
@@ -1,5 +1,6 @@
 
 import LpPairIconStack from "@/components/pools/LpPairIconStack";
+import { handleTokenImageError } from "@/utils/tokenImageUtils";
 
 interface SupplyBorrowHeaderProps {
   mode: "deposit" | "borrow";
@@ -33,6 +34,7 @@ const SupplyBorrowHeader = ({
             src={assetIcon}
             alt={asset}
             className="w-10 h-10 rounded-full"
+            onError={handleTokenImageError}
           />
         )}
         <span className="text-xl font-bold text-slate-800 dark:text-white">{asset}</span>

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -3284,6 +3284,7 @@ const SupplyBorrowModal = ({
               transactionType={mode}
               asset={asset}
               assetIcon={assetData.icon}
+              assetPairIcons={assetPairIcons}
               amount={amount}
               onViewTransaction={handleViewTransaction}
               onGoToPortfolio={handleGoToPortfolio}

--- a/src/components/WithdrawModal.tsx
+++ b/src/components/WithdrawModal.tsx
@@ -1297,6 +1297,7 @@ const WithdrawModal = ({
                   : tokenSymbol
               }
               assetIcon={tokenIcon}
+              assetPairIcons={tokenPairIcons}
               amount={amount !== "" ? amount.toString() : ""}
               onViewTransaction={handleViewTransaction}
               onGoToPortfolio={handleGoToPortfolio}

--- a/src/components/markets/MarketRowTokenIcon.tsx
+++ b/src/components/markets/MarketRowTokenIcon.tsx
@@ -1,5 +1,9 @@
 import type { OnDemandMarketData } from "@/hooks/useOnDemandMarketData";
 import { marketPoolBadgeBgClassName } from "@/constants/marketUi";
+import LpPairIconStack from "@/components/pools/LpPairIconStack";
+import type { NetworkId } from "@/config";
+import { resolveLpTokenPairIcons } from "@/utils/lpTokenIconUtils";
+import { handleTokenImageError } from "@/utils/tokenImageUtils";
 
 export type MarketRowTokenIconProps = {
   market: Pick<OnDemandMarketData, "icon" | "asset" | "iconBadgeUrl">;
@@ -7,6 +11,11 @@ export type MarketRowTokenIconProps = {
   poolLetterLabel: string | null;
   imgClassName?: string;
   iconBadgeTitle?: string;
+  /** When set, resolves Tinyman LP pair icons from config (e.g. `LP_TMPOOL2_WAD_UNIT`). */
+  configSymbol?: string;
+  networkId?: NetworkId;
+  /** Explicit pair icons (overrides config-based LP resolution). */
+  assetPairIcons?: { asset1Icon: string; asset2Icon: string };
 };
 
 /** Market row / card token icon with optional pool letter (top-right) and optional `iconBadgeUrl`. */
@@ -15,10 +24,37 @@ export function MarketRowTokenIcon({
   poolLetterLabel,
   imgClassName = "w-10 h-10 flex-shrink-0 rounded-full object-contain",
   iconBadgeTitle = "Folks Finance",
+  configSymbol,
+  networkId,
+  assetPairIcons,
 }: MarketRowTokenIconProps) {
+  const resolvedPairIcons =
+    assetPairIcons ??
+    (networkId
+      ? resolveLpTokenPairIcons(networkId, { configSymbol })
+      : null);
+
+  const iconContent =
+    resolvedPairIcons != null ? (
+      <LpPairIconStack
+        asset1Icon={resolvedPairIcons.asset1Icon}
+        asset2Icon={resolvedPairIcons.asset2Icon}
+        fallbackIcon={market.icon}
+        alt={market.asset}
+        imgClassName={imgClassName}
+      />
+    ) : (
+      <img
+        src={market.icon}
+        alt={market.asset}
+        className={imgClassName}
+        onError={handleTokenImageError}
+      />
+    );
+
   return (
     <div className="relative flex-shrink-0">
-      <img src={market.icon} alt={market.asset} className={imgClassName} />
+      {iconContent}
       {poolLetterLabel ? (
         <div
           className={`absolute -top-1 -right-1 z-[11] flex h-5 w-5 items-center justify-center rounded-full border-2 border-white dark:border-slate-800 ${marketPoolBadgeBgClassName(poolLetterLabel)}`}
@@ -36,6 +72,7 @@ export function MarketRowTokenIcon({
             alt=""
             className="h-full w-full object-cover"
             aria-hidden
+            onError={handleTokenImageError}
           />
         </div>
       ) : null}

--- a/src/components/markets/MarketSearchFilters.tsx
+++ b/src/components/markets/MarketSearchFilters.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { SortField, SortOrder, type MarketFilter } from "@/hooks/useOnDemandMarketData";
 import MarketsTierFilter from "@/components/markets/MarketsTierFilter";
+import MarketsTierFilterMobileSelect from "@/components/markets/MarketsTierFilterMobileSelect";
 import { Separator } from "@/components/ui/separator";
 
 interface MarketSearchFiltersProps {
@@ -45,6 +46,8 @@ interface MarketSearchFiltersProps {
   hasActiveFilters?: boolean;
   onClearAll?: () => void;
   embedded?: boolean;
+  /** Filtered market count (mobile tier select confirmation). */
+  filteredMarketCount?: number;
 }
 
 function FilterChip({
@@ -97,6 +100,7 @@ const MarketSearchFilters = ({
   hasActiveFilters = false,
   onClearAll,
   embedded = false,
+  filteredMarketCount,
 }: MarketSearchFiltersProps) => {
   const handleSortFieldChange = (field: SortField) => {
     onSortChange(field, sortOrder);
@@ -128,13 +132,21 @@ const MarketSearchFilters = ({
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1">
-            <MarketsTierFilter
-              hideLabel
-              value={marketFilter}
-              onChange={onMarketFilterChange}
-              hasDMarketTab={hasDMarketTab}
-              isMobile={isMobile}
-            />
+            {isMobile ? (
+              <MarketsTierFilterMobileSelect
+                value={marketFilter}
+                onChange={onMarketFilterChange}
+                hasDMarketTab={hasDMarketTab}
+                totalItems={filteredMarketCount}
+              />
+            ) : (
+              <MarketsTierFilter
+                hideLabel
+                value={marketFilter}
+                onChange={onMarketFilterChange}
+                hasDMarketTab={hasDMarketTab}
+              />
+            )}
           </div>
           {hasActiveFilters && onClearAll && (
             <Button

--- a/src/components/markets/MarketsTierFilterMobileSelect.tsx
+++ b/src/components/markets/MarketsTierFilterMobileSelect.tsx
@@ -1,0 +1,63 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import { MARKET_TIER_OPTIONS } from "@/components/markets/MarketsTierFilter";
+
+interface MarketsTierFilterMobileSelectProps {
+  value: MarketFilter;
+  onChange: (value: MarketFilter) => void;
+  hasDMarketTab: boolean;
+  totalItems?: number;
+}
+
+/**
+ * Native select for pool tier on narrow viewports — reliable taps on Android Chrome
+ * (horizontal pill rows can steal touch events as scroll gestures).
+ */
+const MarketsTierFilterMobileSelect = ({
+  value,
+  onChange,
+  hasDMarketTab,
+  totalItems,
+}: MarketsTierFilterMobileSelectProps) => {
+  const options = MARKET_TIER_OPTIONS.filter(
+    (o) => o.value !== "D" || hasDMarketTab
+  );
+  const activeOption = options.find((o) => o.value === value);
+
+  return (
+    <div className="w-full min-w-0">
+      <Select
+        value={value}
+        onValueChange={(v) => onChange(v as MarketFilter)}
+      >
+        <SelectTrigger
+          className="min-h-11 w-full touch-manipulation bg-white dark:bg-slate-800/50 border-gray-300 dark:border-ocean-teal/30"
+          aria-label="Filter by pool tier"
+        >
+          <SelectValue placeholder="All markets" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {value !== "all" && totalItems != null && (
+        <p className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+          Showing {activeOption?.label ?? value} · {totalItems} market
+          {totalItems === 1 ? "" : "s"}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MarketsTierFilterMobileSelect;

--- a/src/components/pools/LpPairIconStack.tsx
+++ b/src/components/pools/LpPairIconStack.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { handleTokenImageError } from "@/utils/tokenImageUtils";
 
 interface LpPairIconStackProps {
   asset1Icon?: string;
@@ -6,13 +7,16 @@ interface LpPairIconStackProps {
   /** Shown when pair icons are unavailable (e.g. dedicated LP ASA logo). */
   fallbackIcon?: string;
   alt?: string;
-  size?: "sm" | "md";
+  size?: "sm" | "md" | "lg" | "xl";
   className?: string;
+  imgClassName?: string;
 }
 
 const sizeClasses = {
   sm: "h-8 w-8",
   md: "h-12 w-12",
+  lg: "h-16 w-16",
+  xl: "h-24 w-24",
 } as const;
 
 const LpPairIconStack = ({
@@ -22,8 +26,9 @@ const LpPairIconStack = ({
   alt = "LP pair",
   size = "md",
   className,
+  imgClassName,
 }: LpPairIconStackProps) => {
-  const iconSize = sizeClasses[size];
+  const iconSize = imgClassName ?? sizeClasses[size];
 
   if (asset1Icon && asset2Icon) {
     return (
@@ -35,6 +40,7 @@ const LpPairIconStack = ({
             iconSize,
             "rounded-full border border-border/50 object-contain bg-white shadow"
           )}
+          onError={handleTokenImageError}
         />
         <img
           src={asset2Icon}
@@ -43,6 +49,7 @@ const LpPairIconStack = ({
             iconSize,
             "rounded-full border border-border/50 object-contain bg-white shadow"
           )}
+          onError={handleTokenImageError}
         />
       </div>
     );
@@ -53,7 +60,12 @@ const LpPairIconStack = ({
       <img
         src={fallbackIcon}
         alt={alt}
-        className={cn(iconSize, "rounded-full object-contain shadow shrink-0", className)}
+        className={cn(
+          iconSize,
+          "rounded-full object-contain shadow shrink-0",
+          className
+        )}
+        onError={handleTokenImageError}
       />
     );
   }

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -102,6 +102,8 @@ const PortfolioTableMobileCard = ({
               }}
               poolLetterLabel={marketLabel}
               imgClassName="h-12 w-12 flex-shrink-0 rounded-full object-contain"
+              configSymbol={configSymbol}
+              networkId={rowNetwork}
             />
             <div className="text-center">
               <div className="font-semibold text-base text-slate-800 dark:text-white">

--- a/src/constants/__tests__/liquidityPools.test.ts
+++ b/src/constants/__tests__/liquidityPools.test.ts
@@ -52,3 +52,17 @@ describe("resolvePoolsPageLendingMarket", () => {
     }
   });
 });
+
+describe("findCuratedLiquidityPairByLpTokenId", () => {
+  it("maps LP ASA id to curated pair", async () => {
+    const { findCuratedLiquidityPairByLpTokenId } = await import(
+      "@/constants/liquidityPools"
+    );
+    expect(findCuratedLiquidityPairByLpTokenId(NETWORK, 3334546641)?.id).toBe(
+      "wad-unit"
+    );
+    expect(findCuratedLiquidityPairByLpTokenId(NETWORK, 3334448440)?.id).toBe(
+      "wad-usdc"
+    );
+  });
+});

--- a/src/constants/liquidityPools.ts
+++ b/src/constants/liquidityPools.ts
@@ -262,6 +262,32 @@ export function getCuratedLiquidityPoolsForNetwork(
   return CURATED_LIQUIDITY_POOLS.filter((p) => p.networkId === networkId);
 }
 
+/** Curated Tinyman pair whose LP ASA matches `lpTokenId` on the given network. */
+export function findCuratedLiquidityPairByLpTokenId(
+  networkId: NetworkId,
+  lpTokenId: number | string
+): LiquidityPoolPairConfig | undefined {
+  const id = String(lpTokenId);
+  return CURATED_LIQUIDITY_POOLS.find(
+    (p) => p.networkId === networkId && String(p.lpTokenId) === id
+  );
+}
+
+/** Curated pair for an `LP_*` lending token config key (e.g. `LP_TMPOOL2_WAD_UNIT`). */
+export function findCuratedLiquidityPairByLpConfigSymbol(
+  networkId: NetworkId,
+  configSymbol: string
+): LiquidityPoolPairConfig | undefined {
+  if (!configSymbol.startsWith("LP_")) return undefined;
+  const tokenConfig = getNetworkConfig(networkId).tokens?.[configSymbol];
+  if (!tokenConfig) return undefined;
+  const tc: TokenConfig = Array.isArray(tokenConfig)
+    ? tokenConfig[0]
+    : tokenConfig;
+  if (!tc?.assetId) return undefined;
+  return findCuratedLiquidityPairByLpTokenId(networkId, tc.assetId);
+}
+
 /** Lending market row in config (`LP_*`) matching a curated Tinyman pool. */
 export interface LiquidityPoolLendingMarket {
   configSymbol: string;

--- a/src/utils/__tests__/lpTokenIconUtils.test.ts
+++ b/src/utils/__tests__/lpTokenIconUtils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { resolveLpTokenPairIcons } from "@/utils/lpTokenIconUtils";
+
+const NETWORK = "algorand-mainnet" as const;
+
+describe("resolveLpTokenPairIcons", () => {
+  it("resolves pair icons for LP_TMPOOL2_WAD_UNIT", () => {
+    const icons = resolveLpTokenPairIcons(NETWORK, {
+      configSymbol: "LP_TMPOOL2_WAD_UNIT",
+    });
+    expect(icons).toEqual({
+      asset1Icon: "/lovable-uploads/WAD_fixed.png",
+      asset2Icon: "/lovable-uploads/UNIT.png",
+    });
+  });
+
+  it("resolves pair icons by lpTokenId", () => {
+    const icons = resolveLpTokenPairIcons(NETWORK, {
+      lpTokenId: 3157974960,
+    });
+    expect(icons).toEqual({
+      asset1Icon: "/lovable-uploads/UNIT.png",
+      asset2Icon: "/lovable-uploads/Algo.webp",
+    });
+  });
+
+  it("resolves WAD/USDC pair icons from curated pool metadata", () => {
+    const icons = resolveLpTokenPairIcons(NETWORK, { lpTokenId: 3334448440 });
+    expect(icons).toEqual({
+      asset1Icon: "/lovable-uploads/WAD_fixed.png",
+      asset2Icon: "/lovable-uploads/USDC.webp",
+    });
+  });
+
+  it("returns null for unconfigured LP config keys", () => {
+    expect(
+      resolveLpTokenPairIcons(NETWORK, {
+        configSymbol: "LP_TMPOOL2_WAD_USDC",
+      })
+    ).toBeNull();
+  });
+
+  it("returns null for non-LP config keys", () => {
+    expect(
+      resolveLpTokenPairIcons(NETWORK, { configSymbol: "WAD" })
+    ).toBeNull();
+  });
+});

--- a/src/utils/lpTokenIconUtils.ts
+++ b/src/utils/lpTokenIconUtils.ts
@@ -1,0 +1,45 @@
+import type { NetworkId } from "@/config";
+import {
+  findCuratedLiquidityPairByLpConfigSymbol,
+  findCuratedLiquidityPairByLpTokenId,
+} from "@/constants/liquidityPools";
+import { resolveLiquidityPairDisplay } from "@/services/tinymanLiquidityService";
+
+export type LpTokenPairIcons = {
+  asset1Icon: string;
+  asset2Icon: string;
+};
+
+/** Resolve underlying asset icons for a Tinyman LP lending token. */
+export function resolveLpTokenPairIcons(
+  networkId: NetworkId,
+  options: {
+    configSymbol?: string;
+    lpTokenId?: number | string;
+  }
+): LpTokenPairIcons | null {
+  const pair =
+    (options.configSymbol
+      ? findCuratedLiquidityPairByLpConfigSymbol(
+          networkId,
+          options.configSymbol
+        )
+      : undefined) ??
+    (options.lpTokenId != null
+      ? findCuratedLiquidityPairByLpTokenId(networkId, options.lpTokenId)
+      : undefined);
+
+  if (!pair) return null;
+
+  const display = resolveLiquidityPairDisplay(pair);
+  if (!display.asset1Icon || !display.asset2Icon) return null;
+
+  return {
+    asset1Icon: display.asset1Icon,
+    asset2Icon: display.asset2Icon,
+  };
+}
+
+export function isLpConfigSymbol(configSymbol?: string): boolean {
+  return !!configSymbol?.startsWith("LP_");
+}

--- a/src/utils/tokenImageUtils.ts
+++ b/src/utils/tokenImageUtils.ts
@@ -99,3 +99,15 @@ export function resolveTokenIconBadgeUrl(
   if (!s) return undefined;
   return getTokenImagePath(s);
 }
+
+export const PLACEHOLDER_ICON = "/placeholder.svg";
+
+/** Swap broken token images to the shared placeholder (safe to reuse on `onError`). */
+export function handleTokenImageError(event: {
+  currentTarget: HTMLImageElement;
+}): void {
+  const target = event.currentTarget;
+  if (!target.src.endsWith(PLACEHOLDER_ICON)) {
+    target.src = PLACEHOLDER_ICON;
+  }
+}


### PR DESCRIPTION
Resolve Tinyman LP lending tokens to underlying pair icons via curated pool config when dedicated LP PNGs are missing. Show stacked pair icons in SupplyBorrowCongrats, portfolio, deposits, and market rows, with onError fallback to placeholder.svg. Use a native select for mobile markets tier filter for reliable Android tap targets.