### PR TITLE
Hide Pool C/E LP from portfolio and fix pool LP withdraw UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.773",
+  "version": "0.1.774",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.1.774",
+  "version": "0.1.776",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -63,8 +63,11 @@ import {
   tokenStandardUsesNativeWalletBalance,
   getAnyFolksAdapter,
   getFolksAdapterForPhase,
+  getPortfolioVisibleTokens,
+  filterPortfolioVisibleMarketRows,
+  isMarketsTableExcludedMarket,
+  getAllTokensWithDisplayInfo,
 } from "@/config";
-import { getAllTokensWithDisplayInfo } from "@/config";
 import {
   getTokenImagePath,
   resolveTokenIconBadgeUrl,
@@ -246,6 +249,23 @@ function folksUnderlyingUsdFallbackSamePool(
   }) as { price?: string | number } | undefined;
   if (!m?.price) return 0;
   return usdPerTokenFromMarketInfoPrice(m.price, ref.decimals);
+}
+
+function isExcludedPortfolioPositionRow(pos: {
+  poolId?: string | null;
+  network?: string;
+  configSymbol?: string;
+  configKey?: string;
+}): boolean {
+  const networkId = pos.network;
+  if (!networkId || pos.poolId == null || String(pos.poolId) === "") {
+    return false;
+  }
+  return isMarketsTableExcludedMarket(
+    networkId,
+    pos.poolId,
+    pos.configSymbol ?? pos.configKey
+  );
 }
 
 /** Standalone "Accrued Interest" summary card + table (below Supplied/Borrowed). */
@@ -807,7 +827,7 @@ const Portfolio = () => {
         networkId,
         marketsCount: markets.length,
       });
-      const tokens = getAllTokensWithDisplayInfo(networkId as NetworkId);
+      const tokens = getPortfolioVisibleTokens(networkId as NetworkId);
       const positions = [];
 
       for (const token of tokens) {
@@ -1121,6 +1141,16 @@ const Portfolio = () => {
             return;
           }
 
+          if (
+            isMarketsTableExcludedMarket(
+              networkId as NetworkId,
+              appId,
+              token.configKey
+            )
+          ) {
+            return;
+          }
+
           // Find market data (do not match display symbol only — ALGO vs fALGO both "Algo" on same pool)
           const market = marketRowForPortfolioPosition(marketData, {
             marketId,
@@ -1365,6 +1395,16 @@ const Portfolio = () => {
             return;
           }
 
+          if (
+            isMarketsTableExcludedMarket(
+              networkId as NetworkId,
+              appId,
+              token.configKey
+            )
+          ) {
+            return;
+          }
+
           const market = marketRowForPortfolioPosition(marketData, {
             marketId,
             poolId: appId,
@@ -1551,14 +1591,20 @@ const Portfolio = () => {
   // Use transformed deposits and borrows from user.computed, fallback to userPositions
   // If user.computed exists but transformation resulted in empty arrays, fall back to userPositions
   const hasComputedData = user?.computed?.deposits || user?.computed?.borrows;
-  const deposits =
+  const rawDeposits =
     hasComputedData && transformedDepositsAndBorrows.deposits.length > 0
       ? transformedDepositsAndBorrows.deposits
       : userPositions.filter((pos) => pos.type === "deposit");
-  const borrows =
+  const rawBorrows =
     hasComputedData && transformedDepositsAndBorrows.borrows.length > 0
       ? transformedDepositsAndBorrows.borrows
       : userPositions.filter((pos) => pos.type === "borrow");
+  const deposits = rawDeposits.filter(
+    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  );
+  const borrows = rawBorrows.filter(
+    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  );
 
   const hasBothPositionTypes =
     deposits.length > 0 && borrows.length > 0;
@@ -2937,7 +2983,10 @@ const Portfolio = () => {
     try {
       // fetch market from node api for accurate position info
       // Fetch fresh market data and global data first
-      const markets = await fetchAllMarkets(currentNetwork);
+      const markets = filterPortfolioVisibleMarketRows(
+        currentNetwork,
+        await fetchAllMarkets(currentNetwork)
+      );
       // const marketDataResponse =
       //   await dorkfiAPIService.getAllMarketDataByNetwork(currentNetwork);
       // const freshMarketData = marketDataResponse.success
@@ -2963,7 +3012,10 @@ const Portfolio = () => {
 
       for (const networkId of enabledNetworks) {
         try {
-          const networkMarkets = await fetchAllMarkets(networkId);
+          const networkMarkets = filterPortfolioVisibleMarketRows(
+            networkId as NetworkId,
+            await fetchAllMarkets(networkId)
+          );
           const networkPositions = await fetchUserPositions(
             displayAddress,
             networkId,
@@ -3964,7 +4016,10 @@ const Portfolio = () => {
         const allMarketData: unknown[] = [];
         for (const networkId of enabledNetworks) {
           try {
-            const markets = await fetchAllMarkets(networkId as NetworkId);
+            const markets = filterPortfolioVisibleMarketRows(
+              networkId as NetworkId,
+              await fetchAllMarkets(networkId as NetworkId)
+            );
             allMarketData.push(...markets);
           } catch (error) {
             console.error(

--- a/src/components/SupplyBorrowCongrats.tsx
+++ b/src/components/SupplyBorrowCongrats.tsx
@@ -6,6 +6,8 @@ interface SupplyBorrowCongratsProps {
   transactionType: "deposit" | "borrow" | "withdraw" | "repay";
   asset: string;
   assetIcon: string;
+  /** Stacked underlying icons for Tinyman LP pair markets. */
+  assetPairIcons?: { asset1Icon: string; asset2Icon: string };
   amount: string;
   onViewTransaction: () => void;
   onGoToPortfolio: () => void;
@@ -19,6 +21,7 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
   transactionType,
   asset,
   assetIcon,
+  assetPairIcons,
   amount,
   onViewTransaction,
   onGoToPortfolio,
@@ -42,6 +45,7 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
   };
 
   const { action, preposition } = getTransactionMessage();
+  const assetLabel = assetPairIcons ? `${asset} LP` : asset;
 
   return (
     <div className="flex flex-col items-center justify-center gap-4 animate-fade-in">
@@ -50,11 +54,29 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
         <Sparkles className="absolute -top-3 -left-3 text-whale-gold w-7 h-7 animate-bounce" />
         <Sparkles className="absolute -top-3 -right-3 text-highlight-aqua w-7 h-7 animate-bounce animation-delay-300" />
         <CheckCircle2 className="w-16 h-16 text-green-500 drop-shadow-xl bg-white dark:bg-slate-800 rounded-full p-1 border-4 border-whale-gold z-10" />
-        <img
-          src={assetIcon}
-          alt={`${asset} icon`}
-          className="mt-[-30px] w-32 h-32 rounded-xl shadow-md border-4 border-whale-gold mx-auto bg-bubble-white dark:bg-slate-800 object-cover"
-        />
+        {assetPairIcons ? (
+          <div
+            className="mt-[-30px] mx-auto flex -space-x-4 justify-center"
+            aria-hidden
+          >
+            <img
+              src={assetPairIcons.asset1Icon}
+              alt=""
+              className="h-24 w-24 rounded-xl border-4 border-whale-gold bg-bubble-white object-contain shadow-md dark:bg-slate-800"
+            />
+            <img
+              src={assetPairIcons.asset2Icon}
+              alt=""
+              className="h-24 w-24 rounded-xl border-4 border-whale-gold bg-bubble-white object-contain shadow-md dark:bg-slate-800"
+            />
+          </div>
+        ) : (
+          <img
+            src={assetIcon}
+            alt={`${asset} icon`}
+            className="mt-[-30px] w-32 h-32 rounded-xl shadow-md border-4 border-whale-gold mx-auto bg-bubble-white dark:bg-slate-800 object-cover"
+          />
+        )}
       </div>
 
       <h2 className="text-xl font-bold text-center mb-1">
@@ -64,7 +86,7 @@ const SupplyBorrowCongrats: React.FC<SupplyBorrowCongratsProps> = ({
       <div className="text-center text-base text-slate-700 dark:text-slate-200 mb-2 font-medium">
         You successfully {action}{" "}
         <span className="text-whale-gold">
-          {amount} {asset}
+          {amount} {assetLabel}
         </span>{" "}
         {preposition} the protocol.
       </div>

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -3284,6 +3284,7 @@ const SupplyBorrowModal = ({
               transactionType={mode}
               asset={asset}
               assetIcon={assetData.icon}
+              assetPairIcons={assetPairIcons}
               amount={amount}
               onViewTransaction={handleViewTransaction}
               onGoToPortfolio={handleGoToPortfolio}

--- a/src/components/WithdrawModal.tsx
+++ b/src/components/WithdrawModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -217,6 +217,8 @@ interface WithdrawModalProps {
   showTooltip?: boolean;
   tooltipText?: string;
   onRefreshBalance?: () => void;
+  /** Called after a successful withdraw is shown (deferred so success UI renders first). */
+  onTransactionSuccess?: () => void;
   /** Lending pool (for pool-scoped LT / est. health, same as deposit modal). */
   poolId?: string;
   network?: string;
@@ -280,6 +282,7 @@ const WithdrawModal = ({
   showTooltip = false,
   tooltipText = "",
   onRefreshBalance,
+  onTransactionSuccess,
   poolId,
   network: networkProp,
   poolCollateralMarkets,
@@ -325,6 +328,10 @@ const WithdrawModal = ({
   const [fiatValue, setFiatValue] = useState(0);
   const [showSuccess, setShowSuccess] = useState(false);
   const [successTxId, setSuccessTxId] = useState<string | null>(null);
+  const [successSnapshot, setSuccessSnapshot] = useState<{
+    amount: string;
+    asset: string;
+  } | null>(null);
   const [pendingWithdrawReview, setPendingWithdrawReview] =
     useState<WithdrawPhasedSignPayload | null>(null);
   const [isSigningWithdrawPhase, setIsSigningWithdrawPhase] = useState(false);
@@ -846,6 +853,7 @@ const WithdrawModal = ({
     if (isOpen) {
       setShowSuccess(false);
       setSuccessTxId(null);
+      setSuccessSnapshot(null);
       setPendingWithdrawReview(null);
       setIsSigningWithdrawPhase(false);
       setAmount("");
@@ -903,6 +911,7 @@ const WithdrawModal = ({
   const handleMakeAnother = () => {
     setShowSuccess(false);
     setSuccessTxId(null);
+    setSuccessSnapshot(null);
     setPendingWithdrawReview(null);
     setAmount("");
     setFiatValue(0);
@@ -1014,6 +1023,75 @@ const WithdrawModal = ({
     }
     return base;
   };
+
+  const completeWithdrawSuccess = useCallback(
+    (opts: {
+      txId: string | null;
+      amountHuman: string;
+      assetLabel: string;
+    }) => {
+      setSuccessSnapshot({
+        amount: opts.amountHuman,
+        asset: opts.assetLabel,
+      });
+      setSuccessTxId(opts.txId);
+      setPendingWithdrawReview(null);
+      setFolksWithdrawTwoStepAwaitRedeem(null);
+      setShowSuccess(true);
+      if (onTransactionSuccess) {
+        window.setTimeout(() => onTransactionSuccess(), 1500);
+      }
+    },
+    [onTransactionSuccess]
+  );
+
+  const finishWithdrawFlow = useCallback(
+    (
+      opts: {
+        txId: string | null;
+        amountHuman: string;
+        assetLabel: string;
+      },
+      rainbowkitDismiss: boolean
+    ) => {
+      setPendingWithdrawReview(null);
+      setFolksWithdrawTwoStepAwaitRedeem(null);
+      if (rainbowkitDismiss) {
+        setShowSuccess(false);
+        setSuccessSnapshot(null);
+        toast({
+          title: "Withdraw confirmed",
+          description:
+            "Your transaction was submitted. The portfolio will update shortly.",
+        });
+        if (onTransactionSuccess) {
+          window.setTimeout(() => onTransactionSuccess(), 1500);
+        }
+        onClose();
+        return;
+      }
+      completeWithdrawSuccess(opts);
+    },
+    [completeWithdrawSuccess, onClose, onTransactionSuccess, toast]
+  );
+
+  const resolveSuccessAssetLabel = useCallback(
+    (pending?: WithdrawPhasedSignPayload | null) => {
+      if (pending?.assetDisplaySymbol?.trim()) {
+        return pending.assetDisplaySymbol.trim();
+      }
+      if (withdrawAmountIsUnderlying || withdrawFolksAdapters.length > 0) {
+        return effectiveAmountLabelSymbol;
+      }
+      return tokenSymbol;
+    },
+    [
+      effectiveAmountLabelSymbol,
+      tokenSymbol,
+      withdrawAmountIsUnderlying,
+      withdrawFolksAdapters.length,
+    ]
+  );
 
   const handleSubmit = async () => {
     setInternalLoading(true);
@@ -1174,8 +1252,8 @@ const WithdrawModal = ({
           ? String(meta.txId).trim()
           : null;
       const atomic = meta?.fAssetToRedeemAtomic?.trim();
-      setSuccessTxId(tx);
-      setPendingWithdrawReview(null);
+      const rainbowkitDismiss =
+        isRainbowkitXchainWallet(activeWallet) && !withdrawTwoStepChainFailed;
 
       if (
         atomic &&
@@ -1199,15 +1277,21 @@ const WithdrawModal = ({
             duration: 10000,
           });
           const meta2 = await signAndFinalize(step2Built);
-          setPendingWithdrawReview(null);
-          setFolksWithdrawTwoStepAwaitRedeem(null);
           const tx2 =
             meta2?.txId != null && String(meta2.txId).trim() !== ""
               ? String(meta2.txId).trim()
               : null;
-          setSuccessTxId(tx2);
           if (!meta2?.skipSuccessModal) {
-            setShowSuccess(true);
+            finishWithdrawFlow(
+              {
+                txId: tx2,
+                amountHuman: step2Built.amountHuman,
+                assetLabel: resolveSuccessAssetLabel(step2Built),
+              },
+              rainbowkitDismiss
+            );
+          } else {
+            setPendingWithdrawReview(null);
           }
         } catch (chainErr) {
           withdrawTwoStepChainFailed = true;
@@ -1231,22 +1315,17 @@ const WithdrawModal = ({
       } else {
         const skipCongrats = meta?.skipSuccessModal === true;
         if (!skipCongrats) {
-          setFolksWithdrawTwoStepAwaitRedeem(null);
-          setShowSuccess(true);
+          finishWithdrawFlow(
+            {
+              txId: tx,
+              amountHuman: pendingStep1.amountHuman,
+              assetLabel: resolveSuccessAssetLabel(pendingStep1),
+            },
+            rainbowkitDismiss
+          );
+        } else {
+          setPendingWithdrawReview(null);
         }
-      }
-
-      if (
-        isRainbowkitXchainWallet(activeWallet) &&
-        !withdrawTwoStepChainFailed
-      ) {
-        setShowSuccess(false);
-        toast({
-          title: "Withdraw confirmed",
-          description:
-            "Your transaction was submitted. The portfolio will update shortly.",
-        });
-        onClose();
       }
     } catch (error) {
       if (isRainbowkitXchainWallet(activeWallet)) {
@@ -1292,12 +1371,17 @@ const WithdrawModal = ({
             <SupplyBorrowCongrats
               transactionType="withdraw"
               asset={
-                withdrawAmountIsUnderlying || withdrawFolksAdapters.length > 0
+                successSnapshot?.asset ??
+                (withdrawAmountIsUnderlying || withdrawFolksAdapters.length > 0
                   ? effectiveAmountLabelSymbol
-                  : tokenSymbol
+                  : tokenSymbol)
               }
               assetIcon={tokenIcon}
-              amount={amount !== "" ? amount.toString() : ""}
+              assetPairIcons={tokenPairIcons}
+              amount={
+                successSnapshot?.amount ??
+                (amount !== "" ? amount.toString() : "")
+              }
               onViewTransaction={handleViewTransaction}
               onGoToPortfolio={handleGoToPortfolio}
               onMakeAnother={handleMakeAnother}

--- a/src/components/pools/PoolLendingModals.tsx
+++ b/src/components/pools/PoolLendingModals.tsx
@@ -22,12 +22,28 @@ import { marketRowCacheKey } from "@/hooks/useOnDemandMarketData";
 import {
   fetchMarketInfo,
   fetchUserDepositBalance,
+  fetchUserGlobalDataForPool,
+  getMaxWithdrawableForMarket,
   withdraw,
 } from "@/services/lendingService";
 import algorandService from "@/services/algorandService";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
 import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
+import {
+  fetchPoolCollateralMarketRowsForDeposit,
+  type PoolCollateralMarketRow,
+} from "@/utils/poolCollateralMarketRows";
 import { waitForConfirmation } from "algosdk";
+
+function poolMinLiquidationThresholdBps(minPercentField: number): bigint {
+  if (!Number.isFinite(minPercentField) || minPercentField <= 0) {
+    return BigInt(8500);
+  }
+  if (minPercentField <= 1) {
+    return BigInt(Math.round(minPercentField * 10000));
+  }
+  return BigInt(Math.round(minPercentField * 100));
+}
 
 type PoolLendingModalsProps = {
   pair: LiquidityPoolPairConfig;
@@ -141,6 +157,20 @@ const PoolLendingModals = ({
   const [walletBalance, setWalletBalance] = useState(initialWalletLpBalance);
   const [suppliedBalance, setSuppliedBalance] = useState(0);
   const [loadingMarket, setLoadingMarket] = useState(false);
+  const [maxWithdrawUnderlying, setMaxWithdrawUnderlying] = useState<
+    number | undefined
+  >(undefined);
+  const [maxWithdrawScaled, setMaxWithdrawScaled] = useState<
+    string | undefined
+  >(undefined);
+  const [userGlobalData, setUserGlobalData] = useState<{
+    totalCollateralValue: number;
+    totalBorrowValue: number;
+    lastUpdateTime: number;
+  } | null>(null);
+  const [poolCollateralMarkets, setPoolCollateralMarkets] = useState<
+    PoolCollateralMarketRow[]
+  >([]);
 
   const marketRowKey = useMemo(
     () =>
@@ -226,6 +256,73 @@ const PoolLendingModals = ({
     }
   }, [supplyOpen, initialWalletLpBalance]);
 
+  useEffect(() => {
+    if (!withdrawOpen || !activeAccount?.address) {
+      setMaxWithdrawUnderlying(undefined);
+      setMaxWithdrawScaled(undefined);
+      setUserGlobalData(null);
+      setPoolCollateralMarkets([]);
+      return;
+    }
+
+    let cancelled = false;
+    const poolId = lendingMarket.poolId;
+    const marketId = lendingMarket.marketId;
+
+    void (async () => {
+      const [globalData, collateralRows] = await Promise.all([
+        fetchUserGlobalDataForPool(activeAccount.address, networkId, poolId),
+        fetchPoolCollateralMarketRowsForDeposit(
+          activeAccount.address,
+          networkId,
+          poolId
+        ),
+      ]);
+      if (cancelled) return;
+      setUserGlobalData(globalData);
+      setPoolCollateralMarkets(collateralRows);
+
+      const minLiquidationThresholdBps =
+        collateralRows.length > 0
+          ? poolMinLiquidationThresholdBps(
+              Math.min(
+                ...collateralRows.map((row) => row.liquidationThresholdPercent)
+              )
+            )
+          : undefined;
+
+      const maxData = await getMaxWithdrawableForMarket(
+        poolId,
+        marketId,
+        activeAccount.address,
+        networkId,
+        lendingMarket.decimals,
+        minLiquidationThresholdBps !== undefined
+          ? { minLiquidationThresholdBps }
+          : undefined
+      );
+      if (cancelled) return;
+      if (!maxData) {
+        setMaxWithdrawUnderlying(undefined);
+        setMaxWithdrawScaled(undefined);
+        return;
+      }
+      setMaxWithdrawUnderlying(maxData.maxWithdrawUnderlying);
+      setMaxWithdrawScaled(maxData.maxWithdrawScaled.toString());
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeAccount?.address,
+    lendingMarket.decimals,
+    lendingMarket.marketId,
+    lendingMarket.poolId,
+    networkId,
+    withdrawOpen,
+  ]);
+
   const tokenConfig = useMemo(() => {
     const raw = getTokenConfig(networkId, lendingMarket.configSymbol);
     return Array.isArray(raw) ? raw[0] : raw;
@@ -236,10 +333,16 @@ const PoolLendingModals = ({
       amount: string,
       options?: WithdrawSubmitOptions
     ): Promise<WithdrawPhasedSignPayload> => {
-      if (!activeAccount?.address || !tokenConfig) {
+      if (!activeAccount?.address) {
         throw new Error("Connect your wallet to withdraw.");
       }
+      if (!tokenConfig) {
+        throw new Error(
+          `Token config not found for ${lendingMarket.configSymbol} on ${networkId}.`
+        );
+      }
 
+      const withdrawAllConfirmed = Boolean(options?.withdrawAllConfirmed);
       const result = await withdraw(
         lendingMarket.poolId,
         lendingMarket.marketId,
@@ -248,7 +351,13 @@ const PoolLendingModals = ({
         activeAccount.address,
         networkId,
         {
-          withdrawAll: Boolean(options?.withdrawAllConfirmed),
+          withdrawAll: withdrawAllConfirmed,
+          maxWithdrawScaled:
+            withdrawAllConfirmed &&
+            options?.isMaxWithdraw &&
+            maxWithdrawScaled
+              ? BigInt(maxWithdrawScaled)
+              : undefined,
         }
       );
 
@@ -271,7 +380,14 @@ const PoolLendingModals = ({
         amountHuman: amount,
       };
     },
-    [activeAccount?.address, lendingMarket, networkId, tokenConfig]
+    [
+      activeAccount?.address,
+      lendingMarket,
+      maxWithdrawScaled,
+      networkId,
+      pairDisplay.label,
+      tokenConfig,
+    ]
   );
 
   const finalizeWithdrawSigned = useCallback(
@@ -289,11 +405,10 @@ const PoolLendingModals = ({
         await algorandService.initializeClientsForTransactions(algorandNetwork);
       const res = await clients.algod.sendRawTransaction(stxns).do();
       await waitForConfirmation(clients.algod, res.txid, 4);
-      onSuccess?.();
       void refreshBalances();
       return { txId: res.txid };
     },
-    [onSuccess, refreshBalances]
+    [refreshBalances]
   );
 
   const withdrawPhased = useMemo(
@@ -368,7 +483,12 @@ const PoolLendingModals = ({
           network={networkId}
           selectedMarketId={lendingMarket.marketId}
           selectedConfigSymbol={lendingMarket.configSymbol}
-          poolHasNoBorrows
+          maxWithdrawUnderlying={maxWithdrawUnderlying}
+          poolCollateralMarkets={poolCollateralMarkets}
+          poolHasNoBorrows={
+            !userGlobalData?.totalBorrowValue ||
+            userGlobalData.totalBorrowValue === 0
+          }
           marketStats={{
             supplyAPY: resolvedAssetData.supplyAPY,
             borrowAPY: resolvedAssetData.borrowAPY,
@@ -381,6 +501,10 @@ const PoolLendingModals = ({
             apyParameters: resolvedAssetData.apyParameters,
           }}
           withdrawPhased={withdrawPhased}
+          onTransactionSuccess={() => {
+            onSuccess?.();
+            void refreshBalances();
+          }}
           onRefreshBalance={() => {
             void refreshBalances();
           }}

--- a/src/components/pools/PoolPairCard.tsx
+++ b/src/components/pools/PoolPairCard.tsx
@@ -252,7 +252,7 @@ const PoolPairCard = ({
             <DorkFiButton
               variant="secondary"
               className="flex-1"
-              disabled={!snapshot || lendingSupplyDisabled}
+              disabled={lendingSupplyDisabled}
               onClick={(e) => {
                 e.stopPropagation();
                 onSupply?.();
@@ -264,7 +264,7 @@ const PoolPairCard = ({
             <DorkFiButton
               variant="borrow-outline"
               className="flex-1"
-              disabled={!snapshot || lendingWithdrawDisabled}
+              disabled={lendingWithdrawDisabled}
               onClick={(e) => {
                 e.stopPropagation();
                 onLendingWithdraw?.();

--- a/src/config/__tests__/marketsTableExclusion.test.ts
+++ b/src/config/__tests__/marketsTableExclusion.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  getPortfolioVisibleTokens,
   isMarketsTableExcludedMarket,
   isMarketsTableExcludedPool,
+  isPortfolioExcludedMarketContract,
 } from "@/config";
 
 const POOL_C = "3578814346";
@@ -39,6 +41,39 @@ describe("markets table Pool C exclusion", () => {
   it("does not exclude WAD on Pool A", () => {
     expect(
       isMarketsTableExcludedMarket("algorand-mainnet", "3333688282", "WAD")
+    ).toBe(false);
+  });
+
+  it("excludes Pool C LP from portfolio visible tokens", () => {
+    const visible = getPortfolioVisibleTokens("algorand-mainnet");
+    expect(
+      visible.some(
+        (t) =>
+          String(t.poolId) === POOL_C &&
+          t.configKey === "LP_TMPOOL2_UNIT_ALGO"
+      )
+    ).toBe(false);
+    expect(
+      visible.some(
+        (t) => String(t.poolId) === POOL_C && t.configKey === "WAD"
+      )
+    ).toBe(true);
+  });
+
+  it("resolves portfolio exclusion by market contract id", () => {
+    expect(
+      isPortfolioExcludedMarketContract(
+        "algorand-mainnet",
+        POOL_C,
+        "3577729953"
+      )
+    ).toBe(true);
+    expect(
+      isPortfolioExcludedMarketContract(
+        "algorand-mainnet",
+        POOL_C,
+        "3333688448"
+      )
     ).toBe(false);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3943,6 +3943,58 @@ export function isMarketsTableExcludedMarket(
   return true;
 }
 
+/** Config `tokens` key for a pool + underlying market contract (from display token rows). */
+export function resolveDisplayTokenConfigKey(
+  networkId: NetworkId,
+  poolId: string | number,
+  marketContractId: string | number
+): string | null {
+  const pid = String(poolId);
+  const mid = String(marketContractId);
+  const token = getAllTokensWithDisplayInfo(networkId).find(
+    (t) =>
+      String(t.poolId ?? "") === pid &&
+      (String(t.underlyingContractId ?? "") === mid ||
+        String(t.originalContractId ?? "") === mid)
+  );
+  return token?.configKey ?? null;
+}
+
+/** True when a pool + market contract row should be hidden on Portfolio (same rules as Markets table). */
+export function isPortfolioExcludedMarketContract(
+  networkId: NetworkId | string | null | undefined,
+  poolId: string | number | null | undefined,
+  marketContractId: string | number | null | undefined
+): boolean {
+  if (!networkId || poolId == null || marketContractId == null) return false;
+  const configKey = resolveDisplayTokenConfigKey(
+    networkId as NetworkId,
+    poolId,
+    marketContractId
+  );
+  return isMarketsTableExcludedMarket(networkId, poolId, configKey);
+}
+
+/** Display tokens for Portfolio lists (Pool C/E LP hidden; WAD borrow on those pools stays visible). */
+export function getPortfolioVisibleTokens(
+  networkId: NetworkId
+): ReturnType<typeof getAllTokensWithDisplayInfo> {
+  return getAllTokensWithDisplayInfo(networkId).filter(
+    (token) =>
+      !isMarketsTableExcludedMarket(networkId, token.poolId, token.configKey)
+  );
+}
+
+/** Omit Pool C/E LP market rows from Portfolio market snapshots. */
+export function filterPortfolioVisibleMarketRows<
+  T extends { poolId: string; marketId?: string },
+>(networkId: NetworkId, rows: T[]): T[] {
+  return rows.filter(
+    (row) =>
+      !isPortfolioExcludedMarketContract(networkId, row.poolId, row.marketId)
+  );
+}
+
 /**
  * Pool id when the row object has not yet populated `marketInfo` / `poolId` (same rules as markets table `getPoolIdForSorting`).
  */

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -9,8 +9,12 @@ import {
 } from "@/services/lendingService";
 import { ARC200Service } from "@/services/arc200Service";
 import algorandService from "@/services/algorandService";
-import { getTokenConfig, tokenStandardUsesNativeWalletBalance } from "@/config";
-import { getAllTokensWithDisplayInfo } from "@/config";
+import {
+  getTokenConfig,
+  tokenStandardUsesNativeWalletBalance,
+  getPortfolioVisibleTokens,
+  getAllTokensWithDisplayInfo,
+} from "@/config";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
 
 export interface PortfolioPosition {
@@ -107,7 +111,7 @@ export const usePortfolioData = () => {
           networkId,
           marketsCount: markets.length,
         });
-        const tokens = getAllTokensWithDisplayInfo(networkId as any);
+        const tokens = getPortfolioVisibleTokens(networkId as any);
         const positions: PortfolioPosition[] = [];
 
         for (const token of tokens) {


### PR DESCRIPTION
## Summary
- Apply the same Pool C/E exclusion rules used on the Markets table to the Portfolio page — hide Tinyman LP collateral (`LP_TMPOOL2_*`) from supplied/borrowed asset lists and portfolio market snapshots while keeping WAD borrow markets on pools C and E visible
- Add shared config helpers (`getPortfolioVisibleTokens`, `filterPortfolioVisibleMarketRows`, `isPortfolioExcludedMarketContract`) and unit tests
- Align pool-page LP withdraw with Portfolio: HF-safe max, pool collateral rows, and borrow-aware `poolHasNoBorrows` instead of a hardcoded value
- Defer pool list refresh until after the withdraw success modal renders so congrats are not wiped by query invalidation
- Improve LP success screens with pair icons, LP labels, and a signed-amount snapshot; enable supply/withdraw when Tinyman snapshot is unavailable

## Test plan
- [x] `npm test -- src/config/__tests__/marketsTableExclusion.test.ts`
- [ ] Open Portfolio with Pool C/E LP positions — LP rows should not appear
- [ ] Confirm WAD borrow on Pool C/E still appears in borrowed assets
- [ ] Confirm health factor / totals still reflect on-chain global values
- [ ] On Pools page, supply LP to platform and confirm success screen shows pair icons, amount, and label (e.g. `WAD / ALGO LP`)
- [ ] Withdraw partial and max LP; confirm success screen appears and stays visible before pool cards refresh
- [ ] With an open WAD borrow against LP collateral, confirm withdraw respects HF-safe max and does not allow unsafe full withdraw
- [ ] Confirm Supply/Withdraw buttons work when Tinyman pool snapshot fails to load but on-chain supplied balance exists
- [ ] Verify Portfolio withdraw success flow still works (shared `WithdrawModal` changes)

Made with [Cursor](https://cursor.com)