### PR TITLE
Hide Pool C/E LP markets from portfolio page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.773",
+  "version": "0.1.774",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -63,8 +63,11 @@ import {
   tokenStandardUsesNativeWalletBalance,
   getAnyFolksAdapter,
   getFolksAdapterForPhase,
+  getPortfolioVisibleTokens,
+  filterPortfolioVisibleMarketRows,
+  isMarketsTableExcludedMarket,
+  getAllTokensWithDisplayInfo,
 } from "@/config";
-import { getAllTokensWithDisplayInfo } from "@/config";
 import {
   getTokenImagePath,
   resolveTokenIconBadgeUrl,
@@ -246,6 +249,23 @@ function folksUnderlyingUsdFallbackSamePool(
   }) as { price?: string | number } | undefined;
   if (!m?.price) return 0;
   return usdPerTokenFromMarketInfoPrice(m.price, ref.decimals);
+}
+
+function isExcludedPortfolioPositionRow(pos: {
+  poolId?: string | null;
+  network?: string;
+  configSymbol?: string;
+  configKey?: string;
+}): boolean {
+  const networkId = pos.network;
+  if (!networkId || pos.poolId == null || String(pos.poolId) === "") {
+    return false;
+  }
+  return isMarketsTableExcludedMarket(
+    networkId,
+    pos.poolId,
+    pos.configSymbol ?? pos.configKey
+  );
 }
 
 /** Standalone "Accrued Interest" summary card + table (below Supplied/Borrowed). */
@@ -807,7 +827,7 @@ const Portfolio = () => {
         networkId,
         marketsCount: markets.length,
       });
-      const tokens = getAllTokensWithDisplayInfo(networkId as NetworkId);
+      const tokens = getPortfolioVisibleTokens(networkId as NetworkId);
       const positions = [];
 
       for (const token of tokens) {
@@ -1121,6 +1141,16 @@ const Portfolio = () => {
             return;
           }
 
+          if (
+            isMarketsTableExcludedMarket(
+              networkId as NetworkId,
+              appId,
+              token.configKey
+            )
+          ) {
+            return;
+          }
+
           // Find market data (do not match display symbol only — ALGO vs fALGO both "Algo" on same pool)
           const market = marketRowForPortfolioPosition(marketData, {
             marketId,
@@ -1365,6 +1395,16 @@ const Portfolio = () => {
             return;
           }
 
+          if (
+            isMarketsTableExcludedMarket(
+              networkId as NetworkId,
+              appId,
+              token.configKey
+            )
+          ) {
+            return;
+          }
+
           const market = marketRowForPortfolioPosition(marketData, {
             marketId,
             poolId: appId,
@@ -1551,14 +1591,20 @@ const Portfolio = () => {
   // Use transformed deposits and borrows from user.computed, fallback to userPositions
   // If user.computed exists but transformation resulted in empty arrays, fall back to userPositions
   const hasComputedData = user?.computed?.deposits || user?.computed?.borrows;
-  const deposits =
+  const rawDeposits =
     hasComputedData && transformedDepositsAndBorrows.deposits.length > 0
       ? transformedDepositsAndBorrows.deposits
       : userPositions.filter((pos) => pos.type === "deposit");
-  const borrows =
+  const rawBorrows =
     hasComputedData && transformedDepositsAndBorrows.borrows.length > 0
       ? transformedDepositsAndBorrows.borrows
       : userPositions.filter((pos) => pos.type === "borrow");
+  const deposits = rawDeposits.filter(
+    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  );
+  const borrows = rawBorrows.filter(
+    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  );
 
   const hasBothPositionTypes =
     deposits.length > 0 && borrows.length > 0;
@@ -2937,7 +2983,10 @@ const Portfolio = () => {
     try {
       // fetch market from node api for accurate position info
       // Fetch fresh market data and global data first
-      const markets = await fetchAllMarkets(currentNetwork);
+      const markets = filterPortfolioVisibleMarketRows(
+        currentNetwork,
+        await fetchAllMarkets(currentNetwork)
+      );
       // const marketDataResponse =
       //   await dorkfiAPIService.getAllMarketDataByNetwork(currentNetwork);
       // const freshMarketData = marketDataResponse.success
@@ -2963,7 +3012,10 @@ const Portfolio = () => {
 
       for (const networkId of enabledNetworks) {
         try {
-          const networkMarkets = await fetchAllMarkets(networkId);
+          const networkMarkets = filterPortfolioVisibleMarketRows(
+            networkId as NetworkId,
+            await fetchAllMarkets(networkId)
+          );
           const networkPositions = await fetchUserPositions(
             displayAddress,
             networkId,
@@ -3964,7 +4016,10 @@ const Portfolio = () => {
         const allMarketData: unknown[] = [];
         for (const networkId of enabledNetworks) {
           try {
-            const markets = await fetchAllMarkets(networkId as NetworkId);
+            const markets = filterPortfolioVisibleMarketRows(
+              networkId as NetworkId,
+              await fetchAllMarkets(networkId as NetworkId)
+            );
             allMarketData.push(...markets);
           } catch (error) {
             console.error(

--- a/src/config/__tests__/marketsTableExclusion.test.ts
+++ b/src/config/__tests__/marketsTableExclusion.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  getPortfolioVisibleTokens,
   isMarketsTableExcludedMarket,
   isMarketsTableExcludedPool,
+  isPortfolioExcludedMarketContract,
 } from "@/config";
 
 const POOL_C = "3578814346";
@@ -39,6 +41,39 @@ describe("markets table Pool C exclusion", () => {
   it("does not exclude WAD on Pool A", () => {
     expect(
       isMarketsTableExcludedMarket("algorand-mainnet", "3333688282", "WAD")
+    ).toBe(false);
+  });
+
+  it("excludes Pool C LP from portfolio visible tokens", () => {
+    const visible = getPortfolioVisibleTokens("algorand-mainnet");
+    expect(
+      visible.some(
+        (t) =>
+          String(t.poolId) === POOL_C &&
+          t.configKey === "LP_TMPOOL2_UNIT_ALGO"
+      )
+    ).toBe(false);
+    expect(
+      visible.some(
+        (t) => String(t.poolId) === POOL_C && t.configKey === "WAD"
+      )
+    ).toBe(true);
+  });
+
+  it("resolves portfolio exclusion by market contract id", () => {
+    expect(
+      isPortfolioExcludedMarketContract(
+        "algorand-mainnet",
+        POOL_C,
+        "3577729953"
+      )
+    ).toBe(true);
+    expect(
+      isPortfolioExcludedMarketContract(
+        "algorand-mainnet",
+        POOL_C,
+        "3333688448"
+      )
     ).toBe(false);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3943,6 +3943,58 @@ export function isMarketsTableExcludedMarket(
   return true;
 }
 
+/** Config `tokens` key for a pool + underlying market contract (from display token rows). */
+export function resolveDisplayTokenConfigKey(
+  networkId: NetworkId,
+  poolId: string | number,
+  marketContractId: string | number
+): string | null {
+  const pid = String(poolId);
+  const mid = String(marketContractId);
+  const token = getAllTokensWithDisplayInfo(networkId).find(
+    (t) =>
+      String(t.poolId ?? "") === pid &&
+      (String(t.underlyingContractId ?? "") === mid ||
+        String(t.originalContractId ?? "") === mid)
+  );
+  return token?.configKey ?? null;
+}
+
+/** True when a pool + market contract row should be hidden on Portfolio (same rules as Markets table). */
+export function isPortfolioExcludedMarketContract(
+  networkId: NetworkId | string | null | undefined,
+  poolId: string | number | null | undefined,
+  marketContractId: string | number | null | undefined
+): boolean {
+  if (!networkId || poolId == null || marketContractId == null) return false;
+  const configKey = resolveDisplayTokenConfigKey(
+    networkId as NetworkId,
+    poolId,
+    marketContractId
+  );
+  return isMarketsTableExcludedMarket(networkId, poolId, configKey);
+}
+
+/** Display tokens for Portfolio lists (Pool C/E LP hidden; WAD borrow on those pools stays visible). */
+export function getPortfolioVisibleTokens(
+  networkId: NetworkId
+): ReturnType<typeof getAllTokensWithDisplayInfo> {
+  return getAllTokensWithDisplayInfo(networkId).filter(
+    (token) =>
+      !isMarketsTableExcludedMarket(networkId, token.poolId, token.configKey)
+  );
+}
+
+/** Omit Pool C/E LP market rows from Portfolio market snapshots. */
+export function filterPortfolioVisibleMarketRows<
+  T extends { poolId: string; marketId?: string },
+>(networkId: NetworkId, rows: T[]): T[] {
+  return rows.filter(
+    (row) =>
+      !isPortfolioExcludedMarketContract(networkId, row.poolId, row.marketId)
+  );
+}
+
 /**
  * Pool id when the row object has not yet populated `marketInfo` / `poolId` (same rules as markets table `getPoolIdForSorting`).
  */

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -9,8 +9,12 @@ import {
 } from "@/services/lendingService";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
-import { getTokenConfig, tokenStandardUsesNativeWalletBalance } from "@/config";
-import { getAllTokensWithDisplayInfo } from "@/config";
+import {
+  getTokenConfig,
+  tokenStandardUsesNativeWalletBalance,
+  getPortfolioVisibleTokens,
+  getAllTokensWithDisplayInfo,
+} from "@/config";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
 
 export interface PortfolioPosition {
@@ -107,7 +111,7 @@ export const usePortfolioData = () => {
           networkId,
           marketsCount: markets.length,
         });
-        const tokens = getAllTokensWithDisplayInfo(networkId as any);
+        const tokens = getPortfolioVisibleTokens(networkId as any);
         const positions: PortfolioPosition[] = [];
 
         for (const token of tokens) {


### PR DESCRIPTION
## Summary
- Apply the same Pool C/E exclusion rules used on the Markets table to the Portfolio page
- Hide Tinyman LP collateral (`LP_TMPOOL2_*`) from supplied/borrowed asset lists and portfolio market snapshots
- Keep WAD borrow markets on pools C and E visible
- Add shared config helpers (`getPortfolioVisibleTokens`, `filterPortfolioVisibleMarketRows`) and unit tests

## Test plan
- [x] `npm test -- src/config/__tests__/marketsTableExclusion.test.ts`
- [ ] Open Portfolio with Pool C/E LP positions — LP rows should not appear
- [ ] Confirm WAD borrow on Pool C/E still appears in borrowed assets
- [ ] Confirm health factor / totals still reflect on-chain global values


Made with [Cursor](https://cursor.com)