### PR TITLE
Pin WAD Mint sToken market as a standalone at the top of the markets table.

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -808,6 +808,7 @@ const MarketsTable = () => {
     loadVisibleMarkets,
     loadAllMarkets,
     isLoading,
+    wadMintMarket,
     newMarketsCount,
     rewardMarketsCount,
     multiPoolMarketsCount,
@@ -841,33 +842,56 @@ const MarketsTable = () => {
 
   const rewardsAprByBaseUrl = useRewardsAprBonusMap([currentNetwork]);
 
-  const markets = useMemo(() => {
-    return marketsPage.map((m) => ({
+  const applyRewardsBonus = useCallback(
+    (m: (typeof marketsPage)[0]) => ({
       ...m,
       rewardsBonusSupplyAprPercent:
         m.hasRewards && m.rewardsPublicBaseUrlResolved
           ? rewardsAprByBaseUrl[m.rewardsPublicBaseUrlResolved] ?? null
           : undefined,
-    }));
-  }, [marketsPage, rewardsAprByBaseUrl]);
+    }),
+    [rewardsAprByBaseUrl]
+  );
+
+  const markets = useMemo(() => {
+    return marketsPage.map(applyRewardsBonus);
+  }, [marketsPage, applyRewardsBonus]);
+
+  const wadMintMarketDisplay = useMemo(() => {
+    if (!wadMintMarket) return null;
+    return applyRewardsBonus(wadMintMarket);
+  }, [wadMintMarket, applyRewardsBonus]);
+
+  const marketsForLookup = useMemo(() => {
+    if (!wadMintMarketDisplay) return markets;
+    const wadKey = (wadMintMarketDisplay as { _sortKey?: string })._sortKey;
+    if (
+      markets.some(
+        (m) => (m as { _sortKey?: string })._sortKey === wadKey
+      )
+    ) {
+      return markets;
+    }
+    return [wadMintMarketDisplay, ...markets];
+  }, [markets, wadMintMarketDisplay]);
 
   /** Resolve config token row when display `asset` + `poolId` match multiple markets (e.g. Algo vs fALGO). */
   const configSymbolFromMarketRowKey = useCallback(
     (marketRowKey: string | undefined) => {
       if (!marketRowKey) return undefined;
-      const row = markets.find(
+      const row = marketsForLookup.find(
         (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
       );
       const cs = row?.configSymbol;
       return typeof cs === "string" ? cs : undefined;
     },
-    [markets]
+    [marketsForLookup]
   );
 
   const marketContractIdFromMarketRowKey = useCallback(
     (marketRowKey: string | undefined) => {
       if (!marketRowKey) return undefined;
-      const row = markets.find(
+      const row = marketsForLookup.find(
         (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
       );
       const fromInfo = row?.marketInfo?.marketId;
@@ -876,7 +900,7 @@ const MarketsTable = () => {
       }
       return marketContractIdFromRowCacheKey(marketRowKey);
     },
-    [markets]
+    [marketsForLookup]
   );
 
   const resolveTokenForDisplayedAsset = useCallback(
@@ -2994,10 +3018,10 @@ const MarketsTable = () => {
 
   const getAssetData = (asset: string, poolId?: string, marketRowKey?: string) => {
     const poolIdStr = poolId != null && poolId !== "" ? String(poolId) : null;
-    let market: (typeof markets)[0] | undefined;
+    let market: (typeof marketsForLookup)[0] | undefined;
 
     if (marketRowKey) {
-      market = markets.find(
+      market = marketsForLookup.find(
         (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
       );
     }
@@ -3010,7 +3034,7 @@ const MarketsTable = () => {
           poolIdStr,
           marketRowKey
         );
-        market = markets.find((m) => {
+        market = marketsForLookup.find((m) => {
           if (m.asset !== asset) return false;
           const poolMatch =
             String(m.poolId) === poolIdStr ||
@@ -3027,7 +3051,7 @@ const MarketsTable = () => {
       }
       if (!market) {
         // Exact match by asset + poolId (required for 2 WAD markets etc.)
-        market = markets.find(
+        market = marketsForLookup.find(
           (m) =>
             m.asset === asset &&
             (String(m.poolId) === poolIdStr ||
@@ -3041,7 +3065,7 @@ const MarketsTable = () => {
 
     if (!market) {
       // No poolId provided – find by asset only
-      const matchingMarkets = markets.filter((m) => m.asset === asset);
+      const matchingMarkets = marketsForLookup.filter((m) => m.asset === asset);
       if (matchingMarkets.length > 1) {
         market = matchingMarkets.reduce((prev, current) => {
           return (current.totalSupply || 0) > (prev.totalSupply || 0)
@@ -3809,7 +3833,7 @@ const MarketsTable = () => {
             aria-hidden
           />
 
-          {markets.length === 0 && !isLoading ? (
+          {markets.length === 0 && !wadMintMarketDisplay && !isLoading ? (
             <div className="text-center py-8">
               <p className="text-muted-foreground">
                 No markets found. Try adjusting your search criteria.
@@ -3819,6 +3843,7 @@ const MarketsTable = () => {
             <MarketsTableContent
               marketFilter={marketFilter}
               markets={markets}
+              pinnedWadMintMarket={wadMintMarketDisplay}
               sortField={sortField}
               sortOrder={sortOrder}
               onRowClick={handleRowClick}

--- a/src/components/markets/MarketCardView.tsx
+++ b/src/components/markets/MarketCardView.tsx
@@ -47,6 +47,8 @@ interface MarketCardViewProps {
     onMintMouseEnter?: (e: React.MouseEvent) => void;
   };
   onRowMouseEnter?: (market: OnDemandMarketData) => void;
+  /** WAD Mint market pinned above paginated cards (excluded from sort/filter/page). */
+  pinnedWadMintMarket?: OnDemandMarketData | null;
 }
 
 const MarketCardView = ({ 
@@ -59,6 +61,7 @@ const MarketCardView = ({
   onMigrateClick,
   getMarketActionHoverHandlers,
   onRowMouseEnter,
+  pinnedWadMintMarket,
 }: MarketCardViewProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -165,15 +168,51 @@ const MarketCardView = ({
     return Array.from(marketMap.values());
   }, [markets]);
 
-  if (deduplicatedMarkets.length === 0) {
+  if (deduplicatedMarkets.length === 0 && !pinnedWadMintMarket) {
     return (
       <div className="text-center py-8">
         <p className="text-ink-blue">No markets found matching your search criteria.</p>
       </div>
     );
   }
+
+  const renderPinnedWadMintCard = () => {
+    if (!pinnedWadMintMarket) return null;
+    const poolId =
+      pinnedWadMintMarket.marketInfo?.poolId ?? pinnedWadMintMarket.poolId;
+    const marketRowKey = (pinnedWadMintMarket as { _sortKey?: string })
+      ._sortKey;
+    const poolIdForLabel = marketRowPoolIdForFilter(pinnedWadMintMarket) || undefined;
+    const marketLabel = getMarketLabel(currentNetwork, poolIdForLabel);
+    const hoverHandlers = getMarketActionHoverHandlers?.(
+      pinnedWadMintMarket.asset,
+      poolId,
+      marketRowKey
+    );
+    return (
+      <STokenCard
+        key="pinned-wad-mint"
+        market={pinnedWadMintMarket}
+        marketLabel={marketLabel}
+        onRowClick={onRowClick}
+        onInfoClick={onInfoClick}
+        onDepositClick={(asset) =>
+          onDepositClick(asset, poolId, marketRowKey)
+        }
+        onBorrowClick={(asset) =>
+          onBorrowClick(asset, poolId, marketRowKey)
+        }
+        onMintClick={onMintClick}
+        marketRowKey={marketRowKey}
+        onMintMouseEnter={hoverHandlers?.onMintMouseEnter}
+        className="w-full"
+      />
+    );
+  };
+
   return (
     <div className="space-y-4">
+      {renderPinnedWadMintCard()}
       {deduplicatedMarkets.map((market) => {
         const poolIdForLabel = marketRowPoolIdForFilter(market) || undefined;
         const marketLabel = getMarketLabel(currentNetwork, poolIdForLabel);

--- a/src/components/markets/MarketsDesktopTable.tsx
+++ b/src/components/markets/MarketsDesktopTable.tsx
@@ -61,6 +61,8 @@ interface MarketsDesktopTableProps {
     onMintMouseEnter?: (e: React.MouseEvent) => void;
   };
   onRowMouseEnter?: (market: OnDemandMarketData) => void;
+  /** WAD Mint market pinned above paginated rows (excluded from sort/filter/page). */
+  pinnedWadMintMarket?: OnDemandMarketData | null;
 }
 
 const headerTooltips = {
@@ -99,6 +101,7 @@ const MarketsDesktopTable = ({
   isLoadingBalance = false,
   getMarketActionHoverHandlers,
   onRowMouseEnter,
+  pinnedWadMintMarket,
 }: MarketsDesktopTableProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -718,7 +721,33 @@ const MarketsDesktopTable = ({
     );
   };
 
-  if (markets.length === 0) {
+  const renderPinnedWadMintRow = () => {
+    if (!pinnedWadMintMarket) return null;
+    const poolId =
+      pinnedWadMintMarket.marketInfo?.poolId ?? pinnedWadMintMarket.poolId;
+    const marketRowKey = (pinnedWadMintMarket as { _sortKey?: string })
+      ._sortKey;
+    return (
+      <STokenRow
+        key="pinned-wad-mint"
+        market={pinnedWadMintMarket}
+        onRowClick={onRowClick}
+        onInfoClick={onInfoClick}
+        onDepositClick={(asset) =>
+          onDepositClick(asset, poolId, marketRowKey)
+        }
+        onBorrowClick={(asset) =>
+          onBorrowClick(asset, poolId, marketRowKey)
+        }
+        onMintClick={onMintClick}
+        isLoadingBalance={isLoadingBalance}
+        getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+        onRowMouseEnter={onRowMouseEnter}
+      />
+    );
+  };
+
+  if (markets.length === 0 && !pinnedWadMintMarket) {
     return (
       <div className="text-center py-8">
         <p className="text-ink-blue">
@@ -842,6 +871,7 @@ const MarketsDesktopTable = ({
             </TableRow>
           </TableHeader>
           <TableBody>
+            {renderPinnedWadMintRow()}
             {Object.entries(groupedMarkets).map(([symbol, symbolMarkets]) => {
               const hasMultipleMarkets = symbolMarkets.length > 1;
               const isExpanded = expandedSymbols.has(symbol);

--- a/src/components/markets/MarketsTableContent.tsx
+++ b/src/components/markets/MarketsTableContent.tsx
@@ -33,6 +33,7 @@ interface MarketsTableContentProps {
     onMintMouseEnter?: (e: React.MouseEvent) => void;
   };
   onRowMouseEnter?: (market: OnDemandMarketData) => void;
+  pinnedWadMintMarket?: OnDemandMarketData | null;
 }
 
 const MarketsTableContent = ({
@@ -51,6 +52,7 @@ const MarketsTableContent = ({
   isLoadingBalance = false,
   getMarketActionHoverHandlers,
   onRowMouseEnter,
+  pinnedWadMintMarket,
 }: MarketsTableContentProps) => {
   const breakpoint = useBreakpoint();
 
@@ -67,6 +69,7 @@ const MarketsTableContent = ({
         onMigrateClick={onMigrateClick}
         getMarketActionHoverHandlers={getMarketActionHoverHandlers}
         onRowMouseEnter={onRowMouseEnter}
+        pinnedWadMintMarket={pinnedWadMintMarket}
       />
     );
   }
@@ -86,6 +89,7 @@ const MarketsTableContent = ({
         isLoadingBalance={isLoadingBalance}
         getMarketActionHoverHandlers={getMarketActionHoverHandlers}
         onRowMouseEnter={onRowMouseEnter}
+        pinnedWadMintMarket={pinnedWadMintMarket}
       />
     );
   }
@@ -105,6 +109,7 @@ const MarketsTableContent = ({
       isLoadingBalance={isLoadingBalance}
       getMarketActionHoverHandlers={getMarketActionHoverHandlers}
       onRowMouseEnter={onRowMouseEnter}
+      pinnedWadMintMarket={pinnedWadMintMarket}
     />
   );
 };

--- a/src/components/markets/MarketsTabletTable.tsx
+++ b/src/components/markets/MarketsTabletTable.tsx
@@ -51,6 +51,8 @@ interface MarketsTabletTableProps {
     onMintMouseEnter?: (e: React.MouseEvent) => void;
   };
   onRowMouseEnter?: (market: OnDemandMarketData) => void;
+  /** WAD Mint market pinned above paginated rows (excluded from sort/filter/page). */
+  pinnedWadMintMarket?: OnDemandMarketData | null;
 }
 
 const MarketsTabletTable = ({
@@ -66,6 +68,7 @@ const MarketsTabletTable = ({
   isLoadingBalance = false,
   getMarketActionHoverHandlers,
   onRowMouseEnter,
+  pinnedWadMintMarket,
 }: MarketsTabletTableProps) => {
   const { currentNetwork } = useNetwork();
   const { activeAccount } = useWallet();
@@ -311,7 +314,7 @@ const MarketsTabletTable = ({
     return sortedGroups;
   }, [markets, currentNetwork, sortField, sortOrder]);
 
-  if (markets.length === 0) {
+  if (markets.length === 0 && !pinnedWadMintMarket) {
     return (
       <div className="text-center py-8">
         <p className="text-ink-blue">
@@ -354,6 +357,8 @@ const MarketsTabletTable = ({
           isLoadingBalance={isLoadingBalance}
           isNested={isNested}
           marketIndex={marketIndex}
+          getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+          onRowMouseEnter={onRowMouseEnter}
         />
       );
     }
@@ -580,7 +585,33 @@ const MarketsTabletTable = ({
     );
   };
 
-  if (markets.length === 0) {
+  const renderPinnedWadMintRow = () => {
+    if (!pinnedWadMintMarket) return null;
+    const poolId =
+      pinnedWadMintMarket.marketInfo?.poolId ?? pinnedWadMintMarket.poolId;
+    const marketRowKey = (pinnedWadMintMarket as { _sortKey?: string })
+      ._sortKey;
+    return (
+      <STokenTabletRow
+        key="pinned-wad-mint"
+        market={pinnedWadMintMarket}
+        onRowClick={onRowClick}
+        onInfoClick={onInfoClick}
+        onDepositClick={(asset) =>
+          onDepositClick(asset, poolId, marketRowKey)
+        }
+        onBorrowClick={(asset) =>
+          onBorrowClick(asset, poolId, marketRowKey)
+        }
+        onMintClick={onMintClick}
+        isLoadingBalance={isLoadingBalance}
+        getMarketActionHoverHandlers={getMarketActionHoverHandlers}
+        onRowMouseEnter={onRowMouseEnter}
+      />
+    );
+  };
+
+  if (markets.length === 0 && !pinnedWadMintMarket) {
     return (
       <div className="text-center py-8">
         <p className="text-ink-blue">
@@ -603,6 +634,7 @@ const MarketsTabletTable = ({
           </TableRow>
         </TableHeader>
           <TableBody>
+            {renderPinnedWadMintRow()}
             {Object.entries(groupedMarkets).map(([symbol, symbolMarkets]) => {
               const hasMultipleMarkets = symbolMarkets.length > 1;
               const isExpanded = expandedSymbols.has(symbol);

--- a/src/components/markets/STokenCard.tsx
+++ b/src/components/markets/STokenCard.tsx
@@ -3,10 +3,10 @@ import { Progress } from "@/components/ui/progress";
 import { OnDemandMarketData } from "@/hooks/useOnDemandMarketData";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import DorkFiButton from "@/components/ui/DorkFiButton";
-import APYDisplay from "@/components/APYDisplay";
 import BorrowAPYDisplay from "@/components/BorrowAPYDisplay";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 import { useNetwork } from "@/contexts/NetworkContext";
+import { cn } from "@/lib/utils";
 import {
   borrowApyBadgeClassName,
   BORROW_APY_BADGE_STOKEN,
@@ -25,7 +25,10 @@ interface STokenCardProps {
   onInfoClick: (e: React.MouseEvent, market: OnDemandMarketData) => void;
   onDepositClick: (asset: string) => void;
   onBorrowClick: (asset: string) => void;
-  onMintClick?: (asset: string, poolId?: string) => void;
+  onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
+  marketRowKey?: string;
+  onMintMouseEnter?: (e: React.MouseEvent) => void;
+  className?: string;
 }
 
 const STokenCard = ({ 
@@ -35,19 +38,28 @@ const STokenCard = ({
   onInfoClick, 
   onDepositClick, 
   onBorrowClick,
-  onMintClick
+  onMintClick,
+  marketRowKey: marketRowKeyProp,
+  onMintMouseEnter,
+  className,
 }: STokenCardProps) => {
-  const { formatCurrency, formatPercent } = useNumberI18n();
+  const { formatCurrency, formatPercent, formatNumber } = useNumberI18n();
   const { currentNetwork } = useNetwork();
   const borrowCapReached = isAtBorrowCap(
     Number(market.totalBorrow ?? 0),
     Number(market.borrowCap ?? 0)
   );
+  const poolId = market.marketInfo?.poolId ?? market.poolId;
+  const marketRowKey =
+    marketRowKeyProp ?? (market as { _sortKey?: string })._sortKey;
 
   return (
     <DorkFiCard
       key={market.asset}
-      className="flex flex-col md:flex-row md:items-stretch gap-4 md:gap-6 border-l-4 border-l-purple-500 bg-gradient-to-r from-purple-50/30 to-pink-50/30 dark:from-purple-900/10 dark:to-pink-900/10 hover:from-purple-50 hover:to-pink-50 dark:hover:from-purple-900/20 dark:hover:to-pink-900/20 transition-all duration-300"
+      className={cn(
+        "flex flex-col md:flex-row md:items-stretch gap-4 md:gap-6 border-l-4 border-l-purple-500 bg-gradient-to-r from-purple-50/30 to-pink-50/30 dark:from-purple-900/10 dark:to-pink-900/10 hover:from-purple-50 hover:to-pink-50 dark:hover:from-purple-900/20 dark:hover:to-pink-900/20 transition-all duration-300",
+        className
+      )}
       onClick={() => onRowClick(market)}
     >
       {/* Header with logo, asset info, and info button */}
@@ -91,7 +103,10 @@ const STokenCard = ({
             />
           </Badge>
           <div className="text-xs text-purple-700 dark:text-purple-300 mt-1">
-            {formatCurrency(market.totalBorrowUSD / 1_000_000, "USD", { maximumFractionDigits: 0 })}
+            {formatCurrency(Math.round(market.totalBorrowUSD / 1_000_000), "USD", { maximumFractionDigits: 0 })}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {formatNumber(market.totalBorrow, { maximumFractionDigits: 3 })} {market.asset}
           </div>
         </div>
       </div>
@@ -117,8 +132,9 @@ const STokenCard = ({
           onClick={e => {
             e.stopPropagation();
             if (borrowCapReached) return;
-            onMintClick?.(market.asset, market.marketInfo?.poolId);
+            onMintClick?.(market.asset, poolId, marketRowKey);
           }}
+          onMouseEnter={onMintMouseEnter}
           disabled={borrowCapReached}
           title={borrowCapReached ? MINT_BORROW_CAP_TOOLTIP : undefined}
           className="w-full bg-purple-100 hover:bg-purple-200 text-purple-800 dark:bg-purple-900 dark:hover:bg-purple-800 dark:text-purple-200"

--- a/src/components/markets/STokenRow.tsx
+++ b/src/components/markets/STokenRow.tsx
@@ -26,7 +26,7 @@ interface STokenRowProps {
   onInfoClick: (e: React.MouseEvent, market: OnDemandMarketData) => void;
   onDepositClick: (asset: string) => void;
   onBorrowClick: (asset: string) => void;
-  onMintClick?: (asset: string, poolId?: string) => void;
+  onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   isLoadingBalance?: boolean;
   isNested?: boolean;
   marketIndex?: number;

--- a/src/components/markets/STokenTabletRow.tsx
+++ b/src/components/markets/STokenTabletRow.tsx
@@ -23,10 +23,20 @@ interface STokenTabletRowProps {
   onInfoClick: (e: React.MouseEvent, market: OnDemandMarketData) => void;
   onDepositClick: (asset: string) => void;
   onBorrowClick: (asset: string) => void;
-  onMintClick?: (asset: string, poolId?: string) => void;
+  onMintClick?: (asset: string, poolId?: string, marketRowKey?: string) => void;
   isLoadingBalance?: boolean;
   isNested?: boolean;
   marketIndex?: number;
+  getMarketActionHoverHandlers?: (
+    asset: string,
+    poolId?: string,
+    marketRowKey?: string
+  ) => {
+    onDepositMouseEnter?: (e: React.MouseEvent) => void;
+    onBorrowMouseEnter?: (e: React.MouseEvent) => void;
+    onMintMouseEnter?: (e: React.MouseEvent) => void;
+  };
+  onRowMouseEnter?: (market: OnDemandMarketData) => void;
 }
 
 const LoadingCell = () => (
@@ -52,18 +62,23 @@ const STokenTabletRow = ({
   isLoadingBalance = false,
   isNested = false,
   marketIndex,
+  getMarketActionHoverHandlers,
+  onRowMouseEnter,
 }: STokenTabletRowProps) => {
   const { currentNetwork } = useNetwork();
   const borrowCapReached = isAtBorrowCap(
     Number(market.totalBorrow ?? 0),
     Number(market.borrowCap ?? 0)
   );
+  const poolId = market.marketInfo?.poolId ?? market.poolId;
+  const marketRowKey = (market as { _sortKey?: string })._sortKey;
 
   return (
     <TableRow
       key={market.asset}
       className="hover:bg-gradient-to-r hover:from-purple-50 hover:to-pink-50 dark:hover:from-purple-900/20 dark:hover:to-pink-900/20 cursor-pointer transition-all duration-300 border-l-4 border-l-purple-500 bg-gradient-to-r from-purple-50/30 to-pink-50/30 dark:from-purple-900/10 dark:to-pink-900/10"
       onClick={() => onRowClick(market)}
+      onMouseEnter={() => onRowMouseEnter?.(market)}
     >
       <TableCell className="text-center">
         <div className="flex items-center justify-center gap-2">
@@ -132,12 +147,35 @@ const STokenTabletRow = ({
       <TableCell className="text-center">
         <MarketsTableActions
           asset={market.asset}
+          poolId={poolId}
+          marketRowKey={marketRowKey}
           onDepositClick={onDepositClick}
           onBorrowClick={onBorrowClick}
           onMintClick={onMintClick}
           isLoadingBalance={isLoadingBalance}
           isSToken={true}
           borrowDisabled={borrowCapReached}
+          onDepositMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              poolId,
+              marketRowKey
+            )?.onDepositMouseEnter
+          }
+          onBorrowMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              poolId,
+              marketRowKey
+            )?.onBorrowMouseEnter
+          }
+          onMintMouseEnter={
+            getMarketActionHoverHandlers?.(
+              market.asset,
+              poolId,
+              marketRowKey
+            )?.onMintMouseEnter
+          }
         />
       </TableCell>
     </TableRow>

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -210,6 +210,11 @@ export function marketRowPoolIdForFilter(m: OnDemandMarketData): string {
   return raw != null && String(raw) !== "" ? String(raw) : "";
 }
 
+/** WAD sToken mint market — rendered outside the markets table as a standalone card. */
+export function isWadMintMarket(market: OnDemandMarketData): boolean {
+  return market.isSToken === true && market.asset === "WAD";
+}
+
 export type SortField =
   | "default"
   | "asset"
@@ -934,11 +939,19 @@ export const useOnDemandMarketData = ({
     }).length;
   }, [marketDataArray, multiPoolAssetKeys]);
 
+  const wadMintMarket = useMemo(() => {
+    return (
+      marketDataArray.find(
+        (m) => isWadMintMarket(m) && !m.marketInfo?.isPaused
+      ) ?? null
+    );
+  }, [marketDataArray]);
+
   // Filter and sort data
   const { filteredData, totalPages, paginatedData } = useMemo(() => {
-    // Filter out paused markets
+    // Filter out paused markets and the standalone WAD Mint card market
     let filtered = marketDataArray.filter(
-      (market) => !market.marketInfo?.isPaused
+      (market) => !market.marketInfo?.isPaused && !isWadMintMarket(market)
     );
     // New markets only (config-driven)
     if (newMarketsOnly) {
@@ -1118,6 +1131,7 @@ export const useOnDemandMarketData = ({
     loadAllMarkets,
     isLoading: loadingMarkets.size > 0,
     marketsData,
+    wadMintMarket,
     newMarketsCount,
     rewardMarketsCount,
     multiPoolMarketsCount,


### PR DESCRIPTION
Extract the WAD Mint market from pagination, sort, and filter so it always appears pinned at the top across desktop, tablet, and card views. This was a feature request from ROAM. Keeps WAD pinned to the top because it is a special market.