### PR TITLE
fix: load portfolio and market data correctly on first paint (#535)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import CountdownPage from "./pages/Countdown";
 import Dashboard from "./components/Dashboard";
 import Portfolio from "./components/Portfolio";
 import PoolsPage from "./pages/Pools";
+import { MarketPrefetch } from "./components/MarketPrefetch";
 import PortfolioPage from "./pages/PortfolioPage";
 //const LAUNCH_TIMESTAMP = Date.UTC(2025, 10, 21, 2, 0, 0); // Nov 20, 2025 6:00 PM PST (Nov 21, 2025 2:00 AM UTC)
 const LAUNCH_TIMESTAMP = Date.now();
@@ -68,6 +69,7 @@ function App() {
       <NetworkProvider>
         <LocaleSettingsProvider>
         <TooltipProvider delayDuration={300} skipDelayDuration={100}>
+          <MarketPrefetch />
           <Toaster />
           <Sonner />
           <BrowserRouter>

--- a/src/components/MarketPrefetch.tsx
+++ b/src/components/MarketPrefetch.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getEnabledNetworks } from "@/config";
+import { marketsQueryOptions } from "@/hooks/marketQueryKeys";
+
+/** Warm market cache on app mount so portfolio/markets load faster after wallet connect. */
+export function MarketPrefetch() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    for (const networkId of getEnabledNetworks()) {
+      void queryClient.prefetchQuery(marketsQueryOptions(networkId));
+    }
+  }, [queryClient]);
+
+  return null;
+}

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -2577,7 +2577,7 @@ const MarketsTable = () => {
 
   // Handle refresh button click
   const handleRefresh = () => {
-    loadAllMarkets();
+    loadAllMarkets(true);
     setMarketsToolbarAlgoRefreshNonce((n) => n + 1);
   };
 

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -84,6 +84,11 @@ import {
   PortfolioPositionsFilteredEmptyState,
 } from "@/components/portfolio/PortfolioPositionsFilterBar";
 import PortfolioPositionsCardHeader from "@/components/portfolio/PortfolioPositionsCardHeader";
+import { usePortfolioLoader } from "@/hooks/usePortfolioLoader";
+import {
+  applyPortfolioUserComputed,
+  extractUserProfileAvatar,
+} from "@/utils/portfolioUserComputed";
 import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
@@ -541,6 +546,15 @@ const Portfolio = () => {
   // Guards for fetchUser: prevent concurrent fetches and stale-address races
   const fetchUserInFlight = useRef(false);
   const fetchUserAddressRef = useRef<string | null>(null);
+
+  const { reloadPortfolio } = usePortfolioLoader({
+    displayAddress,
+    setUser,
+    setMarketData,
+    setUserProfileAvatar,
+    setIsLoadingData,
+    setIsLoadingPositions,
+  });
 
   // Compute final avatar: prioritize user profile avatar > resolver avatar
   // If neither exists, components will show placeholder
@@ -1175,20 +1189,16 @@ const Portfolio = () => {
               : (item.scaledDeposits || 0).toString();
           const scaledDeposits = BigInt(scaledDepositsValue);
 
-          // Get depositIndex from market data - it should be a string representation of BigInt
-          // If not available, use default SCALE (1e18) as fallback to still show the item
-          let depositIndex: bigint;
-          let depositIndexStr: string;
+          // Require market indices before showing position amounts
           if (!market?.depositIndex) {
             console.warn(
-              `[Portfolio] depositIndex not found for ${token.symbol} (poolId: ${appId}), using default SCALE`
+              `[Portfolio] depositIndex not found for ${token.symbol} (poolId: ${appId}), skipping until market data loads`
             );
-            depositIndex = SCALE;
-            depositIndexStr = SCALE.toString();
-          } else {
-            depositIndexStr = market.depositIndex.toString();
-            depositIndex = BigInt(depositIndexStr);
+            return;
           }
+
+          const depositIndexStr = market.depositIndex.toString();
+          const depositIndex = BigInt(depositIndexStr);
 
           const actualDepositsRaw =
             scaledDeposits === 0n
@@ -1255,7 +1265,10 @@ const Portfolio = () => {
             }
           }
           if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            tokenPrice = 1;
+            console.warn(
+              `[Portfolio] price not available for ${token.symbol} (poolId: ${appId}), skipping until market data loads`
+            );
+            return;
           }
 
           // Get APY
@@ -1420,20 +1433,15 @@ const Portfolio = () => {
               : (item.scaledBorrows || 0).toString();
           const scaledBorrows = BigInt(scaledBorrowsValue);
 
-          // Get borrowIndex from market data - it should be a string representation of BigInt
-          // If not available, use default SCALE (1e18) as fallback to still show the item
-          let borrowIndex: bigint;
-          let borrowIndexStr: string;
           if (!market?.borrowIndex) {
             console.warn(
-              `[Portfolio] borrowIndex not found for ${token.symbol} (poolId: ${appId}), using default SCALE`
+              `[Portfolio] borrowIndex not found for ${token.symbol} (poolId: ${appId}), skipping until market data loads`
             );
-            borrowIndex = SCALE;
-            borrowIndexStr = SCALE.toString();
-          } else {
-            borrowIndexStr = market.borrowIndex.toString();
-            borrowIndex = BigInt(borrowIndexStr);
+            return;
           }
+
+          const borrowIndexStr = market.borrowIndex.toString();
+          const borrowIndex = BigInt(borrowIndexStr);
 
           const actualBorrowsRaw =
             scaledBorrows === 0n ? 0n : (scaledBorrows * borrowIndex) / SCALE;
@@ -1498,7 +1506,10 @@ const Portfolio = () => {
             }
           }
           if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            tokenPrice = 1;
+            console.warn(
+              `[Portfolio] price not available for ${token.symbol} (poolId: ${appId}), skipping until market data loads`
+            );
+            return;
           }
 
           // Get APY
@@ -3033,72 +3044,11 @@ const Portfolio = () => {
     [signTransactions, activeAccount?.address]
   );
 
-  // Function to refresh positions data
-  const handleRefreshPositions = async () => {
-    if (!activeAccount?.address || !currentNetwork) {
-      return;
-    }
-
-    setIsLoadingPositions(true);
-    try {
-      // fetch market from node api for accurate position info
-      // Fetch fresh market data and global data first
-      const markets = await fetchAllMarkets(currentNetwork, {
-        excludeMarketsTableHidden: true,
-      });
-      // const marketDataResponse =
-      //   await dorkfiAPIService.getAllMarketDataByNetwork(currentNetwork);
-      // const freshMarketData = marketDataResponse.success
-      //   ? marketDataResponse.data
-      //   : [];
-      const marketData = markets;
-
-      if (!displayAddress) {
-        setIsLoadingPositions(false);
-        return;
-      }
-
-      const freshGlobalData = await fetchUserGlobalData(
-        displayAddress,
-        currentNetwork,
-        marketData
-      );
-
-      // Fetch user positions from all enabled networks (not just currentNetwork)
-      // This ensures VOI items don't disappear when doing Algorand transactions
-      const enabledNetworks = getEnabledNetworks();
-      const allPositions = [];
-
-      for (const networkId of enabledNetworks) {
-        try {
-          const networkMarkets = filterPortfolioVisibleMarketRows(
-            networkId as NetworkId,
-            await fetchAllMarkets(networkId)
-          );
-          const networkPositions = await fetchUserPositions(
-            displayAddress,
-            networkId,
-            networkMarkets
-          );
-          allPositions.push(...networkPositions);
-        } catch (error) {
-          console.error(
-            `Error fetching positions for network ${networkId}:`,
-            error
-          );
-        }
-      }
-
-      setMarketData(marketData);
-      setUserPositions(allPositions);
-      setUserGlobalData(freshGlobalData);
-    } catch (error) {
-      console.error("Error refreshing positions:", error);
-      setDataError("Failed to refresh positions data");
-    } finally {
-      setIsLoadingPositions(false);
-    }
-  };
+  // Function to refresh positions data (same orchestration as initial load).
+  const handleRefreshPositions = useCallback(async () => {
+    if (!displayAddress) return;
+    await reloadPortfolio(displayAddress, { soft: true });
+  }, [displayAddress, reloadPortfolio]);
 
   // Function to refresh all markets via POST requests
   const handleRefreshMarkets = useCallback(async () => {
@@ -3894,97 +3844,10 @@ const Portfolio = () => {
 
     const applyPortfolioComputed = (user: Record<string, unknown>) => {
       if (!isCurrentFetchUser()) return;
-      if (!user.globalUserData || !Array.isArray(user.globalUserData)) {
-        return;
-      }
-      console.log(
-        "[Portfolio] User data globalUserData:",
-        user.globalUserData
-      );
-      const globalCollateralValue =
-        user.globalUserData
-          .map((item: Record<string, unknown>) =>
-            BigInt(item.totalCollateralValue as string | number)
-          )
-          .reduce((acc: bigint, curr: bigint) => acc + curr, BigInt(0)) /
-        BigInt(1e12);
-      console.log(
-        "[Portfolio] Global collateral value:",
-        globalCollateralValue
-      );
-      const globalBorrowValue =
-        user.globalUserData
-          .map((item: Record<string, unknown>) =>
-            BigInt(item.totalBorrowValue as string | number)
-          )
-          .reduce((acc: bigint, curr: bigint) => acc + curr, BigInt(0)) /
-        BigInt(1e12);
-      console.log("[Portfolio] Global borrow value:", globalBorrowValue);
-      const globalNetPortfolioValue = globalCollateralValue - globalBorrowValue;
-      console.log(
-        "[Portfolio] Global net portfolio value:",
-        globalNetPortfolioValue
-      );
-
-      const networkValues: Record<
-        string,
-        {
-          collateral: number;
-          borrow: number;
-          netValue: number;
-        }
-      > = {};
-
-      user.globalUserData.forEach((item: Record<string, unknown>) => {
-        const network = String(item.network || "unknown");
-        const collateralValue = Number(
-          BigInt(String(item.totalCollateralValue ?? 0)) / BigInt(1e12)
-        );
-        const borrowValue = Number(
-          BigInt(String(item.totalBorrowValue ?? 0)) / BigInt(1e12)
-        );
-        const netValue = collateralValue - borrowValue;
-
-        if (!networkValues[network]) {
-          networkValues[network] = {
-            collateral: 0,
-            borrow: 0,
-            netValue: 0,
-          };
-        }
-
-        networkValues[network].collateral += collateralValue;
-        networkValues[network].borrow += borrowValue;
-        networkValues[network].netValue += netValue;
-      });
-
-      const deposits: Record<string, unknown>[] = [];
-      const borrows: Record<string, unknown>[] = [];
-      if (user.userData && Array.isArray(user.userData)) {
-        user.userData.forEach((item: Record<string, unknown>) => {
-          if (BigInt(String(item.scaledDeposits ?? 0)) > BigInt(0)) {
-            deposits.push(item);
-          }
-          if (BigInt(String(item.scaledBorrows ?? 0)) > BigInt(0)) {
-            borrows.push(item);
-          }
-        });
-      }
-      const computedUser = {
-        ...user,
-        computed: {
-          globalCollateralValue: Number(globalCollateralValue),
-          globalBorrowValue: Number(globalBorrowValue),
-          globalNetPortfolioValue: Number(globalNetPortfolioValue),
-          networkValues: networkValues,
-          deposits,
-          borrows,
-        },
-      };
+      const computedUser = applyPortfolioUserComputed(user);
+      if (!computedUser) return;
       console.log("[Portfolio] User:", computedUser);
-      if (!isCurrentFetchUser()) return;
       setUser(computedUser);
-      console.log("[Portfolio] Network values:", networkValues);
     };
 
     try {
@@ -4001,10 +3864,7 @@ const Portfolio = () => {
         console.log("[Portfolio] User data fetched from API:", user);
 
         if (user.avatar || user.avatarImage || user.profileImage) {
-          const avatarUrl =
-            (user.avatar || user.avatarImage || user.profileImage) as string;
-          setUserProfileAvatar(avatarUrl);
-          console.log("[Portfolio] User profile avatar found:", avatarUrl);
+          setUserProfileAvatar(extractUserProfileAvatar(user));
         } else {
           setUserProfileAvatar(null);
         }
@@ -4047,214 +3907,6 @@ const Portfolio = () => {
       }
     }
   };
-
-  useEffect(() => {
-    if (!displayAddress) return;
-    // Reset in-flight state when address changes so new address always fetches
-    fetchUserInFlight.current = false;
-    fetchUserAddressRef.current = null;
-    fetchUser(displayAddress);
-  }, [displayAddress]);
-
-  // Fetch market data for all enabled networks when user data is available.
-  // Also fires after a 6s timeout so markets load even if fetchUser stalls (xChain race).
-  useEffect(() => {
-    const fetchMarketDataForAllNetworks = async () => {
-      // Proceed if user data is ready OR address is present (markets don't require user data)
-      if (!displayAddress && !user?.computed) {
-        return;
-      }
-
-      try {
-        const enabledNetworks = getEnabledNetworks();
-
-        // Market POST `/market-data/...` for visible table rows is handled in
-        // `usePortfolioVisibleChainLive` (intersection) before user-data fetch.
-
-        // GET-backed `fetchAllMarkets` for portfolio display
-        const allMarketData: unknown[] = [];
-        for (const networkId of enabledNetworks) {
-          try {
-            const markets = filterPortfolioVisibleMarketRows(
-              networkId as NetworkId,
-              await fetchAllMarkets(networkId as NetworkId)
-            );
-            allMarketData.push(...markets);
-          } catch (error) {
-            console.error(
-              `Error fetching market data for network ${networkId}:`,
-              error
-            );
-          }
-        }
-
-        console.log("[Portfolio] Fetched market data for all networks:", {
-          count: allMarketData.length,
-          networks: enabledNetworks,
-        });
-
-        setMarketData(allMarketData);
-      } catch (error) {
-        console.error("Error fetching market data:", error);
-      }
-    };
-
-    fetchMarketDataForAllNetworks();
-    // Fallback: if user data hasn't resolved in 6s (xChain wallet init race), load markets anyway
-    const fallbackTimer = setTimeout(() => {
-      if (displayAddress) void fetchMarketDataForAllNetworks();
-    }, 6000);
-    return () => clearTimeout(fallbackTimer);
-  }, [user?.computed, activeAccount?.address, displayAddress]);
-
-  // Fetch user global data and market data when wallet connects
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     if (!activeAccount?.address || !currentNetwork) {
-  //       setUserGlobalData(null);
-  //       setMarketData([]);
-  //       return;
-  //     }
-
-  //     setIsLoadingData(true);
-  //     setDataError(null);
-
-  //     try {
-  //       console.log(
-  //         "Fetching user global data for:",
-  //         activeAccount.address,
-  //         "on network:",
-  //         currentNetwork
-  //       );
-
-  //       // fetch market data from api for faster response on page load
-  //       // Fetch markets first, then global data (so we can pass marketData for healthFactorIndex calculation)
-  //       const markets = await fetchAllMarkets(currentNetwork);
-  //       const tokens = getAllTokensWithDisplayInfo(currentNetwork);
-  //       const marketDataResponse =
-  //         await dorkfiAPIService.getAllMarketDataByNetwork(currentNetwork);
-  //       const freshMarketData = marketDataResponse.success
-  //         ? marketDataResponse.data.map((item: any) => {
-  //             // Try multiple matching strategies to find the correct token
-  //             let token = tokens.find(
-  //               (t) =>
-  //                 t.originalContractId === `${item.marketId}` &&
-  //                 t.poolId === `${item.appId}`
-  //             );
-
-  //             // If not found, try matching by underlyingContractId
-  //             if (!token) {
-  //               token = tokens.find(
-  //                 (t) =>
-  //                   t.underlyingContractId === `${item.marketId}` &&
-  //                   t.poolId === `${item.appId}`
-  //               );
-  //             }
-
-  //             // If still not found, try matching by poolId and marketId "0" (for network tokens like VOI)
-  //             if (!token && item.marketId === "0") {
-  //               token = tokens.find(
-  //                 (t) =>
-  //                   t.poolId === `${item.appId}` &&
-  //                   (t.assetId === "0" || t.originalContractId === "0")
-  //               );
-  //             }
-
-  //             // Log if token not found for debugging
-  //             if (!token) {
-  //               console.warn(
-  //                 `Token not found for marketId ${item.marketId}, appId ${item.appId}`,
-  //                 {
-  //                   availableTokens: tokens.map((t) => ({
-  //                     symbol: t.symbol,
-  //                     originalContractId: t.originalContractId,
-  //                     underlyingContractId: t.underlyingContractId,
-  //                     poolId: t.poolId,
-  //                   })),
-  //                 }
-  //               );
-  //             }
-
-  //             return enhanceAVMMarketInfo(item, token as any);
-  //           })
-  //         : [];
-  //       const marketData = markets;
-
-  //       const globalData = await fetchUserGlobalData(
-  //         activeAccount.address,
-  //         currentNetwork,
-  //         marketData
-  //       );
-
-  //       // Fetch user positions from all enabled networks
-  //       const enabledNetworks = getEnabledNetworks();
-  //       const allPositions = [];
-
-  //       for (const networkId of enabledNetworks) {
-  //         try {
-  //           const networkMarkets = await fetchAllMarkets(networkId);
-  //           const networkPositions = await fetchUserPositions(
-  //             activeAccount.address,
-  //             networkId,
-  //             networkMarkets
-  //           );
-  //           allPositions.push(...networkPositions);
-  //         } catch (error) {
-  //           console.error(
-  //             `Error fetching positions for network ${networkId}:`,
-  //             error
-  //           );
-  //         }
-  //       }
-
-  //       console.log({
-  //         markets,
-  //         freshMarketData,
-  //         marketData,
-  //         globalData: globalData,
-  //         positions: allPositions,
-  //       });
-
-  //       if (globalData) {
-  //         console.log("User global data fetched:", globalData);
-  //         setUserGlobalData(globalData);
-  //       } else {
-  //         console.log("No user global data found");
-  //         setUserGlobalData(null);
-  //       }
-
-  //       if (freshMarketData) {
-  //         console.log("Market data fetched:", freshMarketData);
-  //         setMarketData(freshMarketData);
-  //       } else {
-  //         console.log("No market data found");
-  //         setMarketData([]);
-  //       }
-
-  //       if (allPositions && allPositions.length > 0) {
-  //         console.log(
-  //           "User positions fetched from all networks:",
-  //           allPositions
-  //         );
-  //         setUserPositions(allPositions);
-  //       } else {
-  //         console.log("No user positions found");
-  //         setUserPositions([]);
-  //       }
-  //     } catch (error) {
-  //       console.error("Error fetching data:", error);
-  //       setDataError(
-  //         error instanceof Error ? error.message : "Failed to fetch data"
-  //       );
-  //       setUserGlobalData(null);
-  //       setMarketData([]);
-  //     } finally {
-  //       setIsLoadingData(false);
-  //     }
-  //   };
-
-  //   fetchData();
-  // }, [activeAccount?.address, currentNetwork]);
 
   // Reset supplied list page when filters change
   useEffect(() => {
@@ -5362,8 +5014,8 @@ const Portfolio = () => {
     [activeAccount?.address, toast]
   );
 
-  // Show loading state
-  if (isLoadingData) {
+  // Show loading state during initial portfolio fetch (headline data not ready yet)
+  if (isLoadingData && !user) {
     return (
       <div className="space-y-3 sm:space-y-6">
         {/* Hero skeleton — hidden on mobile to match connected layout */}

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -33,7 +33,6 @@ import {
   fetchMarketInfo,
   repayOnBehalf,
   liquidateCrossMarket,
-  fetchUserDataFromChain,
   postRefreshMarketDataSnapshot,
 } from "@/services/lendingService";
 import {
@@ -85,10 +84,6 @@ import {
 } from "@/components/portfolio/PortfolioPositionsFilterBar";
 import PortfolioPositionsCardHeader from "@/components/portfolio/PortfolioPositionsCardHeader";
 import { usePortfolioLoader } from "@/hooks/usePortfolioLoader";
-import {
-  applyPortfolioUserComputed,
-  extractUserProfileAvatar,
-} from "@/utils/portfolioUserComputed";
 import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
@@ -543,10 +538,6 @@ const Portfolio = () => {
   const [userProfileAvatar, setUserProfileAvatar] = useState<string | null>(
     null
   );
-  // Guards for fetchUser: prevent concurrent fetches and stale-address races
-  const fetchUserInFlight = useRef(false);
-  const fetchUserAddressRef = useRef<string | null>(null);
-
   const { reloadPortfolio } = usePortfolioLoader({
     displayAddress,
     setUser,
@@ -3174,7 +3165,7 @@ const Portfolio = () => {
       // Refresh user data after markets are updated (only if not in view-only mode)
       if (displayAddress && refreshedCount > 0 && !isViewOnly) {
         setTimeout(() => {
-          fetchUser(displayAddress);
+          void reloadPortfolio(displayAddress, { soft: true });
         }, 1000);
       } else if (isViewOnly && refreshedCount > 0) {
         // In view-only mode, just refresh the displayed data without triggering user API refresh
@@ -3201,6 +3192,8 @@ const Portfolio = () => {
     isViewOnly,
     signTransactions,
     syncUserMarketsForPriceChange,
+    reloadPortfolio,
+    handleRefreshPositions,
   ]);
 
   // Function to refresh markets for a specific section
@@ -3331,7 +3324,7 @@ const Portfolio = () => {
         // Refresh user data after markets are updated (only if not in view-only mode)
         if (displayAddress && refreshedCount > 0 && !isViewOnly) {
           setTimeout(() => {
-            fetchUser(displayAddress);
+            void reloadPortfolio(displayAddress, { soft: true });
           }, 1000);
         } else if (isViewOnly && refreshedCount > 0) {
           // In view-only mode, refresh positions data without API user refresh
@@ -3362,6 +3355,8 @@ const Portfolio = () => {
       isViewOnly,
       signTransactions,
       syncUserMarketsForPriceChange,
+      reloadPortfolio,
+      handleRefreshPositions,
     ]
   );
 
@@ -3446,7 +3441,7 @@ const Portfolio = () => {
           // Refresh user data after market is updated (only if not in view-only mode)
           if (displayAddress && !isViewOnly) {
             setTimeout(() => {
-              fetchUser(displayAddress);
+              void reloadPortfolio(displayAddress, { soft: true });
             }, 500);
           } else if (isViewOnly) {
             // In view-only mode, refresh positions data without API user refresh
@@ -3557,7 +3552,7 @@ const Portfolio = () => {
 
         if (displayAddress && !isViewOnly) {
           setTimeout(() => {
-            fetchUser(displayAddress);
+            void reloadPortfolio(displayAddress, { soft: true });
           }, 500);
         } else if (isViewOnly) {
           setTimeout(() => {
@@ -3641,7 +3636,7 @@ const Portfolio = () => {
 
         if (displayAddress && !isViewOnly) {
           setTimeout(() => {
-            fetchUser(displayAddress);
+            void reloadPortfolio(displayAddress, { soft: true });
           }, 500);
         } else if (isViewOnly) {
           setTimeout(() => {
@@ -3725,7 +3720,7 @@ const Portfolio = () => {
 
         if (displayAddress && !isViewOnly) {
           setTimeout(() => {
-            fetchUser(displayAddress);
+            void reloadPortfolio(displayAddress, { soft: true });
           }, 500);
         } else if (isViewOnly) {
           setTimeout(() => {
@@ -3806,7 +3801,7 @@ const Portfolio = () => {
 
         if (displayAddress && !isViewOnly) {
           setTimeout(() => {
-            fetchUser(displayAddress);
+            void reloadPortfolio(displayAddress, { soft: true });
           }, 500);
         } else if (isViewOnly) {
           setTimeout(() => {
@@ -3832,81 +3827,6 @@ const Portfolio = () => {
     activeAccount?.address,
     toast,
   ]);
-
-  const fetchUser = async (userAddress: string) => {
-    // Deduplicate concurrent calls for the same address; cancel stale-address results
-    if (fetchUserInFlight.current && fetchUserAddressRef.current === userAddress) return;
-    fetchUserInFlight.current = true;
-    fetchUserAddressRef.current = userAddress;
-
-    const isCurrentFetchUser = () =>
-      fetchUserAddressRef.current === userAddress;
-
-    const applyPortfolioComputed = (user: Record<string, unknown>) => {
-      if (!isCurrentFetchUser()) return;
-      const computedUser = applyPortfolioUserComputed(user);
-      if (!computedUser) return;
-      console.log("[Portfolio] User:", computedUser);
-      setUser(computedUser);
-    };
-
-    try {
-      console.log(
-        `[Portfolio] Attempting to fetch user data from API for ${userAddress}`
-      );
-      const apiResponse = await dorkfiAPIService.getUser(userAddress);
-
-      console.log("[Portfolio] API response:", apiResponse);
-
-      if (apiResponse.success && apiResponse.data) {
-        if (!isCurrentFetchUser()) return;
-        const user = apiResponse.data as Record<string, unknown>;
-        console.log("[Portfolio] User data fetched from API:", user);
-
-        if (user.avatar || user.avatarImage || user.profileImage) {
-          setUserProfileAvatar(extractUserProfileAvatar(user));
-        } else {
-          setUserProfileAvatar(null);
-        }
-
-        applyPortfolioComputed(user);
-        return;
-      }
-
-      console.error("Error fetching user data:", apiResponse);
-
-      console.log(
-        `[Portfolio] API failed; falling back to chain for ${userAddress}`
-      );
-      const chain = await fetchUserDataFromChain(userAddress);
-      if (chain && isCurrentFetchUser()) {
-        setUserProfileAvatar(null);
-        applyPortfolioComputed({
-          address: userAddress,
-          globalUserData: chain.globalUserData,
-          userData: chain.userData,
-          userDataSource: "chain",
-        });
-      }
-    } catch (error) {
-      console.error("Error fetching user global data:", error);
-      const chain = await fetchUserDataFromChain(userAddress);
-      if (chain && isCurrentFetchUser()) {
-        setUserProfileAvatar(null);
-        applyPortfolioComputed({
-          address: userAddress,
-          globalUserData: chain.globalUserData,
-          userData: chain.userData,
-          userDataSource: "chain",
-        });
-      }
-    } finally {
-      // Only clear the in-flight flag if this call is still the current one
-      if (fetchUserAddressRef.current === userAddress) {
-        fetchUserInFlight.current = false;
-      }
-    }
-  };
 
   // Reset supplied list page when filters change
   useEffect(() => {
@@ -4849,7 +4769,7 @@ const Portfolio = () => {
 
       // Refresh user data
       if (displayAddress) {
-        await fetchUser(displayAddress);
+        await reloadPortfolio(displayAddress, { soft: true });
       }
     } catch (error) {
       console.error("Liquidation error:", error);
@@ -4868,7 +4788,7 @@ const Portfolio = () => {
     signTransactions,
     marketData,
     displayAddress,
-    fetchUser,
+    reloadPortfolio,
     toast,
   ]);
 
@@ -8487,7 +8407,10 @@ const Portfolio = () => {
                 <H1 className="text-xl text-red-500 m-0">At Risk Positions</H1>
               </div>
               <button
-                onClick={() => displayAddress && fetchUser(displayAddress)}
+                onClick={() =>
+                  displayAddress &&
+                  void reloadPortfolio(displayAddress, { soft: true })
+                }
                 disabled={isLoadingPositions}
                 className="flex items-center gap-2 px-3 py-2 text-sm text-red-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Refresh positions data"
@@ -8735,7 +8658,10 @@ const Portfolio = () => {
           })
         }
         onRefreshWalletBalance={refreshWalletBalance}
-        onRefreshMarket={() => displayAddress && fetchUser(displayAddress)}
+        onRefreshMarket={() =>
+          displayAddress &&
+          void reloadPortfolio(displayAddress, { soft: true })
+        }
       />
 
       <Dialog
@@ -8932,7 +8858,7 @@ const Portfolio = () => {
 
             // Refresh user portfolio data from API
             try {
-              await fetchUser(activeAccount.address);
+              await reloadPortfolio(activeAccount.address, { soft: true });
               console.log("User portfolio refreshed from API");
             } catch (fetchError) {
               console.error("Error refreshing user portfolio:", fetchError);
@@ -9504,7 +9430,7 @@ const Portfolio = () => {
 
                   // Refresh user data
                   if (displayAddress) {
-                    await fetchUser(displayAddress);
+                    await reloadPortfolio(displayAddress, { soft: true });
                   }
                 } catch (error) {
                   console.error("Repay on behalf error:", error);

--- a/src/hooks/marketQueryKeys.ts
+++ b/src/hooks/marketQueryKeys.ts
@@ -1,0 +1,17 @@
+import type { NetworkId } from "@/config";
+import { fetchAllMarkets } from "@/services/lendingService";
+
+export const MARKETS_STALE_MS = 30_000;
+
+export const marketQueryKeys = {
+  all: ["markets"] as const,
+  network: (networkId: NetworkId) => ["markets", networkId] as const,
+};
+
+export function marketsQueryOptions(networkId: NetworkId) {
+  return {
+    queryKey: marketQueryKeys.network(networkId),
+    queryFn: () => fetchAllMarkets(networkId),
+    staleTime: MARKETS_STALE_MS,
+  };
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -439,7 +439,7 @@ export const useOnDemandMarketData = ({
         liquidationPenalty: 0,
         reserveFactor: 0,
         collectorContract: "",
-        isLoading: false,
+        isLoading: true,
         isLoaded: false,
         isSToken: tokenConfig?.isStoken || false,
         poolId: token.poolId, // Store poolId for multi-market tokens
@@ -1109,13 +1109,16 @@ export const useOnDemandMarketData = ({
   );
 
   // Load all markets (for cases where you want to preload everything)
-  const loadAllMarkets = useCallback(() => {
-    Object.keys(marketsData).forEach((marketKey) => {
-      if (!loadingMarkets.has(marketKey)) {
-        loadMarketData(marketKey);
-      }
-    });
-  }, [marketsData, loadingMarkets, loadMarketData]);
+  const loadAllMarkets = useCallback(
+    (bypassCache = false) => {
+      Object.keys(marketsData).forEach((marketKey) => {
+        if (!loadingMarkets.has(marketKey)) {
+          loadMarketData(marketKey, bypassCache);
+        }
+      });
+    },
+    [marketsData, loadingMarkets, loadMarketData]
+  );
 
   return {
     data: paginatedData,

--- a/src/hooks/usePortfolioLoader.ts
+++ b/src/hooks/usePortfolioLoader.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   collectPositionMarketKeys,
-  fetchAllMarkets,
   fetchUserDataFromChain,
   postRefreshMarketDataSnapshot,
 } from "@/services/lendingService";
@@ -17,8 +16,14 @@ import {
   applyPortfolioUserComputed,
   extractUserProfileAvatar,
 } from "@/utils/portfolioUserComputed";
+import { invalidateRpcReadCache } from "@/utils/rpcReadCache";
 
 type PortfolioUser = Record<string, unknown>;
+
+export type LoadPortfolioOptions = {
+  /** Keep existing UI visible; refresh in place with position-level loading only. */
+  soft?: boolean;
+};
 
 export interface UsePortfolioLoaderArgs {
   displayAddress: string | undefined;
@@ -113,14 +118,19 @@ export function usePortfolioLoader({
   }, [queryClient]);
 
   const loadPortfolio = useCallback(
-    async (address: string) => {
+    async (address: string, options?: LoadPortfolioOptions) => {
+      const soft = options?.soft ?? false;
       const loadId = ++loadIdRef.current;
 
-      setUser(null);
-      setMarketData([]);
-      setUserProfileAvatar(null);
-      setIsLoadingData(true);
-      setIsLoadingPositions(false);
+      if (!soft) {
+        setUser(null);
+        setMarketData([]);
+        setUserProfileAvatar(null);
+        setIsLoadingData(true);
+        setIsLoadingPositions(false);
+      } else {
+        setIsLoadingPositions(true);
+      }
 
       try {
         const [computedUser, initialMarkets] = await Promise.all([
@@ -132,12 +142,13 @@ export function usePortfolioLoader({
 
         if (computedUser) {
           setUser(computedUser);
-          const avatar = extractUserProfileAvatar(computedUser);
-          setUserProfileAvatar(avatar);
+          setUserProfileAvatar(extractUserProfileAvatar(computedUser));
         }
 
         setMarketData(initialMarkets);
-        setIsLoadingData(false);
+        if (!soft) {
+          setIsLoadingData(false);
+        }
 
         const computed = computedUser?.computed as
           | {
@@ -153,7 +164,9 @@ export function usePortfolioLoader({
 
         if (positionKeys.length === 0) return;
 
-        setIsLoadingPositions(true);
+        if (!soft) {
+          setIsLoadingPositions(true);
+        }
         await refreshPositionMarkets(computed);
         if (loadId !== loadIdRef.current) return;
 
@@ -164,7 +177,7 @@ export function usePortfolioLoader({
         setMarketData(refreshedMarkets);
       } catch (error) {
         console.error("[usePortfolioLoader] load failed:", error);
-        if (loadId === loadIdRef.current) {
+        if (loadId === loadIdRef.current && !soft) {
           setIsLoadingData(false);
         }
       } finally {
@@ -195,6 +208,7 @@ export function usePortfolioLoader({
       return;
     }
 
+    invalidateRpcReadCache();
     void loadPortfolio(displayAddress);
   }, [
     displayAddress,

--- a/src/hooks/usePortfolioLoader.ts
+++ b/src/hooks/usePortfolioLoader.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  collectPositionMarketKeys,
+  fetchAllMarkets,
+  fetchUserDataFromChain,
+  postRefreshMarketDataSnapshot,
+} from "@/services/lendingService";
+import dorkfiAPIService from "@/services/dorkfiAPIService";
+import {
+  filterPortfolioVisibleMarketRows,
+  getEnabledNetworks,
+  type NetworkId,
+} from "@/config";
+import { marketsQueryOptions } from "@/hooks/marketQueryKeys";
+import {
+  applyPortfolioUserComputed,
+  extractUserProfileAvatar,
+} from "@/utils/portfolioUserComputed";
+
+type PortfolioUser = Record<string, unknown>;
+
+export interface UsePortfolioLoaderArgs {
+  displayAddress: string | undefined;
+  setUser: (user: PortfolioUser | null) => void;
+  setMarketData: (data: unknown[]) => void;
+  setUserProfileAvatar: (avatar: string | null) => void;
+  setIsLoadingData: (loading: boolean) => void;
+  setIsLoadingPositions: (loading: boolean) => void;
+}
+
+async function fetchMarketsForAllNetworks(
+  queryClient: ReturnType<typeof useQueryClient>
+): Promise<unknown[]> {
+  const enabledNetworks = getEnabledNetworks();
+  const results = await Promise.all(
+    enabledNetworks.map(async (networkId) => {
+      const markets = await queryClient.fetchQuery(
+        marketsQueryOptions(networkId as NetworkId)
+      );
+      return filterPortfolioVisibleMarketRows(
+        networkId as NetworkId,
+        markets
+      );
+    })
+  );
+  return results.flat();
+}
+
+async function refreshPositionMarkets(
+  computed:
+    | {
+        deposits?: Record<string, unknown>[];
+        borrows?: Record<string, unknown>[];
+      }
+    | undefined
+): Promise<void> {
+  const rows = [
+    ...(computed?.deposits ?? []),
+    ...(computed?.borrows ?? []),
+  ];
+  const keys = collectPositionMarketKeys(rows);
+  if (keys.length === 0) return;
+
+  await Promise.all(
+    keys.map((k) =>
+      postRefreshMarketDataSnapshot(k.networkId, k.poolId, k.marketId)
+    )
+  );
+}
+
+async function resolveUserFromApiOrChain(
+  displayAddress: string
+): Promise<PortfolioUser | null> {
+  const apiResponse = await dorkfiAPIService.getUser(displayAddress);
+  if (apiResponse.success && apiResponse.data) {
+    return applyPortfolioUserComputed(
+      apiResponse.data as Record<string, unknown>
+    );
+  }
+
+  const chain = await fetchUserDataFromChain(displayAddress);
+  if (!chain) return null;
+
+  return applyPortfolioUserComputed({
+    address: displayAddress,
+    globalUserData: chain.globalUserData,
+    userData: chain.userData,
+    userDataSource: "chain",
+  });
+}
+
+/**
+ * Orchestrates portfolio load: parallel user + markets, then scoped POST refresh for positions.
+ */
+export function usePortfolioLoader({
+  displayAddress,
+  setUser,
+  setMarketData,
+  setUserProfileAvatar,
+  setIsLoadingData,
+  setIsLoadingPositions,
+}: UsePortfolioLoaderArgs) {
+  const queryClient = useQueryClient();
+  const loadIdRef = useRef(0);
+
+  const invalidateMarketsCache = useCallback(() => {
+    for (const networkId of getEnabledNetworks()) {
+      void queryClient.invalidateQueries({
+        queryKey: marketsQueryOptions(networkId as NetworkId).queryKey,
+      });
+    }
+  }, [queryClient]);
+
+  const loadPortfolio = useCallback(
+    async (address: string) => {
+      const loadId = ++loadIdRef.current;
+
+      setUser(null);
+      setMarketData([]);
+      setUserProfileAvatar(null);
+      setIsLoadingData(true);
+      setIsLoadingPositions(false);
+
+      try {
+        const [computedUser, initialMarkets] = await Promise.all([
+          resolveUserFromApiOrChain(address),
+          fetchMarketsForAllNetworks(queryClient),
+        ]);
+
+        if (loadId !== loadIdRef.current) return;
+
+        if (computedUser) {
+          setUser(computedUser);
+          const avatar = extractUserProfileAvatar(computedUser);
+          setUserProfileAvatar(avatar);
+        }
+
+        setMarketData(initialMarkets);
+        setIsLoadingData(false);
+
+        const computed = computedUser?.computed as
+          | {
+              deposits?: Record<string, unknown>[];
+              borrows?: Record<string, unknown>[];
+            }
+          | undefined;
+
+        const positionKeys = collectPositionMarketKeys([
+          ...(computed?.deposits ?? []),
+          ...(computed?.borrows ?? []),
+        ]);
+
+        if (positionKeys.length === 0) return;
+
+        setIsLoadingPositions(true);
+        await refreshPositionMarkets(computed);
+        if (loadId !== loadIdRef.current) return;
+
+        invalidateMarketsCache();
+        const refreshedMarkets = await fetchMarketsForAllNetworks(queryClient);
+        if (loadId !== loadIdRef.current) return;
+
+        setMarketData(refreshedMarkets);
+      } catch (error) {
+        console.error("[usePortfolioLoader] load failed:", error);
+        if (loadId === loadIdRef.current) {
+          setIsLoadingData(false);
+        }
+      } finally {
+        if (loadId === loadIdRef.current) {
+          setIsLoadingPositions(false);
+        }
+      }
+    },
+    [
+      invalidateMarketsCache,
+      queryClient,
+      setIsLoadingData,
+      setIsLoadingPositions,
+      setMarketData,
+      setUser,
+      setUserProfileAvatar,
+    ]
+  );
+
+  useEffect(() => {
+    if (!displayAddress) {
+      loadIdRef.current += 1;
+      setUser(null);
+      setMarketData([]);
+      setUserProfileAvatar(null);
+      setIsLoadingData(false);
+      setIsLoadingPositions(false);
+      return;
+    }
+
+    void loadPortfolio(displayAddress);
+  }, [
+    displayAddress,
+    loadPortfolio,
+    setIsLoadingData,
+    setIsLoadingPositions,
+    setMarketData,
+    setUser,
+    setUserProfileAvatar,
+  ]);
+
+  return { reloadPortfolio: loadPortfolio, invalidateMarketsCache };
+}

--- a/src/hooks/usePortfolioVisibleChainLive.ts
+++ b/src/hooks/usePortfolioVisibleChainLive.ts
@@ -366,7 +366,8 @@ export function usePortfolioVisibleChainLive(opts: {
             mkt.price as string | number,
             token.decimals
           )
-        : 1;
+        : null;
+      if (tp == null || !Number.isFinite(tp) || tp <= 0) continue;
 
       try {
         if (kind === "deposit") {
@@ -499,7 +500,10 @@ export function usePortfolioVisibleChainLive(opts: {
             group.market.price as string | number,
             group.tokenDecimals
           )
-        : 1;
+        : null;
+      if (tokenPrice == null || !Number.isFinite(tokenPrice) || tokenPrice <= 0) {
+        continue;
+      }
 
       let groupDepositMinted: bigint | null = null;
       const firstKey = group.rows[0]?.portfolioKey;

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1021,6 +1021,150 @@ export async function fetchFreshMarketInfo(
   }
 }
 
+const MARKET_FETCH_CONCURRENCY = 5;
+
+type DisplayToken = ReturnType<typeof getAllTokensWithDisplayInfo>[number];
+
+function marketRowKey(poolId: string, marketId: string): string {
+  return `${poolId}|${marketId}`;
+}
+
+function matchDisplayTokenForApiMarket(
+  tokens: DisplayToken[],
+  item: Record<string, unknown>
+): DisplayToken | undefined {
+  const marketId = String(item.marketId ?? "");
+  const appId = String(item.appId ?? item.poolId ?? "");
+
+  let token = tokens.find(
+    (t) =>
+      (t.underlyingContractId === marketId ||
+        t.originalContractId === marketId) &&
+      String(t.poolId) === appId
+  );
+
+  if (!token && marketId === "0") {
+    token = tokens.find(
+      (t) =>
+        String(t.poolId) === appId &&
+        (t.assetId === "0" || t.originalContractId === "0")
+    );
+  }
+
+  return token;
+}
+
+async function fetchTokensMarketInfoParallel(
+  tokens: DisplayToken[],
+  networkId: NetworkId,
+  concurrency = MARKET_FETCH_CONCURRENCY
+): Promise<MarketInfo[]> {
+  const markets: MarketInfo[] = [];
+  let index = 0;
+
+  async function worker() {
+    while (index < tokens.length) {
+      const tokenIndex = index++;
+      const token = tokens[tokenIndex];
+      try {
+        const poolId = token.poolId;
+        if (!poolId) continue;
+
+        const marketId = token.underlyingContractId || token.symbol;
+        const marketInfo = await fetchMarketInfo(poolId, marketId, networkId);
+        if (marketInfo) {
+          markets.push(marketInfo);
+        }
+      } catch (error) {
+        console.error(
+          `Error fetching market data for ${token.symbol}:`,
+          error
+        );
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, Math.max(tokens.length, 1));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return markets;
+}
+
+async function fetchAllMarketsViaBulkApi(
+  networkId: NetworkId,
+  tokens: DisplayToken[]
+): Promise<MarketInfo[] | null> {
+  try {
+    const response = await dorkfiAPIService.getAllMarketDataByNetwork(networkId);
+    if (!response?.success || !Array.isArray(response.data) || response.data.length === 0) {
+      return null;
+    }
+
+    const markets: MarketInfo[] = [];
+    const coveredKeys = new Set<string>();
+
+    for (const rawItem of response.data) {
+      const item = rawItem as Record<string, unknown>;
+      const token = matchDisplayTokenForApiMarket(tokens, item);
+      if (!token) continue;
+
+      const poolId = String(item.appId ?? item.poolId ?? token.poolId ?? "");
+      const marketId = String(item.marketId ?? token.underlyingContractId ?? "");
+      const key = marketRowKey(poolId, marketId);
+      if (coveredKeys.has(key)) continue;
+      coveredKeys.add(key);
+
+      const tokenConfig = resolveTokenConfigFromDisplayToken(networkId, token);
+      const merged = {
+        ...item,
+        network: networkId,
+        poolId,
+        appId: poolId,
+        marketId,
+      };
+      markets.push(enhanceAVMMarketInfo(merged, tokenConfig));
+    }
+
+    return markets.length > 0 ? markets : null;
+  } catch (error) {
+    console.warn("[fetchAllMarkets] bulk API failed, falling back:", error);
+    return null;
+  }
+}
+
+async function fetchAllMarketsForTokenList(
+  networkId: NetworkId,
+  tokens: DisplayToken[]
+): Promise<MarketInfo[]> {
+  const bulkMarkets = await fetchAllMarketsViaBulkApi(networkId, tokens);
+  if (bulkMarkets && bulkMarkets.length > 0) {
+    const bulkKeys = new Set(
+      bulkMarkets.map((m) =>
+        marketRowKey(String(m.poolId ?? ""), String(m.marketId ?? ""))
+      )
+    );
+    const missingTokens = tokens.filter((token) => {
+      const poolId = token.poolId;
+      if (!poolId) return false;
+      const marketId = token.underlyingContractId || token.symbol;
+      return !bulkKeys.has(marketRowKey(String(poolId), String(marketId)));
+    });
+
+    if (missingTokens.length > 0) {
+      const extra = await fetchTokensMarketInfoParallel(
+        missingTokens,
+        networkId
+      );
+      return [...bulkMarkets, ...extra];
+    }
+
+    return bulkMarkets;
+  }
+
+  return fetchTokensMarketInfoParallel(tokens, networkId);
+}
+
+
 /**
  * Fetch all markets information
  */
@@ -1029,123 +1173,40 @@ export const fetchAllMarkets = async (
   options?: { excludeMarketsTableHidden?: boolean }
 ): Promise<MarketInfo[]> => {
   try {
-    const networkConfig = getNetworkConfig(networkId);
-
     if (isAlgorandCompatibleNetwork(networkId)) {
-      // Get markets from config
       const tokens = options?.excludeMarketsTableHidden
         ? getMarketsTableVisibleTokensWithDisplayInfo(networkId)
         : getAllTokensWithDisplayInfo(networkId);
 
-      console.log("Fetching real market data for", tokens.length, "tokens");
-
-      // Fetch real market data for each token
-      const markets: MarketInfo[] = [];
-
-      for (const token of tokens) {
-        try {
-          // Use the token's own poolId from config, not the first lending pool
-          const poolId = token.poolId;
-
-          if (!poolId) {
-            console.warn(
-              `No pool ID configured for token ${token.symbol}, skipping`
-            );
-            continue;
-          }
-
-          const marketId = token.underlyingContractId || token.symbol;
-
-          console.log(
-            `Fetching market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
-          );
-
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId); // fetch from api
-
-          if (marketInfo) {
-            console.log(
-              `Successfully fetched market data for ${token.symbol}:`,
-              {
-                price: marketInfo.price,
-                totalDeposits: marketInfo.totalDeposits,
-                totalBorrows: marketInfo.totalBorrows,
-                utilizationRate: marketInfo.utilizationRate,
-              }
-            );
-            markets.push(marketInfo);
-          } else {
-            console.warn(`No market data found for ${token.symbol}, skipping`);
-          }
-        } catch (error) {
-          console.error(
-            `Error fetching market data for ${token.symbol}:`,
-            error
-          );
-          // Continue with other tokens even if one fails
-        }
-      }
-
-      console.log(`Successfully fetched ${markets.length} markets`);
+      console.log(
+        "[fetchAllMarkets] loading",
+        tokens.length,
+        "tokens for",
+        networkId
+      );
+      const markets = await fetchAllMarketsForTokenList(networkId, tokens);
+      console.log(
+        `[fetchAllMarkets] loaded ${markets.length} markets for ${networkId}`
+      );
       return markets;
-    } else if (isEVMNetwork(networkId)) {
-      // For EVM networks, fetch real market data
-      const tokens = getAllTokensWithDisplayInfo(networkId);
-
-      console.log("Fetching real EVM market data for", tokens.length, "tokens");
-
-      // Fetch real market data for each token
-      const markets: MarketInfo[] = [];
-
-      for (const token of tokens) {
-        try {
-          // Use the token's own poolId from config, not the first lending pool
-          const poolId = token.poolId;
-
-          if (!poolId) {
-            console.warn(
-              `No pool ID configured for token ${token.symbol}, skipping`
-            );
-            continue;
-          }
-
-          const marketId = token.underlyingContractId || token.symbol;
-
-          console.log(
-            `Fetching EVM market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
-          );
-
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId);
-
-          if (marketInfo) {
-            console.log(
-              `Successfully fetched EVM market data for ${token.symbol}:`,
-              {
-                price: marketInfo.price,
-                totalDeposits: marketInfo.totalDeposits,
-                totalBorrows: marketInfo.totalBorrows,
-                utilizationRate: marketInfo.utilizationRate,
-              }
-            );
-            markets.push(marketInfo);
-          } else {
-            console.warn(
-              `No EVM market data found for ${token.symbol}, skipping`
-            );
-          }
-        } catch (error) {
-          console.error(
-            `Error fetching EVM market data for ${token.symbol}:`,
-            error
-          );
-          // Continue with other tokens even if one fails
-        }
-      }
-
-      console.log(`Successfully fetched ${markets.length} EVM markets`);
-      return markets;
-    } else {
-      throw new Error("Unsupported network");
     }
+
+    if (isEVMNetwork(networkId)) {
+      const tokens = getAllTokensWithDisplayInfo(networkId);
+      console.log(
+        "[fetchAllMarkets] loading",
+        tokens.length,
+        "EVM tokens for",
+        networkId
+      );
+      const markets = await fetchAllMarketsForTokenList(networkId, tokens);
+      console.log(
+        `[fetchAllMarkets] loaded ${markets.length} EVM markets for ${networkId}`
+      );
+      return markets;
+    }
+
+    throw new Error("Unsupported network");
   } catch (error) {
     console.error("Error fetching all markets:", error);
     return [];

--- a/src/utils/__tests__/portfolioUserComputed.test.ts
+++ b/src/utils/__tests__/portfolioUserComputed.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPortfolioUserComputed,
+  extractUserProfileAvatar,
+} from "@/utils/portfolioUserComputed";
+
+describe("applyPortfolioUserComputed", () => {
+  it("returns null when globalUserData is missing", () => {
+    expect(applyPortfolioUserComputed({ address: "ADDR" })).toBeNull();
+  });
+
+  it("aggregates global totals and splits deposits/borrows", () => {
+    const result = applyPortfolioUserComputed({
+      address: "ADDR",
+      globalUserData: [
+        {
+          network: "algorand-mainnet",
+          totalCollateralValue: "2000000000000000",
+          totalBorrowValue: "500000000000000",
+        },
+        {
+          network: "voi-mainnet",
+          totalCollateralValue: "1000000000000000",
+          totalBorrowValue: "0",
+        },
+      ],
+      userData: [
+        { scaledDeposits: "100", scaledBorrows: "0" },
+        { scaledDeposits: "0", scaledBorrows: "50" },
+        { scaledDeposits: "0", scaledBorrows: "0" },
+      ],
+    });
+
+    expect(result?.computed).toMatchObject({
+      globalCollateralValue: 3000,
+      globalBorrowValue: 500,
+      globalNetPortfolioValue: 2500,
+    });
+    expect(result?.computed?.deposits).toHaveLength(1);
+    expect(result?.computed?.borrows).toHaveLength(1);
+    expect(result?.computed?.networkValues["algorand-mainnet"]).toMatchObject({
+      collateral: 2000,
+      borrow: 500,
+      netValue: 1500,
+    });
+  });
+});
+
+describe("extractUserProfileAvatar", () => {
+  it("prefers avatar, then avatarImage, then profileImage", () => {
+    expect(
+      extractUserProfileAvatar({
+        avatar: "https://a.example/1.png",
+        avatarImage: "https://a.example/2.png",
+      })
+    ).toBe("https://a.example/1.png");
+
+    expect(
+      extractUserProfileAvatar({ avatarImage: "https://a.example/2.png" })
+    ).toBe("https://a.example/2.png");
+
+    expect(extractUserProfileAvatar({})).toBeNull();
+  });
+});

--- a/src/utils/portfolioUserComputed.ts
+++ b/src/utils/portfolioUserComputed.ts
@@ -1,0 +1,86 @@
+/**
+ * Build portfolio `user` state with `computed` totals from API/chain user payload.
+ */
+export function applyPortfolioUserComputed(
+  user: Record<string, unknown>
+): Record<string, unknown> | null {
+  if (!user.globalUserData || !Array.isArray(user.globalUserData)) {
+    return null;
+  }
+
+  const globalCollateralValue =
+    user.globalUserData
+      .map((item: Record<string, unknown>) =>
+        BigInt(item.totalCollateralValue as string | number)
+      )
+      .reduce((acc: bigint, curr: bigint) => acc + curr, BigInt(0)) /
+    BigInt(1e12);
+
+  const globalBorrowValue =
+    user.globalUserData
+      .map((item: Record<string, unknown>) =>
+        BigInt(item.totalBorrowValue as string | number)
+      )
+      .reduce((acc: bigint, curr: bigint) => acc + curr, BigInt(0)) /
+    BigInt(1e12);
+
+  const globalNetPortfolioValue = globalCollateralValue - globalBorrowValue;
+
+  const networkValues: Record<
+    string,
+    { collateral: number; borrow: number; netValue: number }
+  > = {};
+
+  user.globalUserData.forEach((item: Record<string, unknown>) => {
+    const network = String(item.network || "unknown");
+    const collateralValue = Number(
+      BigInt(String(item.totalCollateralValue ?? 0)) / BigInt(1e12)
+    );
+    const borrowValue = Number(
+      BigInt(String(item.totalBorrowValue ?? 0)) / BigInt(1e12)
+    );
+    const netValue = collateralValue - borrowValue;
+
+    if (!networkValues[network]) {
+      networkValues[network] = { collateral: 0, borrow: 0, netValue: 0 };
+    }
+
+    networkValues[network].collateral += collateralValue;
+    networkValues[network].borrow += borrowValue;
+    networkValues[network].netValue += netValue;
+  });
+
+  const deposits: Record<string, unknown>[] = [];
+  const borrows: Record<string, unknown>[] = [];
+  if (user.userData && Array.isArray(user.userData)) {
+    user.userData.forEach((item: Record<string, unknown>) => {
+      if (BigInt(String(item.scaledDeposits ?? 0)) > BigInt(0)) {
+        deposits.push(item);
+      }
+      if (BigInt(String(item.scaledBorrows ?? 0)) > BigInt(0)) {
+        borrows.push(item);
+      }
+    });
+  }
+
+  return {
+    ...user,
+    computed: {
+      globalCollateralValue: Number(globalCollateralValue),
+      globalBorrowValue: Number(globalBorrowValue),
+      globalNetPortfolioValue: Number(globalNetPortfolioValue),
+      networkValues,
+      deposits,
+      borrows,
+    },
+  };
+}
+
+export function extractUserProfileAvatar(
+  user: Record<string, unknown>
+): string | null {
+  const avatarUrl = user.avatar ?? user.avatarImage ?? user.profileImage;
+  return typeof avatarUrl === "string" && avatarUrl.length > 0
+    ? avatarUrl
+    : null;
+}


### PR DESCRIPTION
## Summary
- Fixes stale/incorrect portfolio and market values on initial load by orchestrating parallel user + market fetches, clearing state on wallet change, and POST-refreshing only markets where the user has positions
- Speeds market loading with bulk `GET /market-data/{network}`, parallel fallback fetches, and app-mount market prefetch via React Query
- Removes dangerous display fallbacks (`$1` price, `1e18` index) and shows loading states instead of misleading zeros on the Markets tab

Closes #535

## Test plan
- [ ] Connect wallet on Portfolio — net worth, health, collateral, and borrow totals appear correctly without a manual browser refresh
- [ ] Supply/borrow position rows populate with correct amounts after brief load (no wild USD values on first paint)
- [ ] Switch wallet address — previous wallet data does not flash before new data loads
- [ ] Open Markets tab — TVL/APY cells show loading spinners initially, not `$0`
- [ ] Click Markets refresh — data updates even when clicked twice within 2 minutes
- [ ] Disconnect/reconnect wallet — portfolio reloads automatically with accurate figures


Made with [Cursor](https://cursor.com)