### PR TITLE
fix(markets): display supply and borrow caps for wBTC markets (#492)

### DIFF
--- a/src/components/market-modal/MarketDetailStatsSection.tsx
+++ b/src/components/market-modal/MarketDetailStatsSection.tsx
@@ -18,6 +18,27 @@ function formatNumber(n: number, maxFrac = 4): string {
   });
 }
 
+function resolveMarketCapUnits(
+  fromRow: unknown,
+  fromMarketInfo: unknown
+): number | null {
+  const rowN = Number(fromRow);
+  if (Number.isFinite(rowN) && rowN > 0) return rowN;
+  if (fromMarketInfo != null && String(fromMarketInfo).trim() !== "") {
+    const infoN = parseFloat(String(fromMarketInfo));
+    if (Number.isFinite(infoN) && infoN > 0) return infoN;
+    if (Number.isFinite(infoN) && infoN === 0) return 0;
+  }
+  if (Number.isFinite(rowN) && rowN === 0) return 0;
+  return null;
+}
+
+function formatCapUnitsDisplay(cap: number | null): string {
+  if (cap === null) return "—";
+  if (cap <= 0) return "Unlimited";
+  return formatNumber(cap);
+}
+
 export interface MarketDetailStatsSectionProps {
   rawMarket: Record<string, unknown>;
   networkId: string;
@@ -52,8 +73,17 @@ export const MarketDetailStatsSection: React.FC<MarketDetailStatsSectionProps> =
   const totalBorrowUSD = Number(rawMarket.totalBorrowUSD ?? 0);
   const totalSupply = Number(rawMarket.totalSupply ?? 0);
   const totalBorrow = Number(rawMarket.totalBorrow ?? 0);
-  const supplyCap = Number(rawMarket.supplyCap ?? 0);
-  const borrowCap = Number(rawMarket.borrowCap ?? 0);
+  const marketInfo = rawMarket.marketInfo as
+    | { maxTotalDeposits?: string; maxTotalBorrows?: string }
+    | undefined;
+  const supplyCapUnits = resolveMarketCapUnits(
+    rawMarket.supplyCap,
+    marketInfo?.maxTotalDeposits
+  );
+  const borrowCapUnits = resolveMarketCapUnits(
+    rawMarket.borrowCap,
+    marketInfo?.maxTotalBorrows
+  );
   const asset = String(rawMarket.asset ?? "—");
 
   const isLoading = rawMarket.isLoading === true;
@@ -97,11 +127,11 @@ export const MarketDetailStatsSection: React.FC<MarketDetailStatsSectionProps> =
     },
     {
       label: "Supply cap (units)",
-      value: supplyCap > 0 ? formatNumber(supplyCap) : "—",
+      value: formatCapUnitsDisplay(supplyCapUnits),
     },
     {
       label: "Borrow cap (units)",
-      value: borrowCap > 0 ? formatNumber(borrowCap) : "—",
+      value: formatCapUnitsDisplay(borrowCapUnits),
     },
   ];
 

--- a/src/services/__tests__/lendingServiceCapFormat.test.ts
+++ b/src/services/__tests__/lendingServiceCapFormat.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { formatMarketCapHuman } from "../lendingService";
+
+describe("formatMarketCapHuman", () => {
+  it("preserves sub-1 caps for 8-decimal wBTC markets (issue #492)", () => {
+    expect(formatMarketCapHuman("1000000", 8)).toBe("0.0100");
+    expect(formatMarketCapHuman("100000", 8)).toBe("0.0010");
+  });
+
+  it("formats legacy wBTC caps", () => {
+    expect(formatMarketCapHuman("100000000", 8)).toBe("1.0000");
+    expect(formatMarketCapHuman("10000000", 8)).toBe("0.1000");
+  });
+
+  it("formats 6-decimal stablecoin caps", () => {
+    expect(formatMarketCapHuman("1000000000000", 6)).toBe("1000000.0000");
+  });
+});

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -327,6 +327,16 @@ function totalBorrowsIncludingInterest(
     .toFixed(4);
 }
 
+/** Human-readable supply/borrow cap from on-chain atomic units (issue #492). */
+export function formatMarketCapHuman(
+  atomicCap: string | bigint | number,
+  decimals: number
+): string {
+  return new BigNumber(atomicCap.toString())
+    .div(new BigNumber(10).pow(decimals))
+    .toFixed(4);
+}
+
 export const enhanceAVMMarketInfo = (
   market: any,
   token?: TokenConfig
@@ -424,12 +434,8 @@ export const enhanceAVMMarketInfo = (
     reserveFactor: parseFloat(market.reserveFactor.toString()) / 10000,
     borrowRate: parseFloat(market.borrowRate.toString()) / 10000,
     slope: parseFloat(market.slope.toString()) / 10000,
-    maxTotalDeposits: BigNumber(market.maxTotalDeposits.toString())
-      .div(10 ** decimals)
-      .toFixed(0),
-    maxTotalBorrows: BigNumber(market.maxTotalBorrows.toString())
-      .div(10 ** decimals)
-      .toFixed(0),
+    maxTotalDeposits: formatMarketCapHuman(market.maxTotalDeposits.toString(), decimals),
+    maxTotalBorrows: formatMarketCapHuman(market.maxTotalBorrows.toString(), decimals),
     liquidationBonus: parseFloat(market.liquidationBonus.toString()) / 10000,
     closeFactor: parseFloat(market.closeFactor.toString()) / 10000,
     totalDeposits,
@@ -808,12 +814,14 @@ export const fetchMarketInfo = async (
         reserveFactor: parseFloat(market.reserveFactor) / 10000,
         borrowRate: parseFloat(market.borrowRate) / 10000,
         slope: parseFloat(market.slope) / 10000,
-        maxTotalDeposits: BigNumber(market.maxTotalDeposits)
-          .div(10 ** token?.decimals || 0)
-          .toFixed(0),
-        maxTotalBorrows: BigNumber(market.maxTotalBorrows)
-          .div(10 ** token?.decimals || 0)
-          .toFixed(0),
+        maxTotalDeposits: formatMarketCapHuman(
+          market.maxTotalDeposits,
+          tokenDecimals
+        ),
+        maxTotalBorrows: formatMarketCapHuman(
+          market.maxTotalBorrows,
+          tokenDecimals
+        ),
         liquidationBonus: parseFloat(market.liquidationBonus) / 10000,
         closeFactor: parseFloat(market.closeFactor) / 10000,
         totalDeposits,


### PR DESCRIPTION
Format on-chain cap values with proper decimal scaling so 8-decimal wBTC caps no longer show as dashes. Fall back to marketInfo cap fields in the modal and show "Unlimited" for zero caps.