### PR TITLE
Add portfolio network/market filters and consolidate position insights

### DIFF
--- a/src/components/EnhancedHealthFactor.tsx
+++ b/src/components/EnhancedHealthFactor.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
-import React from "react";
+import React, { type ReactNode } from "react";
 import UnderwaterScene from "./liquidation/UnderwaterScene";
 import PositionStatsGrid from "./liquidation/PositionStatsGrid";
 import HealthFactorActions from "./liquidation/HealthFactorActions";
@@ -10,6 +10,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { portfolioSectionTitleClassName } from "@/components/portfolio/portfolioSectionTitle";
+import { getHealthFactorStatusPanel } from "@/utils/healthFactorUx";
 
 interface EnhancedHealthFactorProps {
   healthFactor: number | null;
@@ -26,6 +28,7 @@ interface EnhancedHealthFactorProps {
   isRefreshingMarkets?: boolean;
   onRepayDebt?: () => void;
   onWithdraw?: () => void;
+  insights?: ReactNode;
 }
 
 const EnhancedHealthFactor = ({
@@ -42,13 +45,16 @@ const EnhancedHealthFactor = ({
   isRefreshingMarkets,
   onRepayDebt,
   onWithdraw,
+  insights,
 }: EnhancedHealthFactorProps) => {
+  const hfStatusPanel = getHealthFactorStatusPanel(healthFactor);
+
   return (
     <div className="w-full max-w-7xl mx-auto animate-fade-in">
       <Card className="bg-gradient-to-br from-blue-50 via-cyan-50 to-sky-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 border-2 border-gray-200/50 dark:border-ocean-teal/30 overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-500 hover:border-ocean-teal/50">
         <CardContent className="p-6 md:p-8">
           {/* Enhanced Responsive Layout */}
-          <div className="grid grid-cols-1 xl:grid-cols-[420px,1fr] gap-8 lg:gap-10">
+          <div className="grid grid-cols-1 items-start xl:grid-cols-[420px,1fr] gap-8 lg:gap-10">
             {/* Left Side - Enhanced Health Gauge + Status message */}
             <div className="xl:border-r-2 xl:border-ocean-teal/20 xl:pr-8 order-2 xl:order-1 space-y-4">
               <UnderwaterScene
@@ -58,42 +64,22 @@ const EnhancedHealthFactor = ({
                 underwaterBg={underwaterBg}
                 onEdit={onEditProfile}
               />
-              {(healthFactor === null || healthFactor <= 1.2) && (
-                <div
-                  className={`rounded-xl border-2 p-4 transition-all duration-300 ${
-                    healthFactor === null
-                      ? "bg-slate-500/10 border-slate-500/30"
-                      : healthFactor <= 1.0
-                        ? "bg-red-500/15 border-red-500/40"
-                        : "bg-amber-500/15 border-amber-500/40"
-                  }`}
-                >
-                  <p className="text-sm font-medium text-foreground">
-                    {healthFactor === null &&
-                      "No collateral yet. Supply assets to earn yield and borrow."}
-                    {healthFactor !== null &&
-                      healthFactor <= 1.0 &&
-                      "Your health factor is at or below 1.0. Withdrawals and new borrows are blocked until you supply collateral or repay debt."}
-                    {healthFactor !== null &&
-                      healthFactor > 1.0 &&
-                      healthFactor <= 1.05 &&
-                      "You are very close to liquidation. Repay debt or add collateral to increase your buffer."}
-                    {healthFactor !== null &&
-                      healthFactor > 1.05 &&
-                      healthFactor <= 1.2 &&
-                      "Warning: limited room before your health factor becomes critical. Consider repaying or supplying more."}
-                  </p>
-                </div>
-              )}
+              <div
+                className={`rounded-xl border-2 p-4 transition-all duration-300 ${hfStatusPanel.panelClassName}`}
+              >
+                <p className="text-sm font-medium text-foreground">
+                  {hfStatusPanel.message}
+                </p>
+              </div>
             </div>
 
             {/* Right Side - Stats Panel & CTAs */}
             <div className="space-y-6 order-1 xl:order-2">
               {/* Enhanced Header */}
-              <div className="flex items-center justify-between pb-4 border-b-2 border-ocean-teal/20">
-                <div>
+              <div className="flex items-start justify-between gap-3 border-b-2 border-ocean-teal/20 pb-4">
+                <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <h2 className="text-2xl font-bold text-slate-800 dark:text-white">
+                    <h2 className={portfolioSectionTitleClassName}>
                       Position Overview
                     </h2>
                     <Tooltip>
@@ -116,11 +102,6 @@ const EnhancedHealthFactor = ({
                   <p className="text-sm text-muted-foreground mt-1">
                     Health factor is your main risk number—keep it above 1.0
                   </p>
-                  {marketContextLine ? (
-                    <p className="text-sm font-medium text-ocean-teal dark:text-cyan-400 mt-1.5">
-                      {marketContextLine}
-                    </p>
-                  ) : null}
                 </div>
                 {onRefreshMarkets && (
                   <DorkFiButton
@@ -128,7 +109,7 @@ const EnhancedHealthFactor = ({
                     disabled={isRefreshingMarkets}
                     variant="secondary"
                     size="sm"
-                    className="min-w-0"
+                    className="min-w-0 shrink-0"
                     title="Refresh all market data"
                   >
                     <RefreshCw
@@ -171,6 +152,10 @@ const EnhancedHealthFactor = ({
                 onWithdraw={onWithdraw}
                 totalBorrowed={totalBorrowed}
               />
+
+              {insights ? (
+                <div className="border-t border-border/50 pt-4">{insights}</div>
+              ) : null}
             </div>
           </div>
         </CardContent>

--- a/src/components/EnhancedHealthFactor.tsx
+++ b/src/components/EnhancedHealthFactor.tsx
@@ -6,12 +6,12 @@ import HealthFactorActions from "./liquidation/HealthFactorActions";
 import DorkFiButton from "@/components/ui/DorkFiButton";
 import { RefreshCw, HelpCircle } from "lucide-react";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
+  DesktopTooltip,
 } from "@/components/ui/tooltip";
 import { portfolioSectionTitleClassName } from "@/components/portfolio/portfolioSectionTitle";
 import { getHealthFactorStatusPanel } from "@/utils/healthFactorUx";
+import { cn } from "@/lib/utils";
+import type { PortfolioWalletStatus } from "@/components/portfolio/PortfolioWalletStatusBar";
 
 interface EnhancedHealthFactorProps {
   healthFactor: number | null;
@@ -29,6 +29,7 @@ interface EnhancedHealthFactorProps {
   onRepayDebt?: () => void;
   onWithdraw?: () => void;
   insights?: ReactNode;
+  walletStatus?: PortfolioWalletStatus;
 }
 
 const EnhancedHealthFactor = ({
@@ -46,17 +47,18 @@ const EnhancedHealthFactor = ({
   onRepayDebt,
   onWithdraw,
   insights,
+  walletStatus,
 }: EnhancedHealthFactorProps) => {
   const hfStatusPanel = getHealthFactorStatusPanel(healthFactor);
 
   return (
     <div className="w-full max-w-7xl mx-auto animate-fade-in">
       <Card className="bg-gradient-to-br from-blue-50 via-cyan-50 to-sky-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 border-2 border-gray-200/50 dark:border-ocean-teal/30 overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-500 hover:border-ocean-teal/50">
-        <CardContent className="p-6 md:p-8">
+        <CardContent className="px-4 pt-3 pb-4 sm:p-6 md:p-8">
           {/* Enhanced Responsive Layout */}
-          <div className="grid grid-cols-1 items-start xl:grid-cols-[420px,1fr] gap-8 lg:gap-10">
+          <div className="grid grid-cols-1 items-start gap-4 sm:gap-8 lg:grid-cols-[420px,1fr] lg:gap-10">
             {/* Left Side - Enhanced Health Gauge + Status message */}
-            <div className="xl:border-r-2 xl:border-ocean-teal/20 xl:pr-8 order-2 xl:order-1 space-y-4">
+            <div className="order-2 space-y-4 lg:order-1 lg:border-r-2 lg:border-ocean-teal/20 lg:pr-8">
               <UnderwaterScene
                 healthFactor={healthFactor}
                 marketContextLine={marketContextLine}
@@ -71,69 +73,65 @@ const EnhancedHealthFactor = ({
                   {hfStatusPanel.message}
                 </p>
               </div>
+              {insights ? (
+                <div className="border-t border-border/50 pt-4 lg:hidden">
+                  {insights}
+                </div>
+              ) : null}
             </div>
 
             {/* Right Side - Stats Panel & CTAs */}
-            <div className="space-y-6 order-1 xl:order-2">
-              {/* Enhanced Header */}
-              <div className="flex items-start justify-between gap-3 border-b-2 border-ocean-teal/20 pb-4">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h2 className={portfolioSectionTitleClassName}>
-                      Position Overview
-                    </h2>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
+            <div className="order-1 space-y-4 sm:space-y-6 lg:order-2">
+              {/* Enhanced Header — hidden on mobile; refresh lives in HealthFactorActions */}
+              <div className="hidden border-b-2 border-ocean-teal/20 pb-4 sm:block">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <h2 className={portfolioSectionTitleClassName}>
+                        Position Overview
+                      </h2>
+                      <DesktopTooltip
+                        className="max-w-xs text-left"
+                        content={
+                          <p>
+                            All collateral contributes to your health factor.
+                            Actions are limited so your position stays above the
+                            liquidation threshold (HF = 1.0).
+                          </p>
+                        }
+                      >
                         <button
                           type="button"
-                          className="text-muted-foreground hover:text-foreground transition-colors rounded-full p-0.5"
+                          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground rounded-full p-0.5"
                           aria-label="About health factor"
                         >
-                          <HelpCircle className="w-4 h-4" />
+                          <HelpCircle className="h-4 w-4" />
                         </button>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs text-left">
-                        <p>
-                          All collateral contributes to your health factor. Actions are limited so your position stays above the liquidation threshold (HF = 1.0).
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
+                      </DesktopTooltip>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Health factor is your main risk number—keep it above 1.0
+                    </p>
                   </div>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Health factor is your main risk number—keep it above 1.0
-                  </p>
+                  {onRefreshMarkets && (
+                    <DorkFiButton
+                      onClick={onRefreshMarkets}
+                      disabled={isRefreshingMarkets}
+                      variant="secondary"
+                      size="sm"
+                      className="min-w-0 shrink-0"
+                      title="Refresh all market data"
+                    >
+                      <RefreshCw
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          isRefreshingMarkets && "animate-spin"
+                        )}
+                      />
+                      Refresh
+                    </DorkFiButton>
+                  )}
                 </div>
-                {onRefreshMarkets && (
-                  <DorkFiButton
-                    onClick={onRefreshMarkets}
-                    disabled={isRefreshingMarkets}
-                    variant="secondary"
-                    size="sm"
-                    className="min-w-0 shrink-0"
-                    title="Refresh all market data"
-                  >
-                    <RefreshCw
-                      className={`w-4 h-4 mr-2 ${
-                        isRefreshingMarkets ? "animate-spin" : ""
-                      }`}
-                    />
-                    Refresh
-                  </DorkFiButton>
-                )}
-                {/*
-<div className={`px-3 py-1 rounded-full text-xs font-semibold ${
-  healthFactor === null ? 'bg-gray-500/20 text-gray-400' :
-  healthFactor <= 1.0 ? 'bg-red-500/20 text-red-400' :
-  healthFactor <= 1.2 ? 'bg-orange-500/20 text-orange-400' :
-  healthFactor <= 1.5 ? 'bg-yellow-500/20 text-yellow-400' :
-  'bg-green-500/20 text-green-400'
-}`}>
-  {healthFactor === null ? 'No Collateral' :
-   healthFactor <= 1.0 ? 'Critical' :
-   healthFactor <= 1.2 ? 'High Risk' :
-   healthFactor <= 1.5 ? 'Moderate' : 'Safe'}
-</div>
-*/}
               </div>
               
               {/* Stats Grid with Tooltips */}
@@ -141,6 +139,7 @@ const EnhancedHealthFactor = ({
                 totalCollateral={totalCollateral}
                 totalBorrowed={totalBorrowed}
                 healthFactor={healthFactor}
+                walletStatus={walletStatus}
               />
               
               {/* Action Buttons and Risk Warning */}
@@ -151,10 +150,14 @@ const EnhancedHealthFactor = ({
                 onRepayDebt={onRepayDebt}
                 onWithdraw={onWithdraw}
                 totalBorrowed={totalBorrowed}
+                onRefreshMarkets={onRefreshMarkets}
+                isRefreshingMarkets={isRefreshingMarkets}
               />
 
               {insights ? (
-                <div className="border-t border-border/50 pt-4">{insights}</div>
+                <div className="hidden border-t border-border/50 pt-4 lg:block">
+                  {insights}
+                </div>
               ) : null}
             </div>
           </div>

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -76,8 +76,7 @@ import { MarketRowTokenIcon } from "@/components/markets/MarketRowTokenIcon";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
 import {
   enabledNetworksHaveDMarket,
-  positionMatchesMarketFilter,
-  positionMatchesNetworkFilter,
+  itemMatchesPortfolioPositionFilters,
   type PortfolioNetworkFilterValue,
 } from "@/utils/portfolioMarketFilter";
 import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
@@ -2266,16 +2265,15 @@ const Portfolio = () => {
   }, [user?.globalUserData, deposits, borrows, marketData]);
 
   const networkPortfolioPoolsFiltered = useMemo(() => {
-    return poolPortfolioBreakdown.filter((row) => {
-      if (!positionMatchesNetworkFilter(row.network, positionsNetworkFilter)) {
-        return false;
-      }
-      return positionMatchesMarketFilter(
-        row.network,
-        row.poolId,
-        positionsMarketFilter
-      );
-    });
+    return poolPortfolioBreakdown.filter((row) =>
+      itemMatchesPortfolioPositionFilters(
+        { asset: row.title, poolId: row.poolId, network: row.network },
+        {
+          networkFilter: positionsNetworkFilter,
+          marketFilter: positionsMarketFilter,
+        }
+      )
+    );
   }, [
     poolPortfolioBreakdown,
     positionsNetworkFilter,
@@ -4269,27 +4267,28 @@ const Portfolio = () => {
   }, [positionsSearchTerm, positionsNetworkFilter, positionsMarketFilter]);
 
   const positionPassesPortfolioFilters = useCallback(
-    (item: { asset: string; poolId?: string; network?: string }) => {
-      if (positionsSearchTerm.trim()) {
-        const q = positionsSearchTerm.toLowerCase();
-        if (!item.asset.toLowerCase().includes(q)) return false;
-      }
-      const network = (item as ItemWithNetwork).network || currentNetwork;
-      if (!positionMatchesNetworkFilter(network, positionsNetworkFilter)) {
-        return false;
-      }
-      return positionMatchesMarketFilter(
-        network,
-        item.poolId,
-        positionsMarketFilter
-      );
-    },
+    (item: { asset: string; poolId?: string; network?: string }) =>
+      itemMatchesPortfolioPositionFilters(item, {
+        searchTerm: positionsSearchTerm,
+        networkFilter: positionsNetworkFilter,
+        marketFilter: positionsMarketFilter,
+        marketNetworkFallback: currentNetwork,
+      }),
     [
       positionsSearchTerm,
       positionsNetworkFilter,
       positionsMarketFilter,
       currentNetwork,
     ]
+  );
+
+  const accruedInterestPassesNetworkFilter = useCallback(
+    (item: { asset: string; network?: string }) =>
+      itemMatchesPortfolioPositionFilters(item, {
+        searchTerm: accruedInterestSearchTerm,
+        networkFilter: positionsNetworkFilter,
+      }),
+    [accruedInterestSearchTerm, positionsNetworkFilter]
   );
 
   const filteredSuppliedCount = useMemo(
@@ -5679,7 +5678,6 @@ const Portfolio = () => {
                     <PortfolioInsightsHub
                       layout="toolbar"
                       showNetworkRow={poolPortfolioBreakdown.length > 0}
-                      poolPortfolioBreakdown={poolPortfolioBreakdown}
                       networkPortfolioPoolsFiltered={
                         networkPortfolioPoolsFiltered
                       }
@@ -5750,39 +5748,7 @@ const Portfolio = () => {
                     <div className="space-y-3">
                       {(() => {
                         const filteredAndSorted = deposits
-                          .filter((deposit) => {
-                            if (positionsSearchTerm) {
-                              const searchLower =
-                                positionsSearchTerm.toLowerCase();
-                              const assetMatch = deposit.asset
-                                .toLowerCase()
-                                .includes(searchLower);
-                              if (!assetMatch) return false;
-                            }
-                            if (positionsNetworkFilter === "all")
-                              return true;
-                            const depositNetwork = (deposit as ItemWithNetwork).network;
-                            if (depositNetwork) {
-                              const normalizedNetwork =
-                                depositNetwork.toLowerCase();
-                              if (positionsNetworkFilter === "algorand") {
-                                return normalizedNetwork.includes("algorand");
-                              } else if (
-                                positionsNetworkFilter === "voi"
-                              ) {
-                                return normalizedNetwork.includes("voi");
-                              }
-                            }
-                            return true;
-                          })
-                          .filter((deposit) =>
-                            positionMatchesMarketFilter(
-                              (deposit as ItemWithNetwork).network ||
-                                currentNetwork,
-                              deposit.poolId,
-                              positionsMarketFilter
-                            )
-                          )
+                          .filter(positionPassesPortfolioFilters)
                           .sort((a, b) => {
                             let comparison = 0;
 
@@ -6336,73 +6302,7 @@ const Portfolio = () => {
                         <TableBody>
                           {(() => {
                             const filteredAndSorted = deposits
-                              .filter((deposit) => {
-                                // Filter by search term
-                                if (positionsSearchTerm) {
-                                  const searchLower =
-                                    positionsSearchTerm.toLowerCase();
-                                  const assetMatch = deposit.asset
-                                    .toLowerCase()
-                                    .includes(searchLower);
-                                  if (!assetMatch) {
-                                    return false;
-                                  }
-                                }
-
-                                // Filter by network
-                                if (positionsNetworkFilter === "all") {
-                                  return true; // Show all deposits
-                                }
-
-                                // Get network from deposit (if available) or infer from networkValues
-                                const depositNetwork = (deposit as ItemWithNetwork).network;
-                                if (depositNetwork) {
-                                  const normalizedNetwork =
-                                    depositNetwork.toLowerCase();
-                                  if (
-                                    positionsNetworkFilter === "algorand"
-                                  ) {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (
-                                    positionsNetworkFilter === "voi"
-                                  ) {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                }
-
-                                // Fallback: try to match by network values
-                                const matchingNetwork = Object.entries(
-                                  user.computed.networkValues
-                                ).find(([network, values]: [string, unknown]) => {
-                                  const normalizedNetwork =
-                                    network.toLowerCase();
-                                  if (
-                                    positionsNetworkFilter === "algorand"
-                                  ) {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (
-                                    positionsNetworkFilter === "voi"
-                                  ) {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                  return false;
-                                });
-
-                                // If we can't determine, show it (better to show than hide)
-                                return true;
-                              })
-                              .filter((deposit) =>
-                                positionMatchesMarketFilter(
-                                  (deposit as ItemWithNetwork).network ||
-                                    currentNetwork,
-                                  deposit.poolId,
-                                  positionsMarketFilter
-                                )
-                              )
+                              .filter(positionPassesPortfolioFilters)
                               .sort((a, b) => {
                                 let comparison = 0;
 
@@ -6920,49 +6820,7 @@ const Portfolio = () => {
                   {!isMobile &&
                     (() => {
                       const filteredAndSorted = deposits
-                        .filter((deposit) => {
-                          // Filter by search term
-                          if (positionsSearchTerm) {
-                            const searchLower =
-                              positionsSearchTerm.toLowerCase();
-                            const assetMatch = deposit.asset
-                              .toLowerCase()
-                              .includes(searchLower);
-                            if (!assetMatch) {
-                              return false;
-                            }
-                          }
-
-                          // Filter by network
-                          if (positionsNetworkFilter === "all") {
-                            return true;
-                          }
-
-                          const depositNetwork = (deposit as ItemWithNetwork).network;
-                          if (depositNetwork) {
-                            const normalizedNetwork =
-                              depositNetwork.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                          }
-
-                          const matchingNetwork = Object.entries(
-                            user?.computed?.networkValues || {}
-                          ).find(([network, values]: [string, unknown]) => {
-                            const normalizedNetwork = network.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                            return false;
-                          });
-
-                          return true;
-                        })
+                        .filter(positionPassesPortfolioFilters)
                         .sort((a, b) => {
                           let comparison = 0;
 
@@ -7034,39 +6892,7 @@ const Portfolio = () => {
                     <div className="space-y-3">
                       {(() => {
                         const filteredAndSorted = borrows
-                          .filter((borrow) => {
-                            if (positionsSearchTerm) {
-                              const searchLower =
-                                positionsSearchTerm.toLowerCase();
-                              const assetMatch = borrow.asset
-                                .toLowerCase()
-                                .includes(searchLower);
-                              if (!assetMatch) return false;
-                            }
-                            if (positionsNetworkFilter === "all")
-                              return true;
-                            const borrowNetwork = (borrow as ItemWithNetwork).network;
-                            if (borrowNetwork) {
-                              const normalizedNetwork =
-                                borrowNetwork.toLowerCase();
-                              if (positionsNetworkFilter === "algorand") {
-                                return normalizedNetwork.includes("algorand");
-                              } else if (
-                                positionsNetworkFilter === "voi"
-                              ) {
-                                return normalizedNetwork.includes("voi");
-                              }
-                            }
-                            return true;
-                          })
-                          .filter((borrow) =>
-                            positionMatchesMarketFilter(
-                              (borrow as ItemWithNetwork).network ||
-                                currentNetwork,
-                              borrow.poolId,
-                              positionsMarketFilter
-                            )
-                          )
+                          .filter(positionPassesPortfolioFilters)
                           .sort((a, b) => {
                             let comparison = 0;
                             switch (borrowedAssetsSort.column) {
@@ -7482,70 +7308,7 @@ const Portfolio = () => {
                         <TableBody>
                           {(() => {
                             const filteredAndSorted = borrows
-                              .filter((borrow) => {
-                                // Filter by search term
-                                if (positionsSearchTerm) {
-                                  const searchLower =
-                                    positionsSearchTerm.toLowerCase();
-                                  const assetMatch = borrow.asset
-                                    .toLowerCase()
-                                    .includes(searchLower);
-                                  if (!assetMatch) {
-                                    return false;
-                                  }
-                                }
-
-                                // Filter by network
-                                if (positionsNetworkFilter === "all") {
-                                  return true;
-                                }
-
-                                const borrowNetwork = (borrow as ItemWithNetwork).network;
-                                if (borrowNetwork) {
-                                  const normalizedNetwork =
-                                    borrowNetwork.toLowerCase();
-                                  if (
-                                    positionsNetworkFilter === "algorand"
-                                  ) {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (
-                                    positionsNetworkFilter === "voi"
-                                  ) {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                }
-
-                                const matchingNetwork = Object.entries(
-                                  user?.computed?.networkValues || {}
-                                ).find(([network, values]: [string, unknown]) => {
-                                  const normalizedNetwork =
-                                    network.toLowerCase();
-                                  if (
-                                    positionsNetworkFilter === "algorand"
-                                  ) {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (
-                                    positionsNetworkFilter === "voi"
-                                  ) {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                  return false;
-                                });
-
-                                return true;
-                              })
-                              .filter((borrow) =>
-                                positionMatchesMarketFilter(
-                                  (borrow as ItemWithNetwork).network ||
-                                    currentNetwork,
-                                  borrow.poolId,
-                                  positionsMarketFilter
-                                )
-                              )
+                              .filter(positionPassesPortfolioFilters)
                               .sort((a, b) => {
                                 let comparison = 0;
 
@@ -7905,49 +7668,7 @@ const Portfolio = () => {
                   {!isMobile &&
                     (() => {
                       const filteredAndSorted = borrows
-                        .filter((borrow) => {
-                          // Filter by search term
-                          if (positionsSearchTerm) {
-                            const searchLower =
-                              positionsSearchTerm.toLowerCase();
-                            const assetMatch = borrow.asset
-                              .toLowerCase()
-                              .includes(searchLower);
-                            if (!assetMatch) {
-                              return false;
-                            }
-                          }
-
-                          // Filter by network
-                          if (positionsNetworkFilter === "all") {
-                            return true;
-                          }
-
-                          const borrowNetwork = (borrow as ItemWithNetwork).network;
-                          if (borrowNetwork) {
-                            const normalizedNetwork =
-                              borrowNetwork.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                          }
-
-                          const matchingNetwork = Object.entries(
-                            user?.computed?.networkValues || {}
-                          ).find(([network, values]: [string, unknown]) => {
-                            const normalizedNetwork = network.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                            return false;
-                          });
-
-                          return true;
-                        })
+                        .filter(positionPassesPortfolioFilters)
                         .sort((a, b) => {
                           let comparison = 0;
 
@@ -8593,28 +8314,7 @@ const Portfolio = () => {
                     <div className="space-y-3">
                       {(() => {
                         const filteredAndSorted = accruedInterestItems
-                          .filter((item) => {
-                            if (accruedInterestSearchTerm) {
-                              const searchLower =
-                                accruedInterestSearchTerm.toLowerCase();
-                              const assetMatch = item.asset
-                                .toLowerCase()
-                                .includes(searchLower);
-                              if (!assetMatch) return false;
-                            }
-                            if (positionsNetworkFilter === "all") return true;
-                            const itemNetwork = (item as ItemWithNetwork).network;
-                            if (itemNetwork) {
-                              const normalizedNetwork =
-                                itemNetwork.toLowerCase();
-                              if (positionsNetworkFilter === "algorand") {
-                                return normalizedNetwork.includes("algorand");
-                              } else if (positionsNetworkFilter === "voi") {
-                                return normalizedNetwork.includes("voi");
-                              }
-                            }
-                            return true;
-                          })
+                          .filter(accruedInterestPassesNetworkFilter)
                           .sort((a, b) => {
                             let comparison = 0;
                             switch (accruedInterestSort.column) {
@@ -8843,54 +8543,7 @@ const Portfolio = () => {
                         <TableBody>
                           {(() => {
                             const filteredAndSorted = accruedInterestItems
-                              .filter((item) => {
-                                // Filter by search term
-                                if (accruedInterestSearchTerm) {
-                                  const searchLower =
-                                    accruedInterestSearchTerm.toLowerCase();
-                                  const assetMatch = item.asset
-                                    .toLowerCase()
-                                    .includes(searchLower);
-                                  if (!assetMatch) {
-                                    return false;
-                                  }
-                                }
-
-                                // Filter by network
-                                if (positionsNetworkFilter === "all") {
-                                  return true;
-                                }
-
-                                const itemNetwork = (item as ItemWithNetwork).network;
-                                if (itemNetwork) {
-                                  const normalizedNetwork =
-                                    itemNetwork.toLowerCase();
-                                  if (positionsNetworkFilter === "algorand") {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (positionsNetworkFilter === "voi") {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                }
-
-                                const matchingNetwork = Object.entries(
-                                  user?.computed?.networkValues || {}
-                                ).find(([network, values]: [string, unknown]) => {
-                                  const normalizedNetwork =
-                                    network.toLowerCase();
-                                  if (positionsNetworkFilter === "algorand") {
-                                    return normalizedNetwork.includes(
-                                      "algorand"
-                                    );
-                                  } else if (positionsNetworkFilter === "voi") {
-                                    return normalizedNetwork.includes("voi");
-                                  }
-                                  return false;
-                                });
-
-                                return true;
-                              })
+                              .filter(accruedInterestPassesNetworkFilter)
                               .sort((a, b) => {
                                 let comparison = 0;
 
@@ -9093,46 +8746,7 @@ const Portfolio = () => {
                   {!isMobile &&
                     (() => {
                       const filteredAndSorted = accruedInterestItems
-                        .filter((item) => {
-                          if (accruedInterestSearchTerm) {
-                            const searchLower =
-                              accruedInterestSearchTerm.toLowerCase();
-                            const assetMatch = item.asset
-                              .toLowerCase()
-                              .includes(searchLower);
-                            if (!assetMatch) {
-                              return false;
-                            }
-                          }
-
-                          if (positionsNetworkFilter === "all") {
-                            return true;
-                          }
-
-                          const itemNetwork = (item as ItemWithNetwork).network;
-                          if (itemNetwork) {
-                            const normalizedNetwork = itemNetwork.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                          }
-
-                          const matchingNetwork = Object.entries(
-                            user?.computed?.networkValues || {}
-                          ).find(([network, values]: [string, unknown]) => {
-                            const normalizedNetwork = network.toLowerCase();
-                            if (positionsNetworkFilter === "algorand") {
-                              return normalizedNetwork.includes("algorand");
-                            } else if (positionsNetworkFilter === "voi") {
-                              return normalizedNetwork.includes("voi");
-                            }
-                            return false;
-                          });
-
-                          return true;
-                        })
+                        .filter(accruedInterestPassesNetworkFilter)
                         .sort((a, b) => {
                           let comparison = 0;
 

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -105,10 +105,10 @@ import DepositsList from "./DepositsList";
 import BorrowsList from "./BorrowsList";
 import PortfolioModals from "./PortfolioModals";
 import { resolveSupplyBorrowToken } from "./SupplyBorrowModal";
-import { XchainUsdcBridgeControls } from "@/components/xchain/XchainUsdcBridgeControls";
 import PortfolioTableMobileCard from "./portfolio/PortfolioTableMobileCard";
 import AccruedInterestMobileCard from "./portfolio/AccruedInterestMobileCard";
 import PortfolioInsightsHub from "@/components/portfolio/PortfolioInsightsHub";
+import PortfolioWalletStatusBar from "@/components/portfolio/PortfolioWalletStatusBar";
 import { NftHolderClaimManualModal } from "@/components/portfolio/NftHolderClaimManualModal";
 import {
   NftHolderClaimSuccessModal,
@@ -5365,26 +5365,32 @@ const Portfolio = () => {
   // Show loading state
   if (isLoadingData) {
     return (
-      <div className="space-y-6">
-        {/* Hero Section Skeleton */}
-        <DorkFiCard className="relative text-center overflow-hidden p-6 md:p-8">
+      <div className="space-y-3 sm:space-y-6">
+        {/* Hero skeleton — hidden on mobile to match connected layout */}
+        <DorkFiCard className="relative hidden overflow-hidden p-6 text-center md:p-8 sm:block">
           <div className="relative z-10">
-            <Skeleton className="h-12 w-64 mx-auto mb-4" />
-            <Skeleton className="h-6 w-96 mx-auto" />
+            <Skeleton className="mx-auto mb-4 h-12 w-64" />
+            <Skeleton className="mx-auto h-6 w-96" />
           </div>
         </DorkFiCard>
 
         {/* Health Factor Skeleton */}
-        <DorkFiCard className="p-8">
-          <div className="grid grid-cols-1 xl:grid-cols-[420px,1fr] gap-8 lg:gap-10">
-            <div className="xl:border-r-2 xl:border-ocean-teal/20 xl:pr-8">
+        <DorkFiCard className="p-4 sm:p-8">
+          <div className="grid grid-cols-1 items-start gap-4 sm:gap-8 lg:grid-cols-[420px,1fr] lg:gap-10">
+            <div className="order-2 space-y-4 lg:order-1 lg:border-r-2 lg:border-ocean-teal/20 lg:pr-8">
               <Skeleton className="h-72 w-full rounded-2xl" />
             </div>
-            <div className="space-y-6">
-              <Skeleton className="h-8 w-48" />
+            <div className="order-1 space-y-4 sm:space-y-6 lg:order-2">
+              <Skeleton className="hidden h-8 w-48 sm:block" />
+              <div className="space-y-3 sm:hidden">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-4 w-full max-w-xs" />
+              </div>
               <div className="grid grid-cols-2 gap-4">
                 <Skeleton className="h-24 w-full" />
                 <Skeleton className="h-24 w-full" />
+                <Skeleton className="col-span-2 h-16 w-full sm:col-span-1 sm:h-24" />
+                <Skeleton className="hidden h-24 w-full sm:block" />
               </div>
             </div>
           </div>
@@ -5400,7 +5406,7 @@ const Portfolio = () => {
         {/* Hero Section */}
         <DorkFiCard
           hoverable
-          className="relative text-center overflow-hidden p-6 md:p-8"
+          className="relative text-center overflow-hidden px-6 py-3 md:px-8 md:py-4"
         >
           <div className="relative z-10">
             <H1 className="m-0 text-4xl md:text-5xl">
@@ -5439,30 +5445,33 @@ const Portfolio = () => {
   // Show loading state while avatar check is in progress
   if (!isAvatarResolved) {
     return (
-      <div className="space-y-6">
-        {/* Hero Section Skeleton */}
-        <DorkFiCard className="relative text-center overflow-hidden p-6 md:p-8">
+      <div className="space-y-3 sm:space-y-6">
+        {/* Hero skeleton — hidden on mobile to match connected layout */}
+        <DorkFiCard className="relative hidden overflow-hidden p-6 text-center md:p-8 sm:block">
           <div className="space-y-4">
-            <Skeleton className="h-12 w-64 mx-auto" />
-            <Skeleton className="h-6 w-full max-w-2xl mx-auto" />
-            <Skeleton className="h-4 w-48 mx-auto" />
+            <Skeleton className="mx-auto h-12 w-64" />
+            <Skeleton className="mx-auto h-6 w-full max-w-2xl" />
+            <Skeleton className="mx-auto h-4 w-48" />
           </div>
         </DorkFiCard>
 
         {/* Health Factor Skeleton */}
-        <DorkFiCard className="p-6 md:p-8">
-          <div className="grid grid-cols-1 xl:grid-cols-[420px,1fr] gap-8 lg:gap-10">
-            <div className="space-y-4">
-              <Skeleton className="h-8 w-32" />
+        <DorkFiCard className="p-4 sm:p-6 md:p-8">
+          <div className="grid grid-cols-1 items-start gap-4 sm:gap-8 lg:grid-cols-[420px,1fr] lg:gap-10">
+            <div className="order-2 space-y-4 lg:order-1 lg:border-r-2 lg:border-ocean-teal/20 lg:pr-8">
               <Skeleton className="h-72 w-full rounded-2xl" />
             </div>
-            <div className="space-y-4">
-              <Skeleton className="h-8 w-40" />
+            <div className="order-1 space-y-4 sm:space-y-6 lg:order-2">
+              <Skeleton className="hidden h-8 w-40 sm:block" />
+              <div className="space-y-3 sm:hidden">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-4 w-full max-w-xs" />
+              </div>
               <div className="grid grid-cols-2 gap-4">
                 <Skeleton className="h-24 w-full" />
                 <Skeleton className="h-24 w-full" />
-                <Skeleton className="h-24 w-full" />
-                <Skeleton className="h-24 w-full" />
+                <Skeleton className="col-span-2 h-16 w-full sm:col-span-1 sm:h-24" />
+                <Skeleton className="hidden h-24 w-full sm:block" />
               </div>
             </div>
           </div>
@@ -5472,11 +5481,21 @@ const Portfolio = () => {
   }
 
   return (
-    <div className="space-y-6">
-      {/* Hero Section */}
+    <div className="space-y-3 sm:space-y-6">
+      {dataError && (
+        <div className="rounded-lg border border-red-500/50 bg-red-500/20 p-3 sm:hidden">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-sm text-red-400">
+              Error loading data: {dataError}
+            </span>
+          </div>
+        </div>
+      )}
+      {/* Hero Section — hidden on mobile when connected; Portfolio Overview covers stats */}
       <DorkFiCard
         hoverable
-        className="relative text-center overflow-hidden p-6 md:p-8"
+        className="relative hidden overflow-hidden px-6 py-3 text-center sm:block md:px-8 md:py-4"
       >
         {/* Decorative elements */}
         {/* Birds - light mode only */}
@@ -5549,51 +5568,21 @@ const Portfolio = () => {
               <span className="hero-header">Portfolio Health</span>
             </H1>
           </div>
-          <Body className="text-sm sm:text-base md:text-lg lg:text-xl max-w-2xl md:max-w-none mx-auto">
-            <span className="block md:inline md:whitespace-nowrap">
-              Track Your Health Factor, Monitor Your Positions, and Manage Your
-              Portfolio.
-            </span>
-          </Body>
 
-          {/* Data Source Indicator */}
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-xs text-muted-foreground">
-            <div
-              className={`w-2 h-2 rounded-full ${user?.computed || userGlobalData
-                ? "bg-green-500"
-                : "bg-gray-500"
-                }`}
-            ></div>
-            <span>
-              {user?.computed
-                ? "Global Portfolio Data"
-                : userGlobalData
-                  ? "Live Data"
-                  : "No Data"}{" "}
-              •{" "}
-              {addressName ||
-                `${activeAccount?.address.slice(
-                  0,
-                  8
-                )}...${activeAccount?.address.slice(-8)}`}
-            </span>
-            {user?.computed?.globalNetPortfolioValue !== undefined && (
-              <span className="ml-2 shrink-0">
-                • Net Value:{" "}
-                {formatCurrency(Number(user.computed.globalNetPortfolioValue), "USD", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-              </span>
-            )}
-            <div className="mt-2 flex w-full basis-full shrink-0 justify-center px-2 empty:hidden lg:mt-0 lg:ml-2 lg:w-auto lg:basis-auto lg:px-0">
-              <XchainUsdcBridgeControls className="justify-center lg:justify-start" />
-            </div>
-            {marketData.length > 0 && totalBorrowed > 0 && (
-              <span className="ml-2">
-                • Collateral Factor:{" "}
-                {formatPercent(weightedCollateralFactor, { maximumFractionDigits: 0 })} • Liquidation
-                Threshold: {formatPercent(weightedLiquidationThreshold, { maximumFractionDigits: 1 })}
-              </span>
-            )}
-          </div>
+          <PortfolioWalletStatusBar
+            className="mt-4"
+            centered
+            hasComputedData={Boolean(user?.computed)}
+            hasUserGlobalData={Boolean(userGlobalData)}
+            addressLabel={
+              addressName ||
+              `${activeAccount?.address.slice(0, 8)}...${activeAccount?.address.slice(-8)}`
+            }
+            globalNetPortfolioValue={user?.computed?.globalNetPortfolioValue}
+            showRiskMetrics={marketData.length > 0 && totalBorrowed > 0}
+            weightedCollateralFactor={weightedCollateralFactor}
+            weightedLiquidationThreshold={weightedLiquidationThreshold}
+          />
 
           {/* Error State */}
           {dataError && (
@@ -5621,6 +5610,10 @@ const Portfolio = () => {
             walletName.includes("pera") ||
             walletName.includes("defly");
 
+          const walletAddressLabel =
+            addressName ||
+            `${activeAccount?.address.slice(0, 8)}...${activeAccount?.address.slice(-8)}`;
+
           return (
             <>
               <EnhancedHealthFactor
@@ -5628,6 +5621,15 @@ const Portfolio = () => {
                 marketContextLine={positionOverviewMarketLine}
                 totalCollateral={totalCollateral}
                 totalBorrowed={totalBorrowed}
+                walletStatus={{
+                  hasComputedData: Boolean(user?.computed),
+                  hasUserGlobalData: Boolean(userGlobalData),
+                  addressLabel: walletAddressLabel,
+                  globalNetPortfolioValue: user?.computed?.globalNetPortfolioValue,
+                  showRiskMetrics: marketData.length > 0 && totalBorrowed > 0,
+                  weightedCollateralFactor,
+                  weightedLiquidationThreshold,
+                }}
                 dorkNftImage={displayAvatar || undefined}
                 underwaterBg="/lovable-uploads/44ebe994-a30e-4eb1-a4a1-776aa2978776.png"
                 onAddCollateral={!isViewOnly ? handleAddCollateral : undefined}

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -74,6 +74,17 @@ import {
 } from "@/utils/tokenImageUtils";
 import { MarketRowTokenIcon } from "@/components/markets/MarketRowTokenIcon";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
+import {
+  enabledNetworksHaveDMarket,
+  positionMatchesMarketFilter,
+  positionMatchesNetworkFilter,
+  type PortfolioNetworkFilterValue,
+} from "@/utils/portfolioMarketFilter";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import {
+  PortfolioPositionsFilteredEmptyState,
+} from "@/components/portfolio/PortfolioPositionsFilterBar";
+import PortfolioPositionsCardHeader from "@/components/portfolio/PortfolioPositionsCardHeader";
 import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
@@ -98,7 +109,7 @@ import { resolveSupplyBorrowToken } from "./SupplyBorrowModal";
 import { XchainUsdcBridgeControls } from "@/components/xchain/XchainUsdcBridgeControls";
 import PortfolioTableMobileCard from "./portfolio/PortfolioTableMobileCard";
 import AccruedInterestMobileCard from "./portfolio/AccruedInterestMobileCard";
-import { AchievementsCompactTrigger } from "@/components/portfolio/AchievementsCompactTrigger";
+import PortfolioInsightsHub from "@/components/portfolio/PortfolioInsightsHub";
 import { NftHolderClaimManualModal } from "@/components/portfolio/NftHolderClaimManualModal";
 import {
   NftHolderClaimSuccessModal,
@@ -128,16 +139,8 @@ import {
   ArrowUp,
   ArrowDown,
   Search,
-  Filter,
-  ChevronDown,
-  ChevronUp,
-  Gift,
-  ChevronRight,
   Loader2,
 } from "lucide-react";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -147,14 +150,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  PieChart,
-  Pie,
-  Cell,
-  ResponsiveContainer,
-  Legend,
-  Tooltip,
-} from "recharts";
 import {
   Table,
   TableBody,
@@ -465,8 +460,8 @@ const Portfolio = () => {
   const { toast } = useToast();
   const breakpoint = useBreakpoint();
   const isMobile = breakpoint === "mobile";
-  /** Matches Tailwind `lg` (1024px+) — wide layouts for Portfolio controls */
-  const isLargePortfolioScreen = breakpoint === "desktop";
+  const isNarrowPositionsViewport =
+    breakpoint === "mobile" || breakpoint === "tablet";
 
   const [depositModal, setDepositModal] = useState<{
     isOpen: boolean;
@@ -617,34 +612,30 @@ const Portfolio = () => {
     !showPortfolioRewardsClaim &&
     !showPortfolioNftHolderRewardsNoBalance;
 
-  const [selectedNetworkFilter, setSelectedNetworkFilter] =
-    useState<string>("all");
-  const [suppliedAssetsNetworkFilter, setSuppliedAssetsNetworkFilter] =
-    useState<string>("all");
-  const [borrowedAssetsNetworkFilter, setBorrowedAssetsNetworkFilter] =
-    useState<string>("all");
-  const [suppliedAssetsMarketFilter, setSuppliedAssetsMarketFilter] =
-    useState<string>("both");
-  const [borrowedAssetsMarketFilter, setBorrowedAssetsMarketFilter] =
-    useState<string>("both");
-  const [atRiskAssetsMarketFilter, setAtRiskAssetsMarketFilter] =
-    useState<string>("both");
-  const [suppliedAssetsFilterModalOpen, setSuppliedAssetsFilterModalOpen] =
-    useState<boolean>(false);
-  const [borrowedAssetsFilterModalOpen, setBorrowedAssetsFilterModalOpen] =
-    useState<boolean>(false);
-  const [atRiskAssetsFilterModalOpen, setAtRiskAssetsFilterModalOpen] =
-    useState<boolean>(false);
+  const [positionsNetworkFilter, setPositionsNetworkFilter] =
+    useState<PortfolioNetworkFilterValue>("all");
+  const [positionsMarketFilter, setPositionsMarketFilter] =
+    useState<MarketFilter>("all");
+  const [positionsSearchTerm, setPositionsSearchTerm] = useState("");
+  const hasDMarketTab = useMemo(() => enabledNetworksHaveDMarket(), []);
+
+  useEffect(() => {
+    if (hasDMarketTab) return;
+    if (positionsMarketFilter === "D") setPositionsMarketFilter("all");
+  }, [hasDMarketTab, positionsMarketFilter]);
+
+  const clearPositionsFilters = useCallback(() => {
+    setPositionsNetworkFilter("all");
+    setPositionsMarketFilter("all");
+    setPositionsSearchTerm("");
+  }, []);
+
   const [suppliedAssetsSort, setSuppliedAssetsSort] = useState<{
     column: string | null;
     direction: "asc" | "desc";
   }>({ column: "apy", direction: "desc" });
-  const [suppliedAssetsSearchTerm, setSuppliedAssetsSearchTerm] =
-    useState<string>("");
   const [suppliedAssetsPage, setSuppliedAssetsPage] = useState(0);
   const suppliedAssetsTableRef = useRef<HTMLDivElement>(null);
-  const [borrowedAssetsSearchTerm, setBorrowedAssetsSearchTerm] =
-    useState<string>("");
   const [portfolioPositionsTab, setPortfolioPositionsTab] = useState<
     "supplied" | "borrowed"
   >("supplied");
@@ -663,7 +654,6 @@ const Portfolio = () => {
     column: string | null;
     direction: "asc" | "desc";
   }>({ column: "value", direction: "desc" });
-  const [networkPortfolioOpen, setNetworkPortfolioOpen] = useState(false);
   const [atRiskAssetsSort, setAtRiskAssetsSort] = useState<{
     column: string | null;
     direction: "asc" | "desc";
@@ -1970,17 +1960,6 @@ const Portfolio = () => {
   // Prefer each pool's get_global_user-style totals from `user.globalUserData`; portfolio HF = worst (min) HF
   // across pools with borrows. Fallback to aggregate collateral/borrow when per-pool data is missing.
 
-  const calculateHealthFactor = (
-    collateral: number,
-    borrowed: number
-  ): number | null =>
-    calculateUserHealthFactor(
-      collateral,
-      borrowed,
-      minLiquidationThresholdForHealth,
-      "portfolio"
-    );
-
   const { healthFactor, hfWorstPoolId, hfWorstNetwork } = useMemo(() => {
     const md = marketData as Array<{
       symbol?: string;
@@ -2092,10 +2071,11 @@ const Portfolio = () => {
     return Math.min(healthFactor, 3.0);
   };
 
-  /** One row per lending pool (`globalUserData`), for Network Portfolio — not network-aggregated. */
+  /** One row per lending pool, for Network Portfolio — not network-aggregated. */
   const poolPortfolioBreakdown = useMemo(() => {
-    const gud = user?.globalUserData;
-    if (!Array.isArray(gud) || gud.length === 0) return [];
+    const gudArray = Array.isArray(user?.globalUserData)
+      ? user.globalUserData
+      : [];
 
     const md = marketData as Array<{
       symbol?: string;
@@ -2127,22 +2107,17 @@ const Portfolio = () => {
         : normalizeLiquidationThresholdToDecimal(undefined);
     };
 
-    const rows: Array<{
-      poolKey: string;
+    type PoolAgg = {
       poolId: string;
       network: string;
-      networkDisplayName: string;
-      marketLabel: string | null;
-      title: string;
-      chartLabel: string;
       collateral: number;
       borrow: number;
-      netValue: number;
-      healthFactor: number | null;
-      liquidationMargin: number;
-    }> = [];
+      fromGud: boolean;
+    };
 
-    for (const raw of gud) {
+    const byKey = new Map<string, PoolAgg>();
+
+    for (const raw of gudArray) {
       const rec = raw as Record<string, unknown>;
       const poolId = String(rec.appId ?? rec.poolId ?? "");
       if (!poolId) continue;
@@ -2160,9 +2135,80 @@ const Portfolio = () => {
         continue;
       }
 
-      if (collateral <= 0 && borrow <= 0) continue;
-
       const network = String(rec.network || "unknown");
+      byKey.set(`${network}:${poolId}`, {
+        poolId,
+        network,
+        collateral,
+        borrow,
+        fromGud: true,
+      });
+    }
+
+    const ensurePool = (network: string, poolId: string) => {
+      if (!poolId || !network) return;
+      const key = `${network}:${poolId}`;
+      if (!byKey.has(key)) {
+        byKey.set(key, {
+          poolId,
+          network,
+          collateral: 0,
+          borrow: 0,
+          fromGud: false,
+        });
+      }
+    };
+
+    for (const deposit of deposits) {
+      ensurePool(
+        String((deposit as ItemWithNetwork).network ?? ""),
+        String(deposit.poolId ?? "")
+      );
+    }
+    for (const borrow of borrows) {
+      ensurePool(
+        String((borrow as ItemWithNetwork).network ?? ""),
+        String(borrow.poolId ?? "")
+      );
+    }
+
+    for (const agg of byKey.values()) {
+      if (agg.fromGud) continue;
+      agg.collateral = deposits
+        .filter(
+          (d) =>
+            String(d.poolId ?? "") === agg.poolId &&
+            String((d as ItemWithNetwork).network ?? "") === agg.network
+        )
+        .reduce((sum, d) => sum + (d.value || 0), 0);
+      agg.borrow = borrows
+        .filter(
+          (b) =>
+            String(b.poolId ?? "") === agg.poolId &&
+            String((b as ItemWithNetwork).network ?? "") === agg.network
+        )
+        .reduce((sum, b) => sum + (b.value || 0), 0);
+    }
+
+    const rows: Array<{
+      poolKey: string;
+      poolId: string;
+      network: string;
+      networkDisplayName: string;
+      marketLabel: string | null;
+      title: string;
+      chartLabel: string;
+      collateral: number;
+      borrow: number;
+      netValue: number;
+      healthFactor: number | null;
+      liquidationMargin: number;
+    }> = [];
+
+    for (const agg of byKey.values()) {
+      if (agg.collateral <= 0 && agg.borrow <= 0) continue;
+
+      const { poolId, network, collateral, borrow } = agg;
       const networkDisplayName = network
         .split("-")
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -2217,17 +2263,24 @@ const Portfolio = () => {
     return rows.sort(
       (a, b) => b.collateral + b.borrow - (a.collateral + a.borrow)
     );
-  }, [user?.globalUserData, deposits, marketData]);
+  }, [user?.globalUserData, deposits, borrows, marketData]);
 
   const networkPortfolioPoolsFiltered = useMemo(() => {
     return poolPortfolioBreakdown.filter((row) => {
-      if (selectedNetworkFilter === "all") return true;
-      const n = row.network.toLowerCase();
-      if (selectedNetworkFilter === "algorand") return n.includes("algorand");
-      if (selectedNetworkFilter === "voi") return n.includes("voi");
-      return true;
+      if (!positionMatchesNetworkFilter(row.network, positionsNetworkFilter)) {
+        return false;
+      }
+      return positionMatchesMarketFilter(
+        row.network,
+        row.poolId,
+        positionsMarketFilter
+      );
     });
-  }, [poolPortfolioBreakdown, selectedNetworkFilter]);
+  }, [
+    poolPortfolioBreakdown,
+    positionsNetworkFilter,
+    positionsMarketFilter,
+  ]);
 
   // Fetch wallet balance when repay modal opens
   useEffect(() => {
@@ -4208,20 +4261,46 @@ const Portfolio = () => {
   // Reset supplied list page when filters change
   useEffect(() => {
     setSuppliedAssetsPage(0);
-  }, [suppliedAssetsSearchTerm, suppliedAssetsNetworkFilter]);
+  }, [positionsSearchTerm, positionsNetworkFilter, positionsMarketFilter]);
 
   // Reset borrowed list page when filters change
   useEffect(() => {
     setBorrowedAssetsPage(0);
-  }, [borrowedAssetsSearchTerm, borrowedAssetsNetworkFilter]);
+  }, [positionsSearchTerm, positionsNetworkFilter, positionsMarketFilter]);
 
-  // Section filter modals are mobile-only; close when viewport shows inline filters
-  useEffect(() => {
-    if (breakpoint !== "mobile") {
-      setSuppliedAssetsFilterModalOpen(false);
-      setBorrowedAssetsFilterModalOpen(false);
-    }
-  }, [breakpoint]);
+  const positionPassesPortfolioFilters = useCallback(
+    (item: { asset: string; poolId?: string; network?: string }) => {
+      if (positionsSearchTerm.trim()) {
+        const q = positionsSearchTerm.toLowerCase();
+        if (!item.asset.toLowerCase().includes(q)) return false;
+      }
+      const network = (item as ItemWithNetwork).network || currentNetwork;
+      if (!positionMatchesNetworkFilter(network, positionsNetworkFilter)) {
+        return false;
+      }
+      return positionMatchesMarketFilter(
+        network,
+        item.poolId,
+        positionsMarketFilter
+      );
+    },
+    [
+      positionsSearchTerm,
+      positionsNetworkFilter,
+      positionsMarketFilter,
+      currentNetwork,
+    ]
+  );
+
+  const filteredSuppliedCount = useMemo(
+    () => deposits.filter(positionPassesPortfolioFilters).length,
+    [deposits, positionPassesPortfolioFilters]
+  );
+
+  const filteredBorrowedCount = useMemo(
+    () => borrows.filter(positionPassesPortfolioFilters).length,
+    [borrows, positionPassesPortfolioFilters]
+  );
 
   const handleDepositClick = async (
     asset: string,
@@ -5595,916 +5674,115 @@ const Portfolio = () => {
                 }
                 onRefreshMarkets={handleRefreshMarkets}
                 isRefreshingMarkets={isRefreshingMarkets}
+                insights={
+                  poolPortfolioBreakdown.length > 0 || displayAddress ? (
+                    <PortfolioInsightsHub
+                      layout="toolbar"
+                      showNetworkRow={poolPortfolioBreakdown.length > 0}
+                      poolPortfolioBreakdown={poolPortfolioBreakdown}
+                      networkPortfolioPoolsFiltered={
+                        networkPortfolioPoolsFiltered
+                      }
+                      positionsNetworkFilter={positionsNetworkFilter}
+                      positionsMarketFilter={positionsMarketFilter}
+                      borrows={borrows}
+                      healthFactor={healthFactor}
+                      displayHealthFactor={displayHealthFactor}
+                      totalBorrowed={totalBorrowed}
+                      isMobile={isMobile}
+                      displayAddress={displayAddress}
+                      isViewOnly={isViewOnly}
+                      showNftRow={!isViewOnly && Boolean(displayAddress)}
+                      nftRewardsLoading={showPortfolioNftHolderRewardsFetching}
+                      nftClaimableDisplay={nftHolderClaimableDisplayWithSymbol}
+                      nftHasClaimable={showPortfolioRewardsClaim}
+                      onOpenNftRewards={() =>
+                        setNftHolderRewardsClaimModalOpen(true)
+                      }
+                    />
+                  ) : undefined
+                }
               />
-              {displayAddress ? (
-                <div className="mx-auto mt-4 w-full max-w-7xl animate-fade-in">
-                  <AchievementsCompactTrigger
-                    address={displayAddress}
-                    isViewOnly={isViewOnly}
-                  />
-                </div>
-              ) : null}
-              {showPortfolioNftHolderRewardsFetching && (
-                <div className="mx-auto mt-4 w-full max-w-7xl animate-fade-in">
-                  <div
-                    role="status"
-                    aria-busy="true"
-                    aria-live="polite"
-                    aria-label="Loading NFT holder rewards"
-                    className="flex w-full flex-col gap-4 rounded-xl border border-yellow-400/30 bg-gradient-to-r from-yellow-400/10 via-amber-950/20 to-slate-900/50 px-4 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6 sm:py-5 dark:border-yellow-500/25"
-                  >
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                      <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-yellow-400/75 text-slate-900 dark:bg-yellow-400/60">
-                        <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
-                      </div>
-                      <div className="min-w-0 flex-1 space-y-2">
-                        <p className="text-base font-semibold text-slate-900 dark:text-yellow-100">
-                          NFT holder rewards
-                        </p>
-                        <p className="text-sm leading-snug text-slate-700 dark:text-slate-300">
-                          Fetching your claim agent snapshot—claimable amount and next steps will
-                          show here in a moment.
-                        </p>
-                        <div className="flex flex-col gap-1.5 pt-0.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
-                          <Skeleton className="h-4 w-36 bg-slate-600/35 dark:bg-slate-700/70" />
-                          <Skeleton className="h-4 w-48 bg-slate-600/35 dark:bg-slate-700/70" />
-                        </div>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      disabled
-                      variant="outline"
-                      className="h-auto w-full shrink-0 cursor-wait border-yellow-500/30 px-5 py-3 opacity-70 sm:w-auto"
-                      aria-disabled
-                    >
-                      <span className="flex items-center justify-center gap-2">
-                        <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
-                        Loading…
-                      </span>
-                    </Button>
-                  </div>
-                </div>
-              )}
-              {showPortfolioRewardsClaim && (
-                <div className="w-full max-w-7xl mx-auto mt-4 animate-fade-in">
-                  <div
-                    role="region"
-                    aria-label="Dork NFT holder rewards"
-                    className="w-full flex flex-col gap-4 rounded-xl border-2 border-yellow-400/60 bg-gradient-to-r from-yellow-400/20 via-amber-100/80 to-yellow-400/15 px-4 py-4 shadow-md sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6 sm:py-5 dark:border-yellow-400/35 dark:from-yellow-400/12 dark:via-amber-950/40 dark:to-yellow-500/10"
-                  >
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                      <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-yellow-400 text-slate-900 shadow-sm dark:bg-yellow-400/90">
-                        <Gift className="h-5 w-5" aria-hidden="true" />
-                      </div>
-                      <div className="min-w-0 space-y-1">
-                        <p className="text-base font-semibold text-slate-900 dark:text-yellow-100">
-                          NFT holder rewards
-                        </p>
-                        <p className="text-sm leading-snug text-slate-700 dark:text-slate-300">
-                          Weekly distributions for Dork and Dork V2 holders. Claimable now:{" "}
-                          <span className="font-semibold text-slate-900 dark:text-yellow-50 tabular-nums">
-                            {nftHolderClaimableDisplayWithSymbol}
-                          </span>
-                          . Continue below to choose settlement.
-                        </p>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      onClick={() => setNftHolderRewardsClaimModalOpen(true)}
-                      className="h-auto w-full shrink-0 border-2 border-yellow-500 bg-yellow-400 px-5 py-3 text-base font-bold text-slate-900 shadow hover:bg-yellow-300 focus-visible:ring-yellow-500 sm:w-auto sm:py-3"
-                      aria-label={`Claim UNIT — Dork NFT holder rewards (${nftHolderClaimableDisplayWithSymbol} claimable)`}
-                    >
-                      <span className="flex items-center justify-center gap-2">
-                        Claim UNIT
-                        <ChevronRight className="h-5 w-5 shrink-0" aria-hidden="true" />
-                      </span>
-                    </Button>
-                  </div>
-                </div>
-              )}
-              {showPortfolioNftHolderRewardsNoBalance && (
-                <div className="w-full max-w-7xl mx-auto mt-4 animate-fade-in">
-                  <div
-                    role="region"
-                    aria-label="Dork NFT holder rewards status"
-                    className="w-full flex flex-col gap-4 rounded-xl border border-ocean-teal/25 bg-muted/40 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6 sm:py-5 dark:border-ocean-teal/20 dark:bg-slate-900/50"
-                  >
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                      <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-ocean-teal/30 bg-background text-ocean-teal dark:text-cyan-400">
-                        <Info className="h-5 w-5" aria-hidden="true" />
-                      </div>
-                      <div className="min-w-0 space-y-1">
-                        <p className="text-base font-semibold text-foreground">
-                          NFT holder rewards
-                        </p>
-                        <p className="text-sm leading-snug text-muted-foreground">
-                          No claimable balance right now for this wallet. Dork and Dork V2
-                          holders receive weekly distributions—check back after the next drop,
-                          or open Markets anytime.
-                        </p>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => navigate("/market")}
-                      className="h-auto w-full shrink-0 border-ocean-teal/40 px-5 py-3 sm:w-auto"
-                      aria-label="Open Markets"
-                    >
-                      <span className="flex items-center justify-center gap-2">
-                        View Markets
-                        <ChevronRight className="h-5 w-5 shrink-0" aria-hidden="true" />
-                      </span>
-                    </Button>
-                  </div>
-                </div>
-              )}
             </>
           );
         })()}
-
-      {/* Network Portfolio Breakdown */}
-      {user?.computed?.networkValues &&
-        Object.keys(user.computed.networkValues).length > 0 && (
-          <DorkFiCard className="p-6 md:p-8">
-            <Collapsible open={networkPortfolioOpen} onOpenChange={setNetworkPortfolioOpen}>
-              <CollapsibleTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="w-full min-w-0 flex items-start justify-between gap-3 p-0 h-auto hover:bg-transparent mb-6 text-left"
-                >
-                  <div className="min-w-0 flex-1 text-left">
-                    <H1 className="text-2xl md:text-3xl mb-1">Network Portfolio</H1>
-                    <Body className="text-xs sm:text-sm text-muted-foreground leading-snug">
-                      Per-pool on-chain totals. Network tabs filter the chart and cards.
-                    </Body>
-                  </div>
-                  {networkPortfolioOpen ? (
-                    <ChevronUp className="w-5 h-5 shrink-0 mt-1 text-muted-foreground" />
-                  ) : (
-                    <ChevronDown className="w-5 h-5 shrink-0 mt-1 text-muted-foreground" />
-                  )}
-                </Button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-            {/* Network Filter Tabs */}
-            <Tabs
-              value={selectedNetworkFilter}
-              onValueChange={setSelectedNetworkFilter}
-              className="w-full"
-            >
-              <TabsList className="grid w-full grid-cols-3 mb-6">
-                <TabsTrigger value="all" className="text-sm">
-                  All Networks
-                </TabsTrigger>
-                <TabsTrigger value="algorand" className="text-sm">
-                  Algorand
-                </TabsTrigger>
-                <TabsTrigger value="voi" className="text-sm">
-                  VOI
-                </TabsTrigger>
-              </TabsList>
-
-              {/* Visual Slice: Allocation + Risk */}
-              {(() => {
-                // Collateral allocation: one slice per lending pool (not network-aggregate)
-                const allocationData = networkPortfolioPoolsFiltered
-                  .map((row) => ({
-                    name: row.chartLabel,
-                    value: row.collateral,
-                    poolKey: row.poolKey,
-                  }))
-                  .filter((item) => item.value > 0)
-                  .sort((a, b) => b.value - a.value);
-
-                const totalAllocation = allocationData.reduce(
-                  (sum, item) => sum + item.value,
-                  0
-                );
-
-                // Calculate risk metrics
-                const topBorrowedAsset =
-                  borrows.length > 0
-                    ? borrows.reduce((top, current) =>
-                      current.value > (top?.value || 0) ? current : top
-                    )
-                    : null;
-
-                const topBorrowedPercentage =
-                  topBorrowedAsset && totalBorrowed > 0
-                    ? (topBorrowedAsset.value / totalBorrowed) * 100
-                    : 0;
-
-                // Find position closest to liquidation (lowest health factor)
-                const positionsWithHealth = deposits
-                  .map((deposit) => {
-                    // For each deposit, calculate a simplified health factor
-                    // This is a simplified calculation - in reality, you'd need network-specific data
-                    const depositHealthFactor = calculateHealthFactor(
-                      deposit.value,
-                      0
-                    );
-                    return {
-                      ...deposit,
-                      healthFactor: depositHealthFactor,
-                    };
-                  })
-                  .filter((pos) => pos.healthFactor !== null);
-
-                const closestToLiquidation =
-                  borrows.length > 0 &&
-                    healthFactor !== null &&
-                    healthFactor < 2.0
-                    ? {
-                      asset: "Portfolio",
-                      healthFactor: healthFactor,
-                    }
-                    : null;
-
-                // Chart colors
-                const COLORS = [
-                  "#0ea5e9", // sky-500
-                  "#8b5cf6", // violet-500
-                  "#10b981", // emerald-500
-                  "#f59e0b", // amber-500
-                  "#ef4444", // red-500
-                  "#06b6d4", // cyan-500
-                  "#a855f7", // purple-500
-                  "#14b8a6", // teal-500
-                ];
-
-                return (
-                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 mb-6">
-                    {/* Left: Allocation Chart */}
-                    <DorkFiCard className="p-4 sm:p-5">
-                      <h3 className="text-base sm:text-lg font-semibold mb-3 sm:mb-4">
-                        Collateral Allocation
-                      </h3>
-                      {totalAllocation > 0 && allocationData.length > 0 ? (
-                        <div className="flex flex-col items-center">
-                          <ResponsiveContainer
-                            width="100%"
-                            height={isMobile ? 200 : 250}
-                          >
-                            <PieChart>
-                              <Pie
-                                data={allocationData}
-                                cx="50%"
-                                cy="50%"
-                                labelLine={false}
-                                label={({ name, percent }) =>
-                                  `${name}: ${formatPercent(percent, { maximumFractionDigits: 0 })}`
-                                }
-                                outerRadius={80}
-                                fill="#8884d8"
-                                dataKey="value"
-                              >
-                                {allocationData.map((entry, index) => (
-                                  <Cell
-                                    key={entry.poolKey ?? `cell-${index}`}
-                                    fill={COLORS[index % COLORS.length]}
-                                  />
-                                ))}
-                              </Pie>
-                              <Tooltip
-                                formatter={(value: number) => [
-                                  `${formatCurrency(value, "USD", {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}`,
-                                  "Collateral",
-                                ]}
-                              />
-                            </PieChart>
-                          </ResponsiveContainer>
-                          <div className="mt-4 w-full space-y-2">
-                            {allocationData.slice(0, 5).map((item, index) => (
-                              <div
-                                key={item.poolKey ?? index}
-                                className="flex items-center justify-between text-sm"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <div
-                                    className="w-3 h-3 rounded-full"
-                                    style={{
-                                      backgroundColor:
-                                        COLORS[index % COLORS.length],
-                                    }}
-                                  />
-                                  <span className="text-muted-foreground">
-                                    {item.name}
-                                  </span>
-                                </div>
-                                <span className="font-semibold">
-                                  {formatPercent(item.value / totalAllocation, { maximumFractionDigits: 1 })}
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex items-center justify-center h-64 text-muted-foreground">
-                          <p>No collateral data available</p>
-                        </div>
-                      )}
-                    </DorkFiCard>
-
-                    {/* Right: Risk Cards */}
-                    <div className="space-y-4">
-                      <h3 className="text-lg font-semibold mb-4">
-                        Risk Overview
-                      </h3>
-
-                      {/* Lowest Liquidation Margin Card */}
-                      {(() => {
-                        const poolMargins = networkPortfolioPoolsFiltered.map(
-                          (row) => row.liquidationMargin
-                        );
-                        const lowestLiquidationMargin =
-                          poolMargins.length > 0
-                            ? Math.min(...poolMargins)
-                            : null;
-
-                        return lowestLiquidationMargin !== null ? (
-                          <UITooltip>
-                            <TooltipTrigger asChild>
-                              <DorkFiCard className="p-4 border-l-4 border-orange-500 cursor-help">
-                                <div className="flex items-start gap-3">
-                                  <AlertTriangle className="w-5 h-5 text-orange-500 mt-0.5" />
-                                  <div className="flex-1">
-                                    <div className="text-sm font-semibold text-orange-600 dark:text-orange-400 mb-1 flex items-center gap-1">
-                                      Lowest Liquidation Margin
-                                      <Info className="w-3 h-3" />
-                                    </div>
-                                    <div className="text-base font-bold">
-                                      {formatPercent(lowestLiquidationMargin / 100, { maximumFractionDigits: 2 })}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground mt-1">
-                                      {selectedNetworkFilter === "all"
-                                        ? "Lowest among pools shown (all networks)"
-                                        : "Lowest among pools on this network"}
-                                    </div>
-                                  </div>
-                                </div>
-                              </DorkFiCard>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-xs">
-                              <p className="font-semibold mb-1">
-                                Liquidation Margin
-                              </p>
-                              <p className="text-sm">
-                                The safety buffer before liquidation. This is
-                                the difference between the liquidation threshold
-                                and your current LTV. A lower margin means
-                                you're closer to liquidation risk. Keep this
-                                above 10-15% for safety.
-                              </p>
-                            </TooltipContent>
-                          </UITooltip>
-                        ) : null;
-                      })()}
-
-                      {/* Top Borrowed Asset Card */}
-                      {topBorrowedAsset && topBorrowedPercentage > 0 && (
-                        <DorkFiCard className="p-4 border-l-4 border-amber-500">
-                          <div className="flex items-start gap-3">
-                            <TrendingDown className="w-5 h-5 text-amber-500 mt-0.5" />
-                            <div className="flex-1">
-                              <div className="text-sm font-semibold text-amber-600 dark:text-amber-400 mb-1">
-                                Top Borrowed Asset
-                              </div>
-                              <div className="text-base font-bold">
-                                {topBorrowedAsset.asset}
-                              </div>
-                              <div className="text-sm text-muted-foreground mt-1">
-                                {formatPercent(topBorrowedPercentage / 100, { maximumFractionDigits: 1 })} of total
-                                borrows
-                              </div>
-                              <div className="text-xs text-muted-foreground mt-1">
-                                $
-                                {formatNumber(topBorrowedAsset.value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                              </div>
-                            </div>
-                          </div>
-                        </DorkFiCard>
-                      )}
-
-                      {/* Closest to Liquidation Card */}
-                      {closestToLiquidation && (
-                        <DorkFiCard className="p-4 border-l-4 border-red-500">
-                          <div className="flex items-start gap-3">
-                            <AlertCircle className="w-5 h-5 text-red-500 mt-0.5" />
-                            <div className="flex-1">
-                              <div className="text-sm font-semibold text-red-600 dark:text-red-400 mb-1">
-                                Closest to Liquidation
-                              </div>
-                              <div className="text-base font-bold">
-                                {closestToLiquidation.asset}
-                              </div>
-                              <div className="text-sm text-muted-foreground mt-1">
-                                Health Factor:{" "}
-                                <span
-                                  className={`font-semibold ${closestToLiquidation.healthFactor >= 1.5
-                                    ? "text-green-600 dark:text-green-400"
-                                    : closestToLiquidation.healthFactor >= 1.0
-                                      ? "text-yellow-600 dark:text-yellow-400"
-                                      : "text-red-600 dark:text-red-400"
-                                    }`}
-                                >
-                                  {formatNumber(closestToLiquidation.healthFactor, { maximumFractionDigits: 2 })}
-                                </span>
-                              </div>
-                              {closestToLiquidation.healthFactor < 1.5 && (
-                                <div className="text-xs text-red-500 mt-1">
-                                  Consider adding collateral or repaying debt
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        </DorkFiCard>
-                      )}
-
-                      {/* Risk Score Card */}
-                      {healthFactor !== null && (
-                        <UITooltip>
-                          <TooltipTrigger asChild>
-                            <DorkFiCard className="p-4 border-l-4 border-ocean-teal cursor-help">
-                              <div className="flex items-start gap-3">
-                                <AlertTriangle className="w-5 h-5 text-ocean-teal mt-0.5" />
-                                <div className="flex-1">
-                                  <div className="text-sm font-semibold text-ocean-teal mb-1 flex items-center gap-1">
-                                    Portfolio Risk Score
-                                    <Info className="w-3 h-3" />
-                                  </div>
-                                  <div className="flex items-center gap-3 mt-2">
-                                    <div className="flex-1">
-                                      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5">
-                                        <div
-                                          className={`h-2.5 rounded-full transition-all ${healthFactor >= 2.0
-                                            ? "bg-green-500"
-                                            : healthFactor >= 1.5
-                                              ? "bg-yellow-500"
-                                              : healthFactor >= 1.0
-                                                ? "bg-orange-500"
-                                                : "bg-red-500"
-                                            }`}
-                                          style={{
-                                            width: `${Math.min(
-                                              ((displayHealthFactor || 0) /
-                                                3.0) *
-                                              100,
-                                              100
-                                            )}%`,
-                                          }}
-                                        />
-                                      </div>
-                                    </div>
-                                    <div className="text-sm font-semibold">
-                                      {displayHealthFactor !== null
-                                        ? formatNumber(displayHealthFactor, { maximumFractionDigits: 2 })
-                                        : "N/A"}
-                                    </div>
-                                  </div>
-                                  <div className="text-xs text-muted-foreground mt-2">
-                                    {healthFactor >= 2.0
-                                      ? "Low Risk"
-                                      : healthFactor >= 1.5
-                                        ? "Moderate Risk"
-                                        : healthFactor >= 1.0
-                                          ? "High Risk"
-                                          : "Critical Risk"}
-                                  </div>
-                                </div>
-                              </div>
-                            </DorkFiCard>
-                          </TooltipTrigger>
-                          <TooltipContent className="max-w-xs">
-                            <p className="font-semibold mb-1">Health Factor</p>
-                            <p className="text-sm mb-2">
-                              Measures your portfolio's safety. Calculated as:
-                              (Total Collateral × Collateral Factor) / Total
-                              Borrowed.
-                            </p>
-                            <ul className="text-xs space-y-1 list-disc list-inside">
-                              <li>
-                                <strong>&gt; 2.0:</strong> Low Risk - Safe
-                                position
-                              </li>
-                              <li>
-                                <strong>1.5-2.0:</strong> Moderate Risk -
-                                Monitor closely
-                              </li>
-                              <li>
-                                <strong>1.0-1.5:</strong> High Risk - Consider
-                                adding collateral
-                              </li>
-                              <li>
-                                <strong>&lt; 1.0:</strong> Critical - At risk of
-                                liquidation
-                              </li>
-                            </ul>
-                          </TooltipContent>
-                        </UITooltip>
-                      )}
-
-                      {/* Empty state if no risk data */}
-                      {!topBorrowedAsset &&
-                        !closestToLiquidation &&
-                        healthFactor === null && (
-                          <DorkFiCard className="p-4">
-                            <div className="text-center text-muted-foreground">
-                              <p className="text-sm">No risk data available</p>
-                            </div>
-                          </DorkFiCard>
-                        )}
-                    </div>
-                  </div>
-                );
-              })()}
-
-              {/* Per-pool portfolio cards (global user per pool app) */}
-              {(() => {
-                if (networkPortfolioPoolsFiltered.length === 0) {
-                  return (
-                    <div className="text-center py-8 text-muted-foreground">
-                      <p>No lending pools found for the selected filter.</p>
-                    </div>
-                  );
-                }
-
-                return (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {networkPortfolioPoolsFiltered.map((row) => {
-                      const {
-                        poolKey,
-                        poolId,
-                        title,
-                        collateral: poolCollateral,
-                        borrow: poolBorrow,
-                        netValue: poolNetValue,
-                        healthFactor: poolHealthFactor,
-                        liquidationMargin: poolLiquidationMargin,
-                      } = row;
-
-                      return (
-                        <DorkFiCard
-                          key={poolKey}
-                          className="p-4 sm:p-5 border-2 hover:border-ocean-teal/50 transition-all"
-                        >
-                          <div className="space-y-4">
-                            <div>
-                              <h3 className="text-lg font-semibold mb-1">
-                                {title}
-                              </h3>
-                              <p className="text-xs text-muted-foreground font-mono break-all">
-                                Pool {poolId}
-                              </p>
-                            </div>
-
-                            <div className="space-y-3">
-                              <div className="flex justify-between items-center gap-2">
-                                <span className="text-sm text-muted-foreground">
-                                  Collateral:
-                                </span>
-                                <span className="text-sm font-semibold text-right tabular-nums">
-                                  {formatCurrency(poolCollateral, "USD", {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}
-                                </span>
-                              </div>
-
-                              <div className="flex justify-between items-center gap-2">
-                                <span className="text-sm text-muted-foreground">
-                                  Borrowed:
-                                </span>
-                                <span className="text-sm font-semibold text-right tabular-nums">
-                                  {formatCurrency(poolBorrow, "USD", {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}
-                                </span>
-                              </div>
-
-                              <div className="flex justify-between items-center gap-2">
-                                <span className="text-sm text-muted-foreground">
-                                  Net Value:
-                                </span>
-                                <span
-                                  className={`text-sm font-semibold text-right tabular-nums ${poolNetValue >= 0
-                                    ? "text-green-600 dark:text-green-400"
-                                    : "text-red-600 dark:text-red-400"
-                                    }`}
-                                >
-                                  {formatCurrency(poolNetValue, "USD", {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}
-                                </span>
-                              </div>
-
-                              <div className="pt-2 border-t border-border space-y-2">
-                                <div className="flex justify-between items-center gap-2">
-                                  <span className="text-sm text-muted-foreground">
-                                    Health Factor:
-                                  </span>
-                                  <span
-                                    className={`text-sm font-semibold tabular-nums ${poolHealthFactor === null
-                                      ? "text-muted-foreground"
-                                      : poolHealthFactor >= 1.5
-                                        ? "text-green-600 dark:text-green-400"
-                                        : poolHealthFactor >= 1.0
-                                          ? "text-yellow-600 dark:text-yellow-400"
-                                          : "text-red-600 dark:text-red-400"
-                                      }`}
-                                  >
-                                    {poolHealthFactor === null
-                                      ? "N/A"
-                                      : formatNumber(poolHealthFactor, {
-                                        maximumFractionDigits: 2,
-                                      })}
-                                  </span>
-                                </div>
-                                <div className="flex justify-between items-center gap-2">
-                                  <span className="text-sm text-muted-foreground">
-                                    Liquidation Margin:
-                                  </span>
-                                  <span
-                                    className={`text-sm font-semibold tabular-nums ${poolLiquidationMargin >= 20
-                                      ? "text-green-600 dark:text-green-400"
-                                      : poolLiquidationMargin >= 10
-                                        ? "text-yellow-600 dark:text-yellow-400"
-                                        : poolLiquidationMargin >= 0
-                                          ? "text-orange-600 dark:text-orange-400"
-                                          : "text-red-600 dark:text-red-400"
-                                      }`}
-                                  >
-                                    {formatPercent(poolLiquidationMargin / 100, {
-                                      maximumFractionDigits: 2,
-                                    })}
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </DorkFiCard>
-                      );
-                    })}
-                  </div>
-                );
-              })()}
-            </Tabs>
-              </CollapsibleContent>
-            </Collapsible>
-          </DorkFiCard>
-        )}
-
 
       {/* Per-Network Asset Tables */}
       {user?.computed?.networkValues &&
         Object.keys(user.computed.networkValues).length > 0 && (
           <TooltipProvider>
             <div className="flex flex-col gap-6">
-              {hasBothPositionTypes && isLargePortfolioScreen && (
-                <div className="order-0 hidden rounded-lg border border-border bg-muted/40 p-4 md:p-5 lg:block">
-                  <ToggleGroup
-                    type="single"
-                    value={portfolioPositionsTab}
-                    onValueChange={(v) => {
-                      if (v === "supplied" || v === "borrowed") {
-                        setPortfolioPositionsTab(v);
-                      }
-                    }}
-                    variant="outline"
-                    className="inline-flex w-full max-w-md gap-0 rounded-lg border border-input bg-background p-1 shadow-sm"
-                    aria-label="Switch between supplied and borrowed positions"
-                  >
-                    <ToggleGroupItem
-                      value="supplied"
-                      className="flex-1 rounded-md px-4 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground sm:min-w-[8rem]"
-                    >
-                      Supplied
-                    </ToggleGroupItem>
-                    <ToggleGroupItem
-                      value="borrowed"
-                      className="flex-1 rounded-md px-4 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground sm:min-w-[8rem]"
-                    >
-                      Borrowed
-                    </ToggleGroupItem>
-                  </ToggleGroup>
-                </div>
-              )}
+              {(deposits.length > 0 || borrows.length > 0) && (
+                <DorkFiCard className="order-0 p-4 md:p-6">
+                  <PortfolioPositionsCardHeader
+                    portfolioPositionsTab={portfolioPositionsTab}
+                    onTabChange={setPortfolioPositionsTab}
+                    hasBothPositionTypes={hasBothPositionTypes}
+                    hasSupplied={deposits.length > 0}
+                    hasBorrowed={borrows.length > 0}
+                    filteredSuppliedCount={filteredSuppliedCount}
+                    filteredBorrowedCount={filteredBorrowedCount}
+                    isViewOnly={isViewOnly}
+                    refreshingSection={refreshingSection}
+                    onRefreshSupplied={() => void handleRefreshSuppliedAssets()}
+                    onRefreshBorrowed={() => void handleRefreshBorrowedAssets()}
+                    networkFilter={positionsNetworkFilter}
+                    onNetworkFilterChange={setPositionsNetworkFilter}
+                    marketFilter={positionsMarketFilter}
+                    onMarketFilterChange={setPositionsMarketFilter}
+                    searchTerm={positionsSearchTerm}
+                    onSearchTermChange={setPositionsSearchTerm}
+                    hasDMarketTab={hasDMarketTab}
+                    isMobile={isNarrowPositionsViewport}
+                  />
               {/* Supplied Assets Table */}
               {deposits.length > 0 && (
-                <DorkFiCard
+                <div
+                  ref={suppliedAssetsTableRef}
                   className={cn(
-                    "p-6 md:p-8",
-                    hasBothPositionTypes && "order-1",
                     hasBothPositionTypes &&
-                      isLargePortfolioScreen &&
                       portfolioPositionsTab === "borrowed" &&
-                      "lg:hidden"
+                      "hidden"
                   )}
                 >
-                  <div ref={suppliedAssetsTableRef} className="mb-4">
-                    <div className="flex items-center justify-between mb-4">
-                      <H1 className="text-xl md:text-2xl">Supplied Assets</H1>
-                      <DorkFiButton
-                        onClick={handleRefreshSuppliedAssets}
-                        disabled={refreshingSection === "Supplied Assets"}
-                        variant="secondary"
-                        size="sm"
-                        className="min-w-0"
-                        title={
-                          isViewOnly
-                            ? "Refresh market data (view-only mode)"
-                            : "Refresh market data for supplied assets"
-                        }
-                      >
-                        <RefreshCw
-                          className={`w-3 h-3 mr-1.5 ${refreshingSection === "Supplied Assets"
-                            ? "animate-spin"
-                            : ""
-                            }`}
-                        />
-                        Refresh
-                      </DorkFiButton>
-                    </div>
-                    <div className="mb-4 flex flex-row flex-wrap items-center gap-3">
-                      <div className="relative flex-1 min-w-0 max-w-md">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4 pointer-events-none" />
-                        <Input
-                          placeholder="Search assets..."
-                          value={suppliedAssetsSearchTerm}
-                          onChange={(e) =>
-                            setSuppliedAssetsSearchTerm(e.target.value)
-                          }
-                          className="pl-10"
-                        />
-                      </div>
-                      <DorkFiButton
-                        variant="secondary"
-                        size="sm"
-                        type="button"
-                        className="shrink-0 md:hidden"
-                        onClick={() => setSuppliedAssetsFilterModalOpen(true)}
-                      >
-                        <Filter className="h-4 w-4" />
-                        Filter assets
-                      </DorkFiButton>
-                    </div>
-                    <div className="hidden md:flex md:flex-row md:items-end md:gap-4 lg:gap-6 mb-4">
-                      <div className="min-w-0 flex-1">
-                        <label className="text-sm font-medium mb-2 block">
-                          Network
-                        </label>
-                        <Tabs
-                          value={suppliedAssetsNetworkFilter}
-                          onValueChange={setSuppliedAssetsNetworkFilter}
-                          className="w-full"
-                        >
-                          <TabsList className="grid w-full grid-cols-3 h-9">
-                            <TabsTrigger value="all" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              All Networks
-                            </TabsTrigger>
-                            <TabsTrigger value="algorand" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              Algorand
-                            </TabsTrigger>
-                            <TabsTrigger value="voi" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              VOI
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <label className="text-sm font-medium mb-2 block">
-                          Market
-                        </label>
-                        <Tabs
-                          value={suppliedAssetsMarketFilter}
-                          onValueChange={setSuppliedAssetsMarketFilter}
-                          className="w-full"
-                        >
-                          <TabsList className="grid w-full grid-cols-3 h-9">
-                            <TabsTrigger value="both" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              Both Markets
-                            </TabsTrigger>
-                            <TabsTrigger value="A" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              A Market
-                            </TabsTrigger>
-                            <TabsTrigger value="B" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              B Market
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </div>
-                    </div>
-                  </div>
-                  {/* Network / market filters (mobile modal) */}
-                  <Dialog
-                    open={suppliedAssetsFilterModalOpen}
-                    onOpenChange={setSuppliedAssetsFilterModalOpen}
-                  >
-                    <DialogContent className="sm:max-w-md p-6">
-                      <DialogHeader>
-                        <DialogTitle>Filter Assets</DialogTitle>
-                      </DialogHeader>
-                      <div className="space-y-4 mt-4">
-                        <div>
-                          <label className="text-sm font-medium mb-2 block">
-                            Network
-                          </label>
-                          <Tabs
-                            value={suppliedAssetsNetworkFilter}
-                            onValueChange={setSuppliedAssetsNetworkFilter}
-                            className="w-full"
-                          >
-                            <TabsList className="grid w-full grid-cols-3">
-                              <TabsTrigger value="all" className="text-sm">
-                                All Networks
-                              </TabsTrigger>
-                              <TabsTrigger value="algorand" className="text-sm">
-                                Algorand
-                              </TabsTrigger>
-                              <TabsTrigger value="voi" className="text-sm">
-                                VOI
-                              </TabsTrigger>
-                            </TabsList>
-                          </Tabs>
-                        </div>
-                        <div>
-                          <label className="text-sm font-medium mb-2 block">
-                            Market
-                          </label>
-                          <Tabs
-                            value={suppliedAssetsMarketFilter}
-                            onValueChange={setSuppliedAssetsMarketFilter}
-                            className="w-full"
-                          >
-                            <TabsList className="grid w-full grid-cols-3">
-                              <TabsTrigger value="both" className="text-sm">
-                                Both Markets
-                              </TabsTrigger>
-                              <TabsTrigger value="A" className="text-sm">
-                                A Market
-                              </TabsTrigger>
-                              <TabsTrigger value="B" className="text-sm">
-                                B Market
-                              </TabsTrigger>
-                            </TabsList>
-                          </Tabs>
-                        </div>
-                      </div>
-                    </DialogContent>
-                  </Dialog>
-
                   {/* Mobile Card View */}
                   {isMobile ? (
                     <div className="space-y-3">
                       {(() => {
                         const filteredAndSorted = deposits
                           .filter((deposit) => {
-                            if (suppliedAssetsSearchTerm) {
+                            if (positionsSearchTerm) {
                               const searchLower =
-                                suppliedAssetsSearchTerm.toLowerCase();
+                                positionsSearchTerm.toLowerCase();
                               const assetMatch = deposit.asset
                                 .toLowerCase()
                                 .includes(searchLower);
                               if (!assetMatch) return false;
                             }
-                            if (suppliedAssetsNetworkFilter === "all")
+                            if (positionsNetworkFilter === "all")
                               return true;
                             const depositNetwork = (deposit as ItemWithNetwork).network;
                             if (depositNetwork) {
                               const normalizedNetwork =
                                 depositNetwork.toLowerCase();
-                              if (suppliedAssetsNetworkFilter === "algorand") {
+                              if (positionsNetworkFilter === "algorand") {
                                 return normalizedNetwork.includes("algorand");
                               } else if (
-                                suppliedAssetsNetworkFilter === "voi"
+                                positionsNetworkFilter === "voi"
                               ) {
                                 return normalizedNetwork.includes("voi");
                               }
                             }
                             return true;
                           })
-                          .filter((deposit) => {
-                            // Filter by market (A, B, or both)
-                            if (suppliedAssetsMarketFilter === "both") {
-                              return true;
-                            }
-                            const depositNetworkForMarket =
-                              (deposit as ItemWithNetwork).network || currentNetwork;
-                            const depositMarketLabel = getMarketLabel(
-                              depositNetworkForMarket,
-                              deposit.poolId
-                            );
-                            return (
-                              depositMarketLabel === suppliedAssetsMarketFilter
-                            );
-                          })
+                          .filter((deposit) =>
+                            positionMatchesMarketFilter(
+                              (deposit as ItemWithNetwork).network ||
+                                currentNetwork,
+                              deposit.poolId,
+                              positionsMarketFilter
+                            )
+                          )
                           .sort((a, b) => {
                             let comparison = 0;
 
@@ -6695,9 +5973,11 @@ const Portfolio = () => {
 
                         if (displayDeposits.length === 0) {
                           return (
-                            <div className="text-center py-8 text-muted-foreground">
-                              <p>No supplied assets</p>
-                            </div>
+                            <PortfolioPositionsFilteredEmptyState
+                              totalCount={deposits.length}
+                              entityLabel="supplied assets"
+                              onClearFilters={clearPositionsFilters}
+                            />
                           );
                         }
 
@@ -7058,9 +6338,9 @@ const Portfolio = () => {
                             const filteredAndSorted = deposits
                               .filter((deposit) => {
                                 // Filter by search term
-                                if (suppliedAssetsSearchTerm) {
+                                if (positionsSearchTerm) {
                                   const searchLower =
-                                    suppliedAssetsSearchTerm.toLowerCase();
+                                    positionsSearchTerm.toLowerCase();
                                   const assetMatch = deposit.asset
                                     .toLowerCase()
                                     .includes(searchLower);
@@ -7070,7 +6350,7 @@ const Portfolio = () => {
                                 }
 
                                 // Filter by network
-                                if (suppliedAssetsNetworkFilter === "all") {
+                                if (positionsNetworkFilter === "all") {
                                   return true; // Show all deposits
                                 }
 
@@ -7080,13 +6360,13 @@ const Portfolio = () => {
                                   const normalizedNetwork =
                                     depositNetwork.toLowerCase();
                                   if (
-                                    suppliedAssetsNetworkFilter === "algorand"
+                                    positionsNetworkFilter === "algorand"
                                   ) {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
                                   } else if (
-                                    suppliedAssetsNetworkFilter === "voi"
+                                    positionsNetworkFilter === "voi"
                                   ) {
                                     return normalizedNetwork.includes("voi");
                                   }
@@ -7099,13 +6379,13 @@ const Portfolio = () => {
                                   const normalizedNetwork =
                                     network.toLowerCase();
                                   if (
-                                    suppliedAssetsNetworkFilter === "algorand"
+                                    positionsNetworkFilter === "algorand"
                                   ) {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
                                   } else if (
-                                    suppliedAssetsNetworkFilter === "voi"
+                                    positionsNetworkFilter === "voi"
                                   ) {
                                     return normalizedNetwork.includes("voi");
                                   }
@@ -7115,22 +6395,14 @@ const Portfolio = () => {
                                 // If we can't determine, show it (better to show than hide)
                                 return true;
                               })
-                              .filter((deposit) => {
-                                // Filter by market (A, B, or both)
-                                if (suppliedAssetsMarketFilter === "both") {
-                                  return true;
-                                }
-                                const depositNetworkForMarket =
-                                  (deposit as ItemWithNetwork).network || currentNetwork;
-                                const depositMarketLabel = getMarketLabel(
-                                  depositNetworkForMarket,
-                                  deposit.poolId
-                                );
-                                return (
-                                  depositMarketLabel ===
-                                  suppliedAssetsMarketFilter
-                                );
-                              })
+                              .filter((deposit) =>
+                                positionMatchesMarketFilter(
+                                  (deposit as ItemWithNetwork).network ||
+                                    currentNetwork,
+                                  deposit.poolId,
+                                  positionsMarketFilter
+                                )
+                              )
                               .sort((a, b) => {
                                 let comparison = 0;
 
@@ -7404,7 +6676,7 @@ const Portfolio = () => {
                                     .join(" ");
                                 }
                               } else if (
-                                suppliedAssetsNetworkFilter === "all"
+                                positionsNetworkFilter === "all"
                               ) {
                                 // Fallback: try to infer from networkValues
                                 const matchingNetwork = Object.entries(
@@ -7650,9 +6922,9 @@ const Portfolio = () => {
                       const filteredAndSorted = deposits
                         .filter((deposit) => {
                           // Filter by search term
-                          if (suppliedAssetsSearchTerm) {
+                          if (positionsSearchTerm) {
                             const searchLower =
-                              suppliedAssetsSearchTerm.toLowerCase();
+                              positionsSearchTerm.toLowerCase();
                             const assetMatch = deposit.asset
                               .toLowerCase()
                               .includes(searchLower);
@@ -7662,7 +6934,7 @@ const Portfolio = () => {
                           }
 
                           // Filter by network
-                          if (suppliedAssetsNetworkFilter === "all") {
+                          if (positionsNetworkFilter === "all") {
                             return true;
                           }
 
@@ -7670,9 +6942,9 @@ const Portfolio = () => {
                           if (depositNetwork) {
                             const normalizedNetwork =
                               depositNetwork.toLowerCase();
-                            if (suppliedAssetsNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (suppliedAssetsNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                           }
@@ -7681,9 +6953,9 @@ const Portfolio = () => {
                             user?.computed?.networkValues || {}
                           ).find(([network, values]: [string, unknown]) => {
                             const normalizedNetwork = network.toLowerCase();
-                            if (suppliedAssetsNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (suppliedAssetsNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                             return false;
@@ -7745,806 +7017,56 @@ const Portfolio = () => {
                         />
                       );
                     })()}
-                </DorkFiCard>
+                </div>
               )}
 
-              {/* At Risk Assets Table */}
-              {atRiskAssets.length > 0 &&
-                (() => {
-                  // Check if any asset has non-zero pool borrows
-                  const hasPoolBorrows = atRiskAssets.some(
-                    (asset) => asset.poolBorrowsUSD > 0
-                  );
-
-                  return (
-                    <DorkFiCard
-                      className={cn(
-                        "p-6 md:p-8 border-orange-500/50 bg-orange-500/5",
-                        hasBothPositionTypes && "order-2 lg:order-3"
-                      )}
-                    >
-                      <div className="mb-4">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-2">
-                            <AlertTriangle className="w-6 h-6 text-orange-500" />
-                            <H1 className="text-xl md:text-2xl text-orange-500">
-                              At Risk Assets
-                            </H1>
-                          </div>
-                          <DorkFiButton
-                            onClick={handleRefreshAtRiskAssets}
-                            disabled={refreshingSection === "At Risk Assets"}
-                            variant="secondary"
-                            size="sm"
-                            className="min-w-0"
-                            title={
-                              isViewOnly
-                                ? "Refresh market data (view-only mode)"
-                                : "Refresh market data for at risk assets"
-                            }
-                          >
-                            <RefreshCw
-                              className={`w-3 h-3 mr-1.5 ${refreshingSection === "At Risk Assets"
-                                ? "animate-spin"
-                                : ""
-                                }`}
-                            />
-                            Refresh
-                          </DorkFiButton>
-                        </div>
-                        <Body className="text-sm text-muted-foreground">
-                          These assets have a health factor (collateral value ×
-                          liquidation factor / total borrows) less than 1.0,
-                          indicating potential liquidation risk.
-                        </Body>
-                      </div>
-                      {/* Market Filter Tabs - Hidden on mobile */}
-                      <div className="hidden md:block mb-4">
-                        <Tabs
-                          value={atRiskAssetsMarketFilter}
-                          onValueChange={setAtRiskAssetsMarketFilter}
-                          className="w-full"
-                        >
-                          <TabsList className="grid w-full grid-cols-3">
-                            <TabsTrigger value="both" className="text-sm">
-                              Both Markets
-                            </TabsTrigger>
-                            <TabsTrigger value="A" className="text-sm">
-                              A Market
-                            </TabsTrigger>
-                            <TabsTrigger value="B" className="text-sm">
-                              B Market
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </div>
-                      {/* Filter Button for Mobile - At Risk Assets */}
-                      <div className="md:hidden mb-4 flex justify-end">
-                        <DorkFiButton
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => setAtRiskAssetsFilterModalOpen(true)}
-                          className="flex items-center gap-2 min-w-0"
-                        >
-                          <Filter className="h-4 w-4" />
-                          Filter
-                        </DorkFiButton>
-                      </div>
-                      {/* Filter Modal for Mobile - At Risk Assets */}
-                      <Dialog
-                        open={atRiskAssetsFilterModalOpen}
-                        onOpenChange={setAtRiskAssetsFilterModalOpen}
-                      >
-                        <DialogContent className="sm:max-w-md p-6">
-                          <DialogHeader>
-                            <DialogTitle>Filter Assets</DialogTitle>
-                          </DialogHeader>
-                          <div className="space-y-4 mt-4">
-                            <div>
-                              <label className="text-sm font-medium mb-2 block">
-                                Market
-                              </label>
-                              <Tabs
-                                value={atRiskAssetsMarketFilter}
-                                onValueChange={setAtRiskAssetsMarketFilter}
-                                className="w-full"
-                              >
-                                <TabsList className="grid w-full grid-cols-3">
-                                  <TabsTrigger value="both" className="text-sm">
-                                    Both Markets
-                                  </TabsTrigger>
-                                  <TabsTrigger value="A" className="text-sm">
-                                    A Market
-                                  </TabsTrigger>
-                                  <TabsTrigger value="B" className="text-sm">
-                                    B Market
-                                  </TabsTrigger>
-                                </TabsList>
-                              </Tabs>
-                            </div>
-                          </div>
-                        </DialogContent>
-                      </Dialog>
-                      <div className="overflow-x-auto">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (atRiskAssetsSort.column === "asset") {
-                                      setAtRiskAssetsSort({
-                                        column: "asset",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "asset",
-                                        direction: "asc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                >
-                                  Asset
-                                  {atRiskAssetsSort.column === "asset" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (atRiskAssetsSort.column === "network") {
-                                      setAtRiskAssetsSort({
-                                        column: "network",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "network",
-                                        direction: "asc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center justify-center gap-1 hover:text-foreground transition-colors w-full"
-                                >
-                                  Network
-                                  {atRiskAssetsSort.column === "network" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              <TableHead>Market</TableHead>
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (atRiskAssetsSort.column === "value") {
-                                      setAtRiskAssetsSort({
-                                        column: "value",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "value",
-                                        direction: "desc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                >
-                                  Value (USD)
-                                  {atRiskAssetsSort.column === "value" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (
-                                      atRiskAssetsSort.column ===
-                                      "liquidationFactor"
-                                    ) {
-                                      setAtRiskAssetsSort({
-                                        column: "liquidationFactor",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "liquidationFactor",
-                                        direction: "desc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                >
-                                  Liquidation Factor
-                                  {atRiskAssetsSort.column ===
-                                    "liquidationFactor" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (
-                                      atRiskAssetsSort.column === "depositValue"
-                                    ) {
-                                      setAtRiskAssetsSort({
-                                        column: "depositValue",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "depositValue",
-                                        direction: "desc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                >
-                                  Deposit Value
-                                  {atRiskAssetsSort.column ===
-                                    "depositValue" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              {hasPoolBorrows && (
-                                <TableHead>
-                                  <button
-                                    onClick={() => {
-                                      if (
-                                        atRiskAssetsSort.column ===
-                                        "borrowValue"
-                                      ) {
-                                        setAtRiskAssetsSort({
-                                          column: "borrowValue",
-                                          direction:
-                                            atRiskAssetsSort.direction === "asc"
-                                              ? "desc"
-                                              : "asc",
-                                        });
-                                      } else {
-                                        setAtRiskAssetsSort({
-                                          column: "borrowValue",
-                                          direction: "desc",
-                                        });
-                                      }
-                                    }}
-                                    className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                  >
-                                    Borrow Value
-                                    {atRiskAssetsSort.column ===
-                                      "borrowValue" ? (
-                                      atRiskAssetsSort.direction === "asc" ? (
-                                        <ArrowUp className="w-3 h-3" />
-                                      ) : (
-                                        <ArrowDown className="w-3 h-3" />
-                                      )
-                                    ) : (
-                                      <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                    )}
-                                  </button>
-                                </TableHead>
-                              )}
-                              <TableHead>
-                                <button
-                                  onClick={() => {
-                                    if (
-                                      atRiskAssetsSort.column === "riskRatio"
-                                    ) {
-                                      setAtRiskAssetsSort({
-                                        column: "riskRatio",
-                                        direction:
-                                          atRiskAssetsSort.direction === "asc"
-                                            ? "desc"
-                                            : "asc",
-                                      });
-                                    } else {
-                                      setAtRiskAssetsSort({
-                                        column: "riskRatio",
-                                        direction: "asc",
-                                      });
-                                    }
-                                  }}
-                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
-                                >
-                                  Health Factor
-                                  {atRiskAssetsSort.column === "riskRatio" ? (
-                                    atRiskAssetsSort.direction === "asc" ? (
-                                      <ArrowUp className="w-3 h-3" />
-                                    ) : (
-                                      <ArrowDown className="w-3 h-3" />
-                                    )
-                                  ) : (
-                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
-                                  )}
-                                </button>
-                              </TableHead>
-                              <TableHead>Actions</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {(() => {
-                              // Sort at-risk assets based on selected column
-                              const sortedAtRiskAssets = [...atRiskAssets].sort(
-                                (a, b) => {
-                                  let comparison = 0;
-
-                                  switch (atRiskAssetsSort.column) {
-                                    case "asset":
-                                      comparison = a.asset.localeCompare(
-                                        b.asset
-                                      );
-                                      break;
-                                    case "network":
-                                      const networkA = (
-                                        (a as ItemWithNetwork).network || "Unknown"
-                                      ).toLowerCase();
-                                      const networkB = (
-                                        (b as ItemWithNetwork).network || "Unknown"
-                                      ).toLowerCase();
-                                      comparison =
-                                        networkA.localeCompare(networkB);
-                                      break;
-                                    case "value":
-                                      comparison = a.value - b.value;
-                                      break;
-                                    case "liquidationFactor":
-                                      comparison =
-                                        a.liquidationFactor -
-                                        b.liquidationFactor;
-                                      break;
-                                    case "depositValue":
-                                      comparison =
-                                        a.poolCollateralValueUSD -
-                                        b.poolCollateralValueUSD;
-                                      break;
-                                    case "borrowValue":
-                                      comparison =
-                                        a.poolBorrowsUSD - b.poolBorrowsUSD;
-                                      break;
-                                    case "riskRatio":
-                                    default:
-                                      comparison = a.riskRatio - b.riskRatio;
-                                      break;
-                                  }
-
-                                  return atRiskAssetsSort.direction === "asc"
-                                    ? comparison
-                                    : -comparison;
-                                }
-                              );
-
-                              // Filter by market (A, B, or both)
-                              const filteredAtRiskAssets =
-                                sortedAtRiskAssets.filter((asset) => {
-                                  if (atRiskAssetsMarketFilter === "both") {
-                                    return true;
-                                  }
-                                  const assetNetwork =
-                                    (asset as ItemWithNetwork).network || currentNetwork;
-                                  const marketLabel = getMarketLabel(
-                                    assetNetwork,
-                                    asset.poolId
-                                  );
-                                  return (
-                                    marketLabel === atRiskAssetsMarketFilter
-                                  );
-                                });
-
-                              return filteredAtRiskAssets.map(
-                                (asset, index) => {
-                                  // Get market label using the asset's network, not currentNetwork
-                                  const assetNetwork =
-                                    (asset as ItemWithNetwork).network || currentNetwork;
-                                  const marketLabel = getMarketLabel(
-                                    assetNetwork,
-                                    asset.poolId
-                                  );
-
-                                  return (
-                                    <TableRow
-                                      key={`${asset.asset}-${asset.poolId || index
-                                        }`}
-                                      className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-orange-400 hover:shadow-[0_0_16px_4px_rgba(249,115,22,0.15)] hover:bg-orange-500/5 hover:z-20 cursor-pointer"
-                                    >
-                                      <TableCell>
-                                        <div className="flex items-center gap-2">
-                                          <MarketRowTokenIcon
-                                            market={{
-                                              icon: asset.icon,
-                                              asset: asset.asset,
-                                              iconBadgeUrl: (
-                                                asset as { iconBadgeUrl?: string }
-                                              ).iconBadgeUrl,
-                                            }}
-                                            poolLetterLabel={marketLabel}
-                                            imgClassName="h-6 w-6 shrink-0 rounded-full object-contain"
-                                          />
-                                          <span className="font-medium">
-                                            {asset.asset}
-                                          </span>
-                                        </div>
-                                      </TableCell>
-                                      <TableCell className="text-center">
-                                        {(() => {
-                                          const depositNetwork = (asset as ItemWithNetwork)
-                                            .network;
-                                          if (depositNetwork) {
-                                            // Format network name: "algorand-mainnet" -> "Algorand", "voi-mainnet" -> "VOI"
-                                            const normalized =
-                                              depositNetwork.toLowerCase();
-                                            if (
-                                              normalized.includes("algorand")
-                                            ) {
-                                              return "Algorand";
-                                            } else if (
-                                              normalized.includes("voi")
-                                            ) {
-                                              return "VOI";
-                                            } else {
-                                              // Fallback to formatted name
-                                              return depositNetwork
-                                                .split("-")
-                                                .map(
-                                                  (word) =>
-                                                    word
-                                                      .charAt(0)
-                                                      .toUpperCase() +
-                                                    word.slice(1)
-                                                )
-                                                .join(" ");
-                                            }
-                                          }
-                                          return "Unknown";
-                                        })()}
-                                      </TableCell>
-                                      <TableCell className="text-center">
-                                        {marketLabel || "-"}
-                                      </TableCell>
-                                      <TableCell>
-                                        $
-                                        {formatNumber(asset.value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                                      </TableCell>
-                                      <TableCell>
-                                        {formatPercent(asset.liquidationFactor, { maximumFractionDigits: 1 })}
-                                      </TableCell>
-                                      <TableCell>
-                                        <span className="text-muted-foreground">
-                                          {formatCurrency(asset.poolCollateralValueUSD, "USD", {
-                                            minimumFractionDigits: 2,
-                                            maximumFractionDigits: 2,
-                                          })}
-                                        </span>
-                                      </TableCell>
-                                      {hasPoolBorrows && (
-                                        <TableCell>
-                                          <span className="text-muted-foreground">
-                                            {formatCurrency(asset.poolBorrowsUSD, "USD",
-                                              {
-                                                minimumFractionDigits: 2,
-                                                maximumFractionDigits: 2,
-                                              }
-                                            )}
-                                          </span>
-                                        </TableCell>
-                                      )}
-                                      <TableCell>
-                                        <span
-                                          className={`font-semibold ${asset.riskRatio < 0.5
-                                            ? "text-red-500"
-                                            : asset.riskRatio < 0.75
-                                              ? "text-orange-500"
-                                              : "text-yellow-500"
-                                            }`}
-                                        >
-                                          {formatNumber(asset.riskRatio, { maximumFractionDigits: 3 })}
-                                        </span>
-                                      </TableCell>
-                                      <TableCell>
-                                        <div className="flex items-center gap-2">
-                                          {!isViewOnly && (() => {
-                                            const atRiskMarket =
-                                              marketRowForPortfolioPosition(
-                                                marketData,
-                                                {
-                                                  marketId: (asset as ItemWithNetwork)
-                                                    .marketId,
-                                                  poolId: asset.poolId,
-                                                  displaySymbol: asset.asset,
-                                                }
-                                              ) as any;
-                                            const depositCapReached =
-                                              atRiskMarket &&
-                                              isAtDepositCap(
-                                                Number(atRiskMarket?.totalDeposits ?? 0),
-                                                Number(atRiskMarket?.maxTotalDeposits ?? 0),
-                                              );
-                                            return !atRiskMarket?.isPaused && (
-                                              <DorkFiButton
-                                                variant="secondary"
-                                                size="sm"
-                                                onClick={(e) => {
-                                                  e.stopPropagation();
-                                                  handleDepositClick(
-                                                    asset.asset,
-                                                    asset.poolId,
-                                                    (asset as ItemWithNetwork).network,
-                                                    (asset as ItemWithNetwork).configSymbol,
-                                                    (asset as ItemWithNetwork).marketId
-                                                  );
-                                                }}
-                                                disabled={depositCapReached}
-                                                title={
-                                                  depositCapReached
-                                                    ? "Market at deposit cap"
-                                                    : "Supply more of this asset to earn yield and use as collateral"
-                                                }
-                                                aria-label="Supply"
-                                                className="min-w-[92px] h-8 px-2 gap-1"
-                                              >
-                                                <span className="text-base leading-none">+</span>
-                                                <span className="hidden lg:inline text-xs">Supply</span>
-                                              </DorkFiButton>
-                                            );
-                                          })()}
-                                        </div>
-                                      </TableCell>
-                                    </TableRow>
-                                  );
-                                }
-                              );
-                            })()}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    </DorkFiCard>
-                  );
-                })()}
-
-              {/* Borrowed Assets Table */}
               {borrows.length > 0 && (
-                <DorkFiCard
+                <div
+                  ref={borrowedAssetsTableRef}
                   className={cn(
-                    "p-6 md:p-8",
-                    hasBothPositionTypes && "order-3 lg:order-2",
                     hasBothPositionTypes &&
-                      isLargePortfolioScreen &&
                       portfolioPositionsTab === "supplied" &&
-                      "lg:hidden"
+                      "hidden"
                   )}
                 >
-                  <div ref={borrowedAssetsTableRef} className="mb-4">
-                    <div className="flex items-center justify-between mb-4">
-                      <H1 className="text-xl md:text-2xl">Borrowed Assets</H1>
-                      <DorkFiButton
-                        onClick={handleRefreshBorrowedAssets}
-                        disabled={refreshingSection === "Borrowed Assets"}
-                        variant="secondary"
-                        size="sm"
-                        className="min-w-0"
-                        title={
-                          isViewOnly
-                            ? "Refresh market data (view-only mode)"
-                            : "Refresh market data for borrowed assets"
-                        }
-                      >
-                        <RefreshCw
-                          className={`w-3 h-3 mr-1.5 ${refreshingSection === "Borrowed Assets"
-                            ? "animate-spin"
-                            : ""
-                            }`}
-                        />
-                        Refresh
-                      </DorkFiButton>
-                    </div>
-                    <div className="mb-4 flex flex-row flex-wrap items-center gap-3">
-                      <div className="relative flex-1 min-w-0 max-w-md">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4 pointer-events-none" />
-                        <Input
-                          placeholder="Search assets..."
-                          value={borrowedAssetsSearchTerm}
-                          onChange={(e) =>
-                            setBorrowedAssetsSearchTerm(e.target.value)
-                          }
-                          className="pl-10"
-                        />
-                      </div>
-                      <DorkFiButton
-                        variant="secondary"
-                        size="sm"
-                        type="button"
-                        className="shrink-0 md:hidden"
-                        onClick={() => setBorrowedAssetsFilterModalOpen(true)}
-                      >
-                        <Filter className="h-4 w-4" />
-                        Filter assets
-                      </DorkFiButton>
-                    </div>
-                    <div className="hidden md:flex md:flex-row md:items-end md:gap-4 lg:gap-6 mb-4">
-                      <div className="min-w-0 flex-1">
-                        <label className="text-sm font-medium mb-2 block">
-                          Network
-                        </label>
-                        <Tabs
-                          value={borrowedAssetsNetworkFilter}
-                          onValueChange={setBorrowedAssetsNetworkFilter}
-                          className="w-full"
-                        >
-                          <TabsList className="grid w-full grid-cols-3 h-9">
-                            <TabsTrigger value="all" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              All Networks
-                            </TabsTrigger>
-                            <TabsTrigger value="algorand" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              Algorand
-                            </TabsTrigger>
-                            <TabsTrigger value="voi" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              VOI
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <label className="text-sm font-medium mb-2 block">
-                          Market
-                        </label>
-                        <Tabs
-                          value={borrowedAssetsMarketFilter}
-                          onValueChange={setBorrowedAssetsMarketFilter}
-                          className="w-full"
-                        >
-                          <TabsList className="grid w-full grid-cols-3 h-9">
-                            <TabsTrigger value="both" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              Both Markets
-                            </TabsTrigger>
-                            <TabsTrigger value="A" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              A Market
-                            </TabsTrigger>
-                            <TabsTrigger value="B" className="text-xs px-1.5 lg:text-sm lg:px-2">
-                              B Market
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </div>
-                    </div>
-                  </div>
-                  {/* Network / market filters (mobile modal) */}
-                  <Dialog
-                    open={borrowedAssetsFilterModalOpen}
-                    onOpenChange={setBorrowedAssetsFilterModalOpen}
-                  >
-                    <DialogContent className="sm:max-w-md p-6">
-                      <DialogHeader>
-                        <DialogTitle>Filter Assets</DialogTitle>
-                      </DialogHeader>
-                      <div className="space-y-4 mt-4">
-                        <div>
-                          <label className="text-sm font-medium mb-2 block">
-                            Network
-                          </label>
-                          <Tabs
-                            value={borrowedAssetsNetworkFilter}
-                            onValueChange={setBorrowedAssetsNetworkFilter}
-                            className="w-full"
-                          >
-                            <TabsList className="grid w-full grid-cols-3">
-                              <TabsTrigger value="all" className="text-sm">
-                                All Networks
-                              </TabsTrigger>
-                              <TabsTrigger value="algorand" className="text-sm">
-                                Algorand
-                              </TabsTrigger>
-                              <TabsTrigger value="voi" className="text-sm">
-                                VOI
-                              </TabsTrigger>
-                            </TabsList>
-                          </Tabs>
-                        </div>
-                        <div>
-                          <label className="text-sm font-medium mb-2 block">
-                            Market
-                          </label>
-                          <Tabs
-                            value={borrowedAssetsMarketFilter}
-                            onValueChange={setBorrowedAssetsMarketFilter}
-                            className="w-full"
-                          >
-                            <TabsList className="grid w-full grid-cols-3">
-                              <TabsTrigger value="both" className="text-sm">
-                                Both Markets
-                              </TabsTrigger>
-                              <TabsTrigger value="A" className="text-sm">
-                                A Market
-                              </TabsTrigger>
-                              <TabsTrigger value="B" className="text-sm">
-                                B Market
-                              </TabsTrigger>
-                            </TabsList>
-                          </Tabs>
-                        </div>
-                      </div>
-                    </DialogContent>
-                  </Dialog>
-
                   {/* Mobile Card View */}
                   {isMobile ? (
                     <div className="space-y-3">
                       {(() => {
                         const filteredAndSorted = borrows
                           .filter((borrow) => {
-                            if (borrowedAssetsSearchTerm) {
+                            if (positionsSearchTerm) {
                               const searchLower =
-                                borrowedAssetsSearchTerm.toLowerCase();
+                                positionsSearchTerm.toLowerCase();
                               const assetMatch = borrow.asset
                                 .toLowerCase()
                                 .includes(searchLower);
                               if (!assetMatch) return false;
                             }
-                            if (borrowedAssetsNetworkFilter === "all")
+                            if (positionsNetworkFilter === "all")
                               return true;
                             const borrowNetwork = (borrow as ItemWithNetwork).network;
                             if (borrowNetwork) {
                               const normalizedNetwork =
                                 borrowNetwork.toLowerCase();
-                              if (borrowedAssetsNetworkFilter === "algorand") {
+                              if (positionsNetworkFilter === "algorand") {
                                 return normalizedNetwork.includes("algorand");
                               } else if (
-                                borrowedAssetsNetworkFilter === "voi"
+                                positionsNetworkFilter === "voi"
                               ) {
                                 return normalizedNetwork.includes("voi");
                               }
                             }
                             return true;
                           })
+                          .filter((borrow) =>
+                            positionMatchesMarketFilter(
+                              (borrow as ItemWithNetwork).network ||
+                                currentNetwork,
+                              borrow.poolId,
+                              positionsMarketFilter
+                            )
+                          )
                           .sort((a, b) => {
                             let comparison = 0;
                             switch (borrowedAssetsSort.column) {
@@ -8573,9 +7095,11 @@ const Portfolio = () => {
 
                         if (displayBorrows.length === 0) {
                           return (
-                            <div className="text-center py-8 text-muted-foreground">
-                              <p>No borrowed assets</p>
-                            </div>
+                            <PortfolioPositionsFilteredEmptyState
+                              totalCount={borrows.length}
+                              entityLabel="borrowed assets"
+                              onClearFilters={clearPositionsFilters}
+                            />
                           );
                         }
 
@@ -8960,9 +7484,9 @@ const Portfolio = () => {
                             const filteredAndSorted = borrows
                               .filter((borrow) => {
                                 // Filter by search term
-                                if (borrowedAssetsSearchTerm) {
+                                if (positionsSearchTerm) {
                                   const searchLower =
-                                    borrowedAssetsSearchTerm.toLowerCase();
+                                    positionsSearchTerm.toLowerCase();
                                   const assetMatch = borrow.asset
                                     .toLowerCase()
                                     .includes(searchLower);
@@ -8972,7 +7496,7 @@ const Portfolio = () => {
                                 }
 
                                 // Filter by network
-                                if (borrowedAssetsNetworkFilter === "all") {
+                                if (positionsNetworkFilter === "all") {
                                   return true;
                                 }
 
@@ -8981,13 +7505,13 @@ const Portfolio = () => {
                                   const normalizedNetwork =
                                     borrowNetwork.toLowerCase();
                                   if (
-                                    borrowedAssetsNetworkFilter === "algorand"
+                                    positionsNetworkFilter === "algorand"
                                   ) {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
                                   } else if (
-                                    borrowedAssetsNetworkFilter === "voi"
+                                    positionsNetworkFilter === "voi"
                                   ) {
                                     return normalizedNetwork.includes("voi");
                                   }
@@ -8999,13 +7523,13 @@ const Portfolio = () => {
                                   const normalizedNetwork =
                                     network.toLowerCase();
                                   if (
-                                    borrowedAssetsNetworkFilter === "algorand"
+                                    positionsNetworkFilter === "algorand"
                                   ) {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
                                   } else if (
-                                    borrowedAssetsNetworkFilter === "voi"
+                                    positionsNetworkFilter === "voi"
                                   ) {
                                     return normalizedNetwork.includes("voi");
                                   }
@@ -9014,22 +7538,14 @@ const Portfolio = () => {
 
                                 return true;
                               })
-                              .filter((borrow) => {
-                                // Filter by market (A, B, or both)
-                                if (borrowedAssetsMarketFilter === "both") {
-                                  return true;
-                                }
-                                const borrowNetwork =
-                                  (borrow as ItemWithNetwork).network || currentNetwork;
-                                const borrowMarketLabel = getMarketLabel(
-                                  borrowNetwork,
-                                  borrow.poolId
-                                );
-                                return (
-                                  borrowMarketLabel ===
-                                  borrowedAssetsMarketFilter
-                                );
-                              })
+                              .filter((borrow) =>
+                                positionMatchesMarketFilter(
+                                  (borrow as ItemWithNetwork).network ||
+                                    currentNetwork,
+                                  borrow.poolId,
+                                  positionsMarketFilter
+                                )
+                              )
                               .sort((a, b) => {
                                 let comparison = 0;
 
@@ -9152,7 +7668,7 @@ const Portfolio = () => {
                                     .join(" ");
                                 }
                               } else if (
-                                borrowedAssetsNetworkFilter === "all"
+                                positionsNetworkFilter === "all"
                               ) {
                                 // Fallback: try to infer from networkValues
                                 const matchingNetwork = Object.entries(
@@ -9391,9 +7907,9 @@ const Portfolio = () => {
                       const filteredAndSorted = borrows
                         .filter((borrow) => {
                           // Filter by search term
-                          if (borrowedAssetsSearchTerm) {
+                          if (positionsSearchTerm) {
                             const searchLower =
-                              borrowedAssetsSearchTerm.toLowerCase();
+                              positionsSearchTerm.toLowerCase();
                             const assetMatch = borrow.asset
                               .toLowerCase()
                               .includes(searchLower);
@@ -9403,7 +7919,7 @@ const Portfolio = () => {
                           }
 
                           // Filter by network
-                          if (selectedNetworkFilter === "all") {
+                          if (positionsNetworkFilter === "all") {
                             return true;
                           }
 
@@ -9411,9 +7927,9 @@ const Portfolio = () => {
                           if (borrowNetwork) {
                             const normalizedNetwork =
                               borrowNetwork.toLowerCase();
-                            if (selectedNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (selectedNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                           }
@@ -9422,9 +7938,9 @@ const Portfolio = () => {
                             user?.computed?.networkValues || {}
                           ).find(([network, values]: [string, unknown]) => {
                             const normalizedNetwork = network.toLowerCase();
-                            if (selectedNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (selectedNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                             return false;
@@ -9486,8 +8002,534 @@ const Portfolio = () => {
                         />
                       );
                     })()}
+                </div>
+              )}
                 </DorkFiCard>
               )}
+
+              {/* At Risk Assets Table */}
+              {atRiskAssets.length > 0 &&
+                (() => {
+                  // Check if any asset has non-zero pool borrows
+                  const hasPoolBorrows = atRiskAssets.some(
+                    (asset) => asset.poolBorrowsUSD > 0
+                  );
+
+                  return (
+                    <DorkFiCard
+                      className={cn(
+                        "p-6 md:p-8 border-orange-500/50 bg-orange-500/5",
+                        hasBothPositionTypes && "order-2 lg:order-3"
+                      )}
+                    >
+                      <div className="mb-4">
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center gap-2">
+                            <AlertTriangle className="w-6 h-6 text-orange-500" />
+                            <H1 className="text-xl md:text-2xl text-orange-500">
+                              At Risk Assets
+                            </H1>
+                          </div>
+                          <DorkFiButton
+                            onClick={handleRefreshAtRiskAssets}
+                            disabled={refreshingSection === "At Risk Assets"}
+                            variant="secondary"
+                            size="sm"
+                            className="min-w-0"
+                            title={
+                              isViewOnly
+                                ? "Refresh market data (view-only mode)"
+                                : "Refresh market data for at risk assets"
+                            }
+                          >
+                            <RefreshCw
+                              className={`w-3 h-3 mr-1.5 ${refreshingSection === "At Risk Assets"
+                                ? "animate-spin"
+                                : ""
+                                }`}
+                            />
+                            Refresh
+                          </DorkFiButton>
+                        </div>
+                        <Body className="text-sm text-muted-foreground">
+                          These assets have a health factor (collateral value ×
+                          liquidation factor / total borrows) less than 1.0,
+                          indicating potential liquidation risk.
+                        </Body>
+                      </div>
+                      <div className="overflow-x-auto">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (atRiskAssetsSort.column === "asset") {
+                                      setAtRiskAssetsSort({
+                                        column: "asset",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "asset",
+                                        direction: "asc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  Asset
+                                  {atRiskAssetsSort.column === "asset" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (atRiskAssetsSort.column === "network") {
+                                      setAtRiskAssetsSort({
+                                        column: "network",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "network",
+                                        direction: "asc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center justify-center gap-1 hover:text-foreground transition-colors w-full"
+                                >
+                                  Network
+                                  {atRiskAssetsSort.column === "network" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              <TableHead>Market</TableHead>
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (atRiskAssetsSort.column === "value") {
+                                      setAtRiskAssetsSort({
+                                        column: "value",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "value",
+                                        direction: "desc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  Value (USD)
+                                  {atRiskAssetsSort.column === "value" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (
+                                      atRiskAssetsSort.column ===
+                                      "liquidationFactor"
+                                    ) {
+                                      setAtRiskAssetsSort({
+                                        column: "liquidationFactor",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "liquidationFactor",
+                                        direction: "desc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  Liquidation Factor
+                                  {atRiskAssetsSort.column ===
+                                    "liquidationFactor" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (
+                                      atRiskAssetsSort.column === "depositValue"
+                                    ) {
+                                      setAtRiskAssetsSort({
+                                        column: "depositValue",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "depositValue",
+                                        direction: "desc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  Deposit Value
+                                  {atRiskAssetsSort.column ===
+                                    "depositValue" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              {hasPoolBorrows && (
+                                <TableHead>
+                                  <button
+                                    onClick={() => {
+                                      if (
+                                        atRiskAssetsSort.column ===
+                                        "borrowValue"
+                                      ) {
+                                        setAtRiskAssetsSort({
+                                          column: "borrowValue",
+                                          direction:
+                                            atRiskAssetsSort.direction === "asc"
+                                              ? "desc"
+                                              : "asc",
+                                        });
+                                      } else {
+                                        setAtRiskAssetsSort({
+                                          column: "borrowValue",
+                                          direction: "desc",
+                                        });
+                                      }
+                                    }}
+                                    className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                  >
+                                    Borrow Value
+                                    {atRiskAssetsSort.column ===
+                                      "borrowValue" ? (
+                                      atRiskAssetsSort.direction === "asc" ? (
+                                        <ArrowUp className="w-3 h-3" />
+                                      ) : (
+                                        <ArrowDown className="w-3 h-3" />
+                                      )
+                                    ) : (
+                                      <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                    )}
+                                  </button>
+                                </TableHead>
+                              )}
+                              <TableHead>
+                                <button
+                                  onClick={() => {
+                                    if (
+                                      atRiskAssetsSort.column === "riskRatio"
+                                    ) {
+                                      setAtRiskAssetsSort({
+                                        column: "riskRatio",
+                                        direction:
+                                          atRiskAssetsSort.direction === "asc"
+                                            ? "desc"
+                                            : "asc",
+                                      });
+                                    } else {
+                                      setAtRiskAssetsSort({
+                                        column: "riskRatio",
+                                        direction: "asc",
+                                      });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  Health Factor
+                                  {atRiskAssetsSort.column === "riskRatio" ? (
+                                    atRiskAssetsSort.direction === "asc" ? (
+                                      <ArrowUp className="w-3 h-3" />
+                                    ) : (
+                                      <ArrowDown className="w-3 h-3" />
+                                    )
+                                  ) : (
+                                    <ArrowUpDown className="w-3 h-3 opacity-50" />
+                                  )}
+                                </button>
+                              </TableHead>
+                              <TableHead>Actions</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {(() => {
+                              // Sort at-risk assets based on selected column
+                              const sortedAtRiskAssets = [...atRiskAssets].sort(
+                                (a, b) => {
+                                  let comparison = 0;
+
+                                  switch (atRiskAssetsSort.column) {
+                                    case "asset":
+                                      comparison = a.asset.localeCompare(
+                                        b.asset
+                                      );
+                                      break;
+                                    case "network":
+                                      const networkA = (
+                                        (a as ItemWithNetwork).network || "Unknown"
+                                      ).toLowerCase();
+                                      const networkB = (
+                                        (b as ItemWithNetwork).network || "Unknown"
+                                      ).toLowerCase();
+                                      comparison =
+                                        networkA.localeCompare(networkB);
+                                      break;
+                                    case "value":
+                                      comparison = a.value - b.value;
+                                      break;
+                                    case "liquidationFactor":
+                                      comparison =
+                                        a.liquidationFactor -
+                                        b.liquidationFactor;
+                                      break;
+                                    case "depositValue":
+                                      comparison =
+                                        a.poolCollateralValueUSD -
+                                        b.poolCollateralValueUSD;
+                                      break;
+                                    case "borrowValue":
+                                      comparison =
+                                        a.poolBorrowsUSD - b.poolBorrowsUSD;
+                                      break;
+                                    case "riskRatio":
+                                    default:
+                                      comparison = a.riskRatio - b.riskRatio;
+                                      break;
+                                  }
+
+                                  return atRiskAssetsSort.direction === "asc"
+                                    ? comparison
+                                    : -comparison;
+                                }
+                              );
+
+                              const filteredAtRiskAssets =
+                                sortedAtRiskAssets.filter(
+                                  positionPassesPortfolioFilters
+                                );
+
+                              return filteredAtRiskAssets.map(
+                                (asset, index) => {
+                                  // Get market label using the asset's network, not currentNetwork
+                                  const assetNetwork =
+                                    (asset as ItemWithNetwork).network || currentNetwork;
+                                  const marketLabel = getMarketLabel(
+                                    assetNetwork,
+                                    asset.poolId
+                                  );
+
+                                  return (
+                                    <TableRow
+                                      key={`${asset.asset}-${asset.poolId || index
+                                        }`}
+                                      className="transition-all relative card-hover rounded-lg border border-gray-200/30 dark:border-ocean-teal/10 bg-white/50 dark:bg-slate-800/50 hover:border-orange-400 hover:shadow-[0_0_16px_4px_rgba(249,115,22,0.15)] hover:bg-orange-500/5 hover:z-20 cursor-pointer"
+                                    >
+                                      <TableCell>
+                                        <div className="flex items-center gap-2">
+                                          <MarketRowTokenIcon
+                                            market={{
+                                              icon: asset.icon,
+                                              asset: asset.asset,
+                                              iconBadgeUrl: (
+                                                asset as { iconBadgeUrl?: string }
+                                              ).iconBadgeUrl,
+                                            }}
+                                            poolLetterLabel={marketLabel}
+                                            imgClassName="h-6 w-6 shrink-0 rounded-full object-contain"
+                                          />
+                                          <span className="font-medium">
+                                            {asset.asset}
+                                          </span>
+                                        </div>
+                                      </TableCell>
+                                      <TableCell className="text-center">
+                                        {(() => {
+                                          const depositNetwork = (asset as ItemWithNetwork)
+                                            .network;
+                                          if (depositNetwork) {
+                                            // Format network name: "algorand-mainnet" -> "Algorand", "voi-mainnet" -> "VOI"
+                                            const normalized =
+                                              depositNetwork.toLowerCase();
+                                            if (
+                                              normalized.includes("algorand")
+                                            ) {
+                                              return "Algorand";
+                                            } else if (
+                                              normalized.includes("voi")
+                                            ) {
+                                              return "VOI";
+                                            } else {
+                                              // Fallback to formatted name
+                                              return depositNetwork
+                                                .split("-")
+                                                .map(
+                                                  (word) =>
+                                                    word
+                                                      .charAt(0)
+                                                      .toUpperCase() +
+                                                    word.slice(1)
+                                                )
+                                                .join(" ");
+                                            }
+                                          }
+                                          return "Unknown";
+                                        })()}
+                                      </TableCell>
+                                      <TableCell className="text-center">
+                                        {marketLabel || "-"}
+                                      </TableCell>
+                                      <TableCell>
+                                        $
+                                        {formatNumber(asset.value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                                      </TableCell>
+                                      <TableCell>
+                                        {formatPercent(asset.liquidationFactor, { maximumFractionDigits: 1 })}
+                                      </TableCell>
+                                      <TableCell>
+                                        <span className="text-muted-foreground">
+                                          {formatCurrency(asset.poolCollateralValueUSD, "USD", {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 2,
+                                          })}
+                                        </span>
+                                      </TableCell>
+                                      {hasPoolBorrows && (
+                                        <TableCell>
+                                          <span className="text-muted-foreground">
+                                            {formatCurrency(asset.poolBorrowsUSD, "USD",
+                                              {
+                                                minimumFractionDigits: 2,
+                                                maximumFractionDigits: 2,
+                                              }
+                                            )}
+                                          </span>
+                                        </TableCell>
+                                      )}
+                                      <TableCell>
+                                        <span
+                                          className={`font-semibold ${asset.riskRatio < 0.5
+                                            ? "text-red-500"
+                                            : asset.riskRatio < 0.75
+                                              ? "text-orange-500"
+                                              : "text-yellow-500"
+                                            }`}
+                                        >
+                                          {formatNumber(asset.riskRatio, { maximumFractionDigits: 3 })}
+                                        </span>
+                                      </TableCell>
+                                      <TableCell>
+                                        <div className="flex items-center gap-2">
+                                          {!isViewOnly && (() => {
+                                            const atRiskMarket =
+                                              marketRowForPortfolioPosition(
+                                                marketData,
+                                                {
+                                                  marketId: (asset as ItemWithNetwork)
+                                                    .marketId,
+                                                  poolId: asset.poolId,
+                                                  displaySymbol: asset.asset,
+                                                }
+                                              ) as any;
+                                            const depositCapReached =
+                                              atRiskMarket &&
+                                              isAtDepositCap(
+                                                Number(atRiskMarket?.totalDeposits ?? 0),
+                                                Number(atRiskMarket?.maxTotalDeposits ?? 0),
+                                              );
+                                            return !atRiskMarket?.isPaused && (
+                                              <DorkFiButton
+                                                variant="secondary"
+                                                size="sm"
+                                                onClick={(e) => {
+                                                  e.stopPropagation();
+                                                  handleDepositClick(
+                                                    asset.asset,
+                                                    asset.poolId,
+                                                    (asset as ItemWithNetwork).network,
+                                                    (asset as ItemWithNetwork).configSymbol,
+                                                    (asset as ItemWithNetwork).marketId
+                                                  );
+                                                }}
+                                                disabled={depositCapReached}
+                                                title={
+                                                  depositCapReached
+                                                    ? "Market at deposit cap"
+                                                    : "Supply more of this asset to earn yield and use as collateral"
+                                                }
+                                                aria-label="Supply"
+                                                className="min-w-[92px] h-8 px-2 gap-1"
+                                              >
+                                                <span className="text-base leading-none">+</span>
+                                                <span className="hidden lg:inline text-xs">Supply</span>
+                                              </DorkFiButton>
+                                            );
+                                          })()}
+                                        </div>
+                                      </TableCell>
+                                    </TableRow>
+                                  );
+                                }
+                              );
+                            })()}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    </DorkFiCard>
+                  );
+                })()}
 
               {/* Accrued Interest Table */}
               {SHOW_ACCRUED_INTEREST_SECTION && accruedInterestItems.length > 0 && (
@@ -9501,11 +8543,11 @@ const Portfolio = () => {
                     <div className="flex items-center justify-between mb-2">
                       <H1 className="text-xl md:text-2xl">
                         Accrued Interest
-                        {selectedNetworkFilter !== "all" && (
+                        {positionsNetworkFilter !== "all" && (
                           <span className="text-lg text-muted-foreground ml-2">
                             (
-                            {selectedNetworkFilter.charAt(0).toUpperCase() +
-                              selectedNetworkFilter.slice(1)}
+                            {positionsNetworkFilter.charAt(0).toUpperCase() +
+                              positionsNetworkFilter.slice(1)}
                             )
                           </span>
                         )}
@@ -9560,14 +8602,14 @@ const Portfolio = () => {
                                 .includes(searchLower);
                               if (!assetMatch) return false;
                             }
-                            if (selectedNetworkFilter === "all") return true;
+                            if (positionsNetworkFilter === "all") return true;
                             const itemNetwork = (item as ItemWithNetwork).network;
                             if (itemNetwork) {
                               const normalizedNetwork =
                                 itemNetwork.toLowerCase();
-                              if (selectedNetworkFilter === "algorand") {
+                              if (positionsNetworkFilter === "algorand") {
                                 return normalizedNetwork.includes("algorand");
-                              } else if (selectedNetworkFilter === "voi") {
+                              } else if (positionsNetworkFilter === "voi") {
                                 return normalizedNetwork.includes("voi");
                               }
                             }
@@ -9693,7 +8735,7 @@ const Portfolio = () => {
                                 )}
                               </button>
                             </TableHead>
-                            {selectedNetworkFilter === "all" && (
+                            {positionsNetworkFilter === "all" && (
                               <TableHead>
                                 <button
                                   onClick={() => {
@@ -9815,7 +8857,7 @@ const Portfolio = () => {
                                 }
 
                                 // Filter by network
-                                if (selectedNetworkFilter === "all") {
+                                if (positionsNetworkFilter === "all") {
                                   return true;
                                 }
 
@@ -9823,11 +8865,11 @@ const Portfolio = () => {
                                 if (itemNetwork) {
                                   const normalizedNetwork =
                                     itemNetwork.toLowerCase();
-                                  if (selectedNetworkFilter === "algorand") {
+                                  if (positionsNetworkFilter === "algorand") {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
-                                  } else if (selectedNetworkFilter === "voi") {
+                                  } else if (positionsNetworkFilter === "voi") {
                                     return normalizedNetwork.includes("voi");
                                   }
                                 }
@@ -9837,11 +8879,11 @@ const Portfolio = () => {
                                 ).find(([network, values]: [string, unknown]) => {
                                   const normalizedNetwork =
                                     network.toLowerCase();
-                                  if (selectedNetworkFilter === "algorand") {
+                                  if (positionsNetworkFilter === "algorand") {
                                     return normalizedNetwork.includes(
                                       "algorand"
                                     );
-                                  } else if (selectedNetworkFilter === "voi") {
+                                  } else if (positionsNetworkFilter === "voi") {
                                     return normalizedNetwork.includes("voi");
                                   }
                                   return false;
@@ -9909,7 +8951,7 @@ const Portfolio = () => {
                                     )
                                     .join(" ");
                                 }
-                              } else if (selectedNetworkFilter === "all") {
+                              } else if (positionsNetworkFilter === "all") {
                                 const matchingNetwork = Object.entries(
                                   user.computed.networkValues
                                 ).find(([network, values]: [string, unknown]) => {
@@ -9978,7 +9020,7 @@ const Portfolio = () => {
                                       </span>
                                     </div>
                                   </TableCell>
-                                  {selectedNetworkFilter === "all" && (
+                                  {positionsNetworkFilter === "all" && (
                                     <TableCell className="font-medium">
                                       {networkName}
                                     </TableCell>
@@ -10063,16 +9105,16 @@ const Portfolio = () => {
                             }
                           }
 
-                          if (selectedNetworkFilter === "all") {
+                          if (positionsNetworkFilter === "all") {
                             return true;
                           }
 
                           const itemNetwork = (item as ItemWithNetwork).network;
                           if (itemNetwork) {
                             const normalizedNetwork = itemNetwork.toLowerCase();
-                            if (selectedNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (selectedNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                           }
@@ -10081,9 +9123,9 @@ const Portfolio = () => {
                             user?.computed?.networkValues || {}
                           ).find(([network, values]: [string, unknown]) => {
                             const normalizedNetwork = network.toLowerCase();
-                            if (selectedNetworkFilter === "algorand") {
+                            if (positionsNetworkFilter === "algorand") {
                               return normalizedNetwork.includes("algorand");
-                            } else if (selectedNetworkFilter === "voi") {
+                            } else if (positionsNetworkFilter === "voi") {
                               return normalizedNetwork.includes("voi");
                             }
                             return false;

--- a/src/components/liquidation/HealthFactorActions.tsx
+++ b/src/components/liquidation/HealthFactorActions.tsx
@@ -1,10 +1,7 @@
 import DorkFiButton from "@/components/ui/DorkFiButton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Plus, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+import { DesktopTooltip } from "@/components/ui/tooltip";
+import { Plus, ArrowDownToLine, ArrowUpFromLine, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface HealthFactorActionsProps {
   healthFactor: number | null;
@@ -13,6 +10,8 @@ interface HealthFactorActionsProps {
   onRepayDebt?: () => void;
   onWithdraw?: () => void;
   totalBorrowed?: number;
+  onRefreshMarkets?: () => void;
+  isRefreshingMarkets?: boolean;
 }
 
 const HealthFactorActions = ({
@@ -22,76 +21,106 @@ const HealthFactorActions = ({
   onRepayDebt,
   onWithdraw,
   totalBorrowed = 0,
+  onRefreshMarkets,
+  isRefreshingMarkets,
 }: HealthFactorActionsProps) => {
   const isHighRisk = healthFactor !== null && healthFactor <= 1.2;
   const isCritical = healthFactor !== null && healthFactor <= 1.0;
 
   return (
     <>
+      {onRefreshMarkets && (
+        <DorkFiButton
+          onClick={onRefreshMarkets}
+          disabled={isRefreshingMarkets}
+          variant="secondary"
+          size="sm"
+          className="mb-3 w-full !min-h-10 !min-w-0 gap-2 sm:hidden"
+          title="Refresh all market data"
+        >
+          <RefreshCw
+            className={cn(
+              "h-4 w-4 shrink-0",
+              isRefreshingMarkets && "animate-spin"
+            )}
+          />
+          Refresh
+        </DorkFiButton>
+      )}
+
       {/* Actions: Supply and Repay */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1">
         {onAddCollateral && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DorkFiButton
-                onClick={onAddCollateral}
-                variant={isHighRisk ? "danger" : "primary"}
-                size="lg"
-                className="w-full min-w-0 h-12 gap-2"
-              >
-                <Plus className="w-5 h-5 shrink-0" />
-                Supply
-              </DorkFiButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-xs">
-              <p>Add assets to earn yield and use as collateral. Improves health factor.</p>
-            </TooltipContent>
-          </Tooltip>
+          <DesktopTooltip
+            side="top"
+            className="max-w-xs"
+            content={
+              <p>
+                Add assets to earn yield and use as collateral. Improves health
+                factor.
+              </p>
+            }
+          >
+            <DorkFiButton
+              onClick={onAddCollateral}
+              variant={isHighRisk ? "danger" : "primary"}
+              size="lg"
+              className="w-full min-w-0 h-12 gap-2"
+            >
+              <Plus className="w-5 h-5 shrink-0" />
+              Supply
+            </DorkFiButton>
+          </DesktopTooltip>
         )}
         {totalBorrowed > 0 && onRepayDebt && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DorkFiButton
-                variant={isHighRisk ? "danger-outline" : "secondary"}
-                size="lg"
-                onClick={onRepayDebt}
-                className="w-full min-w-0 h-12 gap-2"
-              >
-                <ArrowDownToLine className="w-5 h-5 shrink-0" />
-                Repay
-              </DorkFiButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-xs">
-              <p>Pay down debt to improve health factor and reduce liquidation risk.</p>
-            </TooltipContent>
-          </Tooltip>
+          <DesktopTooltip
+            side="top"
+            className="max-w-xs"
+            content={
+              <p>
+                Pay down debt to improve health factor and reduce liquidation
+                risk.
+              </p>
+            }
+          >
+            <DorkFiButton
+              variant={isHighRisk ? "danger-outline" : "secondary"}
+              size="lg"
+              onClick={onRepayDebt}
+              className="w-full min-w-0 h-12 gap-2"
+            >
+              <ArrowDownToLine className="w-5 h-5 shrink-0" />
+              Repay
+            </DorkFiButton>
+          </DesktopTooltip>
         )}
       </div>
 
       {onWithdraw && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="block w-full">
-              <DorkFiButton
-                variant="withdraw"
-                size="lg"
-                onClick={onWithdraw}
-                disabled={isCritical}
-                className="w-full min-w-0 h-12 gap-2 mt-1 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <ArrowUpFromLine className="w-5 h-5 shrink-0" />
-                Withdraw
-              </DorkFiButton>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-xs">
+        <DesktopTooltip
+          side="top"
+          className="max-w-xs"
+          content={
             <p>
               {isCritical
                 ? "Withdrawals are blocked while health factor is at or below 1.0. Supply collateral or repay debt first."
                 : "Withdraw supplied assets to your wallet (up to the HF-safe maximum)."}
             </p>
-          </TooltipContent>
-        </Tooltip>
+          }
+        >
+          <span className="block w-full">
+            <DorkFiButton
+              variant="withdraw"
+              size="lg"
+              onClick={onWithdraw}
+              disabled={isCritical}
+              className="w-full min-w-0 h-12 gap-2 mt-1 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ArrowUpFromLine className="w-5 h-5 shrink-0" />
+              Withdraw
+            </DorkFiButton>
+          </span>
+        </DesktopTooltip>
       )}
 
       {isHighRisk && (

--- a/src/components/liquidation/PositionStatsGrid.tsx
+++ b/src/components/liquidation/PositionStatsGrid.tsx
@@ -22,102 +22,96 @@ const PositionStatsGrid = ({
     healthFactor !== null
       ? getHealthFactorTextColorClass(healthFactor)
       : "text-muted-foreground";
+  const netValue = totalCollateral - totalBorrowed;
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-4">
-        <div className="p-5 rounded-xl bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 border border-green-200/50 dark:border-green-700/30 hover:shadow-lg transition-all duration-300">
-          <div className="text-sm text-muted-foreground flex items-center gap-1 mb-2">
-            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-            Total Collateral
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="w-3 h-3 cursor-help" />
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                <p>Total USD value of assets you have supplied.</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-          <div className="text-2xl font-bold text-green-600 dark:text-green-400">
-            $
-            {totalCollateral.toLocaleString("en-US", {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </div>
+    <div className="grid grid-cols-1 gap-px overflow-hidden rounded-xl border border-border/60 bg-border/40 sm:grid-cols-2">
+      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+          <div className="h-2 w-2 rounded-full bg-green-500" />
+          Total Collateral
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3 w-3 cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>Total USD value of assets you have supplied.</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
-
-        <div className="p-5 rounded-xl bg-gradient-to-br from-red-50 to-rose-50 dark:from-red-900/20 dark:to-rose-900/20 border border-red-200/50 dark:border-red-700/30 hover:shadow-lg transition-all duration-300">
-          <div className="text-sm text-muted-foreground flex items-center gap-1 mb-2">
-            <div className="w-2 h-2 bg-red-500 rounded-full"></div>
-            Total Borrowed
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="w-3 h-3 cursor-help" />
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                <p>Total USD value of your outstanding debt (accrues interest).</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-          <div className="text-2xl font-bold text-red-600 dark:text-red-400">
-            $
-            {totalBorrowed.toLocaleString("en-US", {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </div>
+        <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+          $
+          {totalCollateral.toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="h-full p-5 rounded-xl bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-800 dark:to-slate-900 border border-slate-200/50 dark:border-slate-600/30 hover:shadow-lg transition-all duration-300">
-          <div className="text-sm text-muted-foreground flex items-center gap-1 mb-2">
-            <div className="w-2 h-2 bg-cyan-500 rounded-full"></div>
-            Liquidation buffer
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="w-3 h-3 cursor-help" />
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                <p>
-                  How far your health factor is above liquidation (HF = 1.0).
-                  Higher buffer means more room before actions are blocked.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-          <div className={`text-2xl font-bold ${hfColorClass}`}>{bufferText}</div>
+      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+          <div className="h-2 w-2 rounded-full bg-red-500" />
+          Total Borrowed
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3 w-3 cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>Total USD value of your outstanding debt (accrues interest).</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
+        <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+          $
+          {totalBorrowed.toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+        </div>
+      </div>
 
-        <div className="h-full p-5 rounded-xl bg-gradient-to-r from-slate-50 to-gray-50 dark:from-slate-800 dark:to-slate-700 border border-slate-200/50 dark:border-slate-600/30 hover:shadow-lg transition-all duration-300">
-          <div className="text-sm text-muted-foreground mb-2">
-            Net Portfolio Value
-          </div>
-          <div
-            className={`text-2xl font-bold ${
-              totalCollateral - totalBorrowed >= 0
-                ? "text-green-600 dark:text-green-400"
-                : "text-red-600 dark:text-red-400"
-            }`}
-          >
-            $
-            {(totalCollateral - totalBorrowed).toLocaleString("en-US", {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </div>
-          {totalCollateral > 0 && (
-            <div className="text-xs text-muted-foreground mt-1">
-              {(
-                ((totalCollateral - totalBorrowed) / totalCollateral) *
-                100
-              ).toFixed(1)}
-              % of collateral value
-            </div>
-          )}
+      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+          <div className="h-2 w-2 rounded-full bg-cyan-500" />
+          Liquidation buffer
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3 w-3 cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>
+                How far your health factor is above liquidation (HF = 1.0).
+                Higher buffer means more room before actions are blocked.
+              </p>
+            </TooltipContent>
+          </Tooltip>
         </div>
+        <div className={`text-2xl font-bold ${hfColorClass}`}>{bufferText}</div>
+      </div>
+
+      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+        <div className="mb-2 text-sm text-muted-foreground">
+          Net Portfolio Value
+        </div>
+        <div
+          className={`text-2xl font-bold ${
+            netValue >= 0
+              ? "text-green-600 dark:text-green-400"
+              : "text-red-600 dark:text-red-400"
+          }`}
+        >
+          $
+          {netValue.toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+        </div>
+        {totalCollateral > 0 && (
+          <div className="mt-1 text-xs text-muted-foreground">
+            {((netValue / totalCollateral) * 100).toFixed(1)}% of collateral
+            value
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/liquidation/PositionStatsGrid.tsx
+++ b/src/components/liquidation/PositionStatsGrid.tsx
@@ -1,119 +1,172 @@
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { ReactNode } from "react";
+import { DesktopTooltip } from "@/components/ui/tooltip";
 import { Info } from "lucide-react";
 import {
   formatHealthFactorBuffer,
   getHealthFactorTextColorClass,
 } from "@/utils/healthFactorUx";
+import { H1 } from "@/components/ui/Typography";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import PortfolioWalletStatusBar, {
+  type PortfolioWalletStatus,
+} from "@/components/portfolio/PortfolioWalletStatusBar";
 
 interface PositionStatsGridProps {
   totalCollateral: number;
   totalBorrowed: number;
   healthFactor: number | null;
+  walletStatus?: PortfolioWalletStatus;
+}
+
+const usdOptions = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+} as const;
+
+function StatInfoTooltip({ children }: { children: ReactNode }) {
+  return (
+    <DesktopTooltip className="max-w-xs" content={children}>
+      <Info className="h-3 w-3 cursor-help" />
+    </DesktopTooltip>
+  );
 }
 
 const PositionStatsGrid = ({
   totalCollateral,
   totalBorrowed,
   healthFactor,
+  walletStatus,
 }: PositionStatsGridProps) => {
+  const { formatCurrency } = useNumberI18n();
+  const formatUsd = (value: number) =>
+    formatCurrency(value, "USD", usdOptions);
+
   const bufferText = formatHealthFactorBuffer(healthFactor);
   const hfColorClass =
     healthFactor !== null
       ? getHealthFactorTextColorClass(healthFactor)
       : "text-muted-foreground";
   const netValue = totalCollateral - totalBorrowed;
+  const netColorClass =
+    netValue >= 0
+      ? "text-green-600 dark:text-green-400"
+      : "text-red-600 dark:text-red-400";
 
   return (
-    <div className="grid grid-cols-1 gap-px overflow-hidden rounded-xl border border-border/60 bg-border/40 sm:grid-cols-2">
-      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
-        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
-          <div className="h-2 w-2 rounded-full bg-green-500" />
-          Total Collateral
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3 w-3 cursor-help" />
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">
+    <>
+      {/* Mobile: hero-style title + stats */}
+      <div className="sm:hidden">
+        <div className="mb-3 text-left">
+          <H1 className="m-0 text-2xl font-semibold leading-none tracking-tight">
+            <span className="hero-header">Portfolio Overview</span>
+          </H1>
+          {walletStatus ? (
+            <PortfolioWalletStatusBar className="mt-2" {...walletStatus} />
+          ) : null}
+        </div>
+        <div className="overflow-hidden rounded-xl border border-border/60 bg-muted/20 px-4 pb-4 pt-3 dark:bg-muted/10">
+          <div className="text-sm text-muted-foreground">Net Portfolio Value</div>
+          <div className={`mt-1 text-3xl font-bold tabular-nums ${netColorClass}`}>
+            {formatUsd(netValue)}
+          </div>
+          {totalCollateral > 0 && (
+            <div className="mt-1 text-xs text-muted-foreground">
+              {((netValue / totalCollateral) * 100).toFixed(1)}% of collateral
+              value
+            </div>
+          )}
+
+          <div className="mt-4 grid grid-cols-2 gap-4 border-t border-border/50 pt-4">
+            <div>
+              <div className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
+                <div className="h-2 w-2 shrink-0 rounded-full bg-green-500" />
+                Collateral
+              </div>
+              <div className="text-lg font-bold tabular-nums text-green-600 dark:text-green-400">
+                {formatUsd(totalCollateral)}
+              </div>
+            </div>
+            <div>
+              <div className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
+                <div className="h-2 w-2 shrink-0 rounded-full bg-red-500" />
+                Borrowed
+              </div>
+              <div className="text-lg font-bold tabular-nums text-red-600 dark:text-red-400">
+                {formatUsd(totalBorrowed)}
+              </div>
+            </div>
+            <div className="col-span-2">
+              <div className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
+                <div className="h-2 w-2 shrink-0 rounded-full bg-cyan-500" />
+                Liquidation buffer
+              </div>
+              <div className={`text-lg font-bold tabular-nums ${hfColorClass}`}>
+                {bufferText}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tablet / desktop: full 2×2 grid */}
+      <div className="hidden gap-px overflow-hidden rounded-xl border border-border/60 bg-border/40 sm:grid sm:grid-cols-2">
+        <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+          <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+            <div className="h-2 w-2 rounded-full bg-green-500" />
+            Total Collateral
+            <StatInfoTooltip>
               <p>Total USD value of assets you have supplied.</p>
-            </TooltipContent>
-          </Tooltip>
+            </StatInfoTooltip>
+          </div>
+          <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+            {formatUsd(totalCollateral)}
+          </div>
         </div>
-        <div className="text-2xl font-bold text-green-600 dark:text-green-400">
-          $
-          {totalCollateral.toLocaleString("en-US", {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })}
-        </div>
-      </div>
 
-      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
-        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
-          <div className="h-2 w-2 rounded-full bg-red-500" />
-          Total Borrowed
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3 w-3 cursor-help" />
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">
+        <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+          <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+            <div className="h-2 w-2 rounded-full bg-red-500" />
+            Total Borrowed
+            <StatInfoTooltip>
               <p>Total USD value of your outstanding debt (accrues interest).</p>
-            </TooltipContent>
-          </Tooltip>
+            </StatInfoTooltip>
+          </div>
+          <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+            {formatUsd(totalBorrowed)}
+          </div>
         </div>
-        <div className="text-2xl font-bold text-red-600 dark:text-red-400">
-          $
-          {totalBorrowed.toLocaleString("en-US", {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })}
-        </div>
-      </div>
 
-      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
-        <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
-          <div className="h-2 w-2 rounded-full bg-cyan-500" />
-          Liquidation buffer
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3 w-3 cursor-help" />
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">
+        <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+          <div className="mb-2 flex items-center gap-1 text-sm text-muted-foreground">
+            <div className="h-2 w-2 rounded-full bg-cyan-500" />
+            Liquidation buffer
+            <StatInfoTooltip>
               <p>
                 How far your health factor is above liquidation (HF = 1.0).
                 Higher buffer means more room before actions are blocked.
               </p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        <div className={`text-2xl font-bold ${hfColorClass}`}>{bufferText}</div>
-      </div>
-
-      <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
-        <div className="mb-2 text-sm text-muted-foreground">
-          Net Portfolio Value
-        </div>
-        <div
-          className={`text-2xl font-bold ${
-            netValue >= 0
-              ? "text-green-600 dark:text-green-400"
-              : "text-red-600 dark:text-red-400"
-          }`}
-        >
-          $
-          {netValue.toLocaleString("en-US", {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })}
-        </div>
-        {totalCollateral > 0 && (
-          <div className="mt-1 text-xs text-muted-foreground">
-            {((netValue / totalCollateral) * 100).toFixed(1)}% of collateral
-            value
+            </StatInfoTooltip>
           </div>
-        )}
+          <div className={`text-2xl font-bold ${hfColorClass}`}>{bufferText}</div>
+        </div>
+
+        <div className="bg-muted/20 p-4 dark:bg-muted/10 sm:p-5">
+          <div className="mb-2 text-sm text-muted-foreground">
+            Net Portfolio Value
+          </div>
+          <div className={`text-2xl font-bold ${netColorClass}`}>
+            {formatUsd(netValue)}
+          </div>
+          {totalCollateral > 0 && (
+            <div className="mt-1 text-xs text-muted-foreground">
+              {((netValue / totalCollateral) * 100).toFixed(1)}% of collateral
+              value
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/portfolio/AccruedInterestMobileCard.tsx
+++ b/src/components/portfolio/AccruedInterestMobileCard.tsx
@@ -66,43 +66,41 @@ const AccruedInterestMobileCard = ({
         : "bg-red-500/5 border-red-500/10"
     }`}>
       <div className="space-y-3">
-        {/* Header: Asset Icon + Name + Actions */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <MarketRowTokenIcon
-              market={{
-                icon,
-                asset,
-                iconBadgeUrl: resolvedBadgeUrl,
-              }}
-              poolLetterLabel={marketLabel}
-              imgClassName="h-12 w-12 flex-shrink-0 rounded-full object-contain"
-            />
-            <div>
-              <div className="font-semibold text-base text-slate-800 dark:text-white">
-                {asset}
-              </div>
-              {network && (
-                <div className="text-xs text-muted-foreground">
-                  {network.split("-")[0].charAt(0).toUpperCase() +
-                    network.split("-")[0].slice(1)}
-                </div>
-              )}
-            </div>
-          </div>
+        {/* Header: centered icon + ticker; refresh pinned top-right */}
+        <div className="relative flex flex-col items-center gap-1">
           {onRefreshClick && (
             <Button
               variant="ghost"
               size="sm"
               onClick={onRefreshClick}
               disabled={isRefreshing}
-              className="h-8 w-8 p-0"
+              className="absolute right-0 top-0 h-8 w-8 p-0"
             >
               <RefreshCw
                 className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`}
               />
             </Button>
           )}
+          <MarketRowTokenIcon
+            market={{
+              icon,
+              asset,
+              iconBadgeUrl: resolvedBadgeUrl,
+            }}
+            poolLetterLabel={marketLabel}
+            imgClassName="h-12 w-12 flex-shrink-0 rounded-full object-contain"
+          />
+          <div className="text-center">
+            <div className="font-semibold text-base text-slate-800 dark:text-white">
+              {asset}
+            </div>
+            {network && (
+              <div className="text-xs text-muted-foreground">
+                {network.split("-")[0].charAt(0).toUpperCase() +
+                  network.split("-")[0].slice(1)}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Net Interest Value */}

--- a/src/components/portfolio/PortfolioInsightChip.tsx
+++ b/src/components/portfolio/PortfolioInsightChip.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type PortfolioInsightChipProps = {
+  label: string;
+  primary: ReactNode;
+  secondary?: ReactNode;
+  highlight?: boolean;
+  dimmed?: boolean;
+  loading?: boolean;
+  onClick: () => void;
+  ariaLabel: string;
+};
+
+const PortfolioInsightChip = ({
+  label,
+  primary,
+  secondary,
+  highlight = false,
+  dimmed = false,
+  loading = false,
+  onClick,
+  ariaLabel,
+}: PortfolioInsightChipProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={loading}
+    aria-label={ariaLabel}
+    aria-busy={loading}
+    className={cn(
+      "bg-muted/20 p-4 text-left transition-colors dark:bg-muted/10 sm:p-4",
+      "hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ocean-teal/50",
+      highlight &&
+        "bg-yellow-400/10 hover:bg-yellow-400/15 dark:bg-yellow-400/10 dark:hover:bg-yellow-400/15",
+      dimmed && !highlight && "opacity-75 hover:opacity-100"
+    )}
+  >
+    <div className="mb-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+      {label}
+      {loading ? (
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+      ) : null}
+    </div>
+    <div
+      className={cn(
+        "text-xl font-bold tabular-nums leading-tight",
+        highlight
+          ? "text-slate-900 dark:text-yellow-100"
+          : "text-foreground"
+      )}
+    >
+      {primary}
+    </div>
+    {secondary ? (
+      <div className="mt-1 text-xs text-muted-foreground">{secondary}</div>
+    ) : null}
+  </button>
+);
+
+export default PortfolioInsightChip;

--- a/src/components/portfolio/PortfolioInsightsHub.tsx
+++ b/src/components/portfolio/PortfolioInsightsHub.tsx
@@ -29,7 +29,6 @@ type PortfolioInsightsHubProps = {
   embedded?: boolean;
   layout?: PortfolioInsightsLayout;
   showNetworkRow: boolean;
-  poolPortfolioBreakdown: PortfolioPoolBreakdownRow[];
   networkPortfolioPoolsFiltered: PortfolioPoolBreakdownRow[];
   positionsNetworkFilter: PortfolioNetworkFilterValue;
   positionsMarketFilter: MarketFilter;
@@ -52,7 +51,6 @@ const PortfolioInsightsHub = ({
   embedded = false,
   layout = "chips",
   showNetworkRow,
-  poolPortfolioBreakdown,
   networkPortfolioPoolsFiltered,
   positionsNetworkFilter,
   positionsMarketFilter,
@@ -86,13 +84,13 @@ const PortfolioInsightsHub = ({
     showAchievementsRow && (isLoading || isFetching);
 
   const networkSummary = useMemo(() => {
-    const count = poolPortfolioBreakdown.length;
-    const netTotal = poolPortfolioBreakdown.reduce(
+    const count = networkPortfolioPoolsFiltered.length;
+    const netTotal = networkPortfolioPoolsFiltered.reduce(
       (sum, row) => sum + row.netValue,
       0
     );
     return { count, netTotal };
-  }, [poolPortfolioBreakdown]);
+  }, [networkPortfolioPoolsFiltered]);
 
   const visibleRows = [
     showNetworkRow,

--- a/src/components/portfolio/PortfolioInsightsHub.tsx
+++ b/src/components/portfolio/PortfolioInsightsHub.tsx
@@ -3,11 +3,7 @@ import { Gift, Globe, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import DorkFiCard from "@/components/ui/DorkFiCard";
 import DorkFiButton from "@/components/ui/DorkFiButton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { DesktopTooltip } from "@/components/ui/tooltip";
 import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
 import { PORTFOLIO_ACHIEVEMENT_FAMILIES } from "@/data/achievementsCatalog";
 import { useUserAchievements } from "@/hooks/useUserAchievements";
@@ -125,84 +121,75 @@ const PortfolioInsightsHub = ({
       className={cn(
         "grid gap-2",
         visibleRows === 1 && "grid-cols-1",
-        visibleRows === 2 && "grid-cols-2",
-        visibleRows === 3 && "grid-cols-3",
+        visibleRows === 2 && "grid-cols-1 sm:grid-cols-2",
+        visibleRows === 3 && "grid-cols-1 sm:grid-cols-3",
         className
       )}
     >
       {showNetworkRow ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DorkFiButton
-              type="button"
-              variant="secondary"
-              size="sm"
-              className="h-10 w-full min-w-0 gap-1.5 px-2"
-              onClick={() => setNetworkModalOpen(true)}
-              aria-label={`Networks. ${networkTooltip}. Open breakdown.`}
-            >
-              <Globe className="h-4 w-4 shrink-0" aria-hidden />
-              <span className="truncate">Networks</span>
-            </DorkFiButton>
-          </TooltipTrigger>
-          <TooltipContent>{networkTooltip}</TooltipContent>
-        </Tooltip>
+        <DesktopTooltip content={networkTooltip}>
+          <DorkFiButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-10 w-full min-w-0 gap-1.5 px-2"
+            onClick={() => setNetworkModalOpen(true)}
+            aria-label={`Networks. ${networkTooltip}. Open breakdown.`}
+          >
+            <Globe className="h-4 w-4 shrink-0" aria-hidden />
+            <span className="truncate">Networks</span>
+          </DorkFiButton>
+        </DesktopTooltip>
       ) : null}
 
       {showAchievementsRow ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DorkFiButton
-              type="button"
-              variant="secondary"
-              size="sm"
-              className="h-10 w-full min-w-0 gap-1.5 px-2"
-              disabled={achievementsLoading}
-              onClick={() => setAchievementsModalOpen(true)}
-              aria-label={`Achievements. ${achievementsTooltip}. Open details.`}
-            >
-              {achievementsLoading ? (
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
-              ) : (
-                <AchievementWhaleIcon className="h-4 w-4 shrink-0" />
-              )}
-              <span className="truncate">
-                {achievementsLoading
-                  ? "…"
-                  : `${earnedCount}/${totalFamilies} Achievements`}
-              </span>
-            </DorkFiButton>
-          </TooltipTrigger>
-          <TooltipContent>{achievementsTooltip}</TooltipContent>
-        </Tooltip>
+        <DesktopTooltip content={achievementsTooltip}>
+          <DorkFiButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-10 w-full min-w-0 gap-1.5 px-2"
+            disabled={achievementsLoading}
+            onClick={() => setAchievementsModalOpen(true)}
+            aria-label={`Achievements. ${achievementsTooltip}. Open details.`}
+          >
+            {achievementsLoading ? (
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
+            ) : (
+              <AchievementWhaleIcon className="h-4 w-4 shrink-0" />
+            )}
+            <span className="truncate">
+              {achievementsLoading
+                ? "…"
+                : `${earnedCount}/${totalFamilies} Achievements`}
+            </span>
+          </DorkFiButton>
+        </DesktopTooltip>
       ) : null}
 
       {showNftRow ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DorkFiButton
-              type="button"
-              variant={nftHasClaimable ? "moderate" : "secondary"}
-              size="sm"
-              className={cn(
-                "h-10 w-full min-w-0 gap-1.5 px-2",
-                nftHasClaimable &&
-                  "border-yellow-500/60 bg-yellow-400/90 text-slate-900 hover:bg-yellow-300"
-              )}
-              disabled={nftRewardsLoading}
-              onClick={onOpenNftRewards}
-              aria-label={`NFT rewards. ${nftTooltip}`}
-            >
-              {nftRewardsLoading ? (
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
-              ) : (
-                <Gift className="h-4 w-4 shrink-0" aria-hidden />
-              )}
-              <span className="truncate">Rewards</span>
-            </DorkFiButton>
-          </TooltipTrigger>
-          <TooltipContent>{nftTooltip}</TooltipContent>
-        </Tooltip>
+        <DesktopTooltip content={nftTooltip}>
+          <DorkFiButton
+            type="button"
+            variant={nftHasClaimable ? "moderate" : "secondary"}
+            size="sm"
+            className={cn(
+              "h-10 w-full min-w-0 gap-1.5 px-2",
+              nftHasClaimable &&
+                "border-yellow-500/60 bg-yellow-400/90 text-slate-900 hover:bg-yellow-300"
+            )}
+            disabled={nftRewardsLoading}
+            onClick={onOpenNftRewards}
+            aria-label={`NFT rewards. ${nftTooltip}`}
+          >
+            {nftRewardsLoading ? (
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
+            ) : (
+              <Gift className="h-4 w-4 shrink-0" aria-hidden />
+            )}
+            <span className="truncate">Rewards</span>
+          </DorkFiButton>
+        </DesktopTooltip>
       ) : null}
     </div>
   );

--- a/src/components/portfolio/PortfolioInsightsHub.tsx
+++ b/src/components/portfolio/PortfolioInsightsHub.tsx
@@ -1,0 +1,335 @@
+import { useMemo, useState } from "react";
+import { Gift, Globe, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import DorkFiCard from "@/components/ui/DorkFiCard";
+import DorkFiButton from "@/components/ui/DorkFiButton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import { PORTFOLIO_ACHIEVEMENT_FAMILIES } from "@/data/achievementsCatalog";
+import { useUserAchievements } from "@/hooks/useUserAchievements";
+import { AchievementsModal } from "@/components/portfolio/AchievementsModal";
+import { AchievementWhaleIcon } from "@/components/portfolio/AchievementWhaleIcon";
+import PortfolioInsightChip from "@/components/portfolio/PortfolioInsightChip";
+import PortfolioNetworkBreakdownModal from "@/components/portfolio/PortfolioNetworkBreakdownModal";
+import type {
+  PortfolioBorrowSummary,
+  PortfolioPoolBreakdownRow,
+} from "@/components/portfolio/portfolioPoolBreakdownTypes";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import type { PortfolioNetworkFilterValue } from "@/utils/portfolioMarketFilter";
+
+export type PortfolioInsightsLayout = "chips" | "toolbar";
+
+type PortfolioInsightsHubProps = {
+  className?: string;
+  embedded?: boolean;
+  layout?: PortfolioInsightsLayout;
+  showNetworkRow: boolean;
+  poolPortfolioBreakdown: PortfolioPoolBreakdownRow[];
+  networkPortfolioPoolsFiltered: PortfolioPoolBreakdownRow[];
+  positionsNetworkFilter: PortfolioNetworkFilterValue;
+  positionsMarketFilter: MarketFilter;
+  borrows: PortfolioBorrowSummary[];
+  healthFactor: number | null;
+  displayHealthFactor: number | null;
+  totalBorrowed: number;
+  isMobile: boolean;
+  displayAddress?: string | null;
+  isViewOnly?: boolean;
+  showNftRow: boolean;
+  nftRewardsLoading: boolean;
+  nftClaimableDisplay?: string;
+  nftHasClaimable: boolean;
+  onOpenNftRewards: () => void;
+};
+
+const PortfolioInsightsHub = ({
+  className,
+  embedded = false,
+  layout = "chips",
+  showNetworkRow,
+  poolPortfolioBreakdown,
+  networkPortfolioPoolsFiltered,
+  positionsNetworkFilter,
+  positionsMarketFilter,
+  borrows,
+  healthFactor,
+  displayHealthFactor,
+  totalBorrowed,
+  isMobile,
+  displayAddress,
+  isViewOnly = false,
+  showNftRow,
+  nftRewardsLoading,
+  nftClaimableDisplay,
+  nftHasClaimable,
+  onOpenNftRewards,
+}: PortfolioInsightsHubProps) => {
+  const { formatCurrency } = useNumberI18n();
+  const [networkModalOpen, setNetworkModalOpen] = useState(false);
+  const [achievementsModalOpen, setAchievementsModalOpen] = useState(false);
+
+  const { data: earned = {}, isLoading, isFetching } = useUserAchievements(
+    displayAddress ?? undefined
+  );
+
+  const showAchievementsRow = Boolean(displayAddress);
+  const earnedCount = PORTFOLIO_ACHIEVEMENT_FAMILIES.filter(
+    (family) => earned[family.id] != null
+  ).length;
+  const totalFamilies = PORTFOLIO_ACHIEVEMENT_FAMILIES.length;
+  const achievementsLoading =
+    showAchievementsRow && (isLoading || isFetching);
+
+  const networkSummary = useMemo(() => {
+    const count = poolPortfolioBreakdown.length;
+    const netTotal = poolPortfolioBreakdown.reduce(
+      (sum, row) => sum + row.netValue,
+      0
+    );
+    return { count, netTotal };
+  }, [poolPortfolioBreakdown]);
+
+  const visibleRows = [
+    showNetworkRow,
+    showAchievementsRow,
+    showNftRow,
+  ].filter(Boolean).length;
+
+  if (visibleRows === 0) return null;
+
+  const netFormatted = formatCurrency(networkSummary.netTotal, "USD", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+
+  const networkTooltip =
+    networkSummary.count === 0
+      ? "No pool data"
+      : `${networkSummary.count} pool${networkSummary.count === 1 ? "" : "s"} · ${netFormatted} net`;
+
+  const achievementsTooltip = achievementsLoading
+    ? "Loading achievements…"
+    : `${earnedCount} of ${totalFamilies} earned${isViewOnly ? " (viewing)" : ""}`;
+
+  const nftTooltip = nftRewardsLoading
+    ? "Loading NFT holder rewards…"
+    : nftHasClaimable
+      ? `${nftClaimableDisplay} claimable — tap to claim UNIT`
+      : "No claimable balance right now";
+
+  const toolbar = (
+    <div
+      className={cn(
+        "grid gap-2",
+        visibleRows === 1 && "grid-cols-1",
+        visibleRows === 2 && "grid-cols-2",
+        visibleRows === 3 && "grid-cols-3",
+        className
+      )}
+    >
+      {showNetworkRow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DorkFiButton
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-10 w-full min-w-0 gap-1.5 px-2"
+              onClick={() => setNetworkModalOpen(true)}
+              aria-label={`Networks. ${networkTooltip}. Open breakdown.`}
+            >
+              <Globe className="h-4 w-4 shrink-0" aria-hidden />
+              <span className="truncate">Networks</span>
+            </DorkFiButton>
+          </TooltipTrigger>
+          <TooltipContent>{networkTooltip}</TooltipContent>
+        </Tooltip>
+      ) : null}
+
+      {showAchievementsRow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DorkFiButton
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-10 w-full min-w-0 gap-1.5 px-2"
+              disabled={achievementsLoading}
+              onClick={() => setAchievementsModalOpen(true)}
+              aria-label={`Achievements. ${achievementsTooltip}. Open details.`}
+            >
+              {achievementsLoading ? (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
+              ) : (
+                <AchievementWhaleIcon className="h-4 w-4 shrink-0" />
+              )}
+              <span className="truncate">
+                {achievementsLoading
+                  ? "…"
+                  : `${earnedCount}/${totalFamilies} Achievements`}
+              </span>
+            </DorkFiButton>
+          </TooltipTrigger>
+          <TooltipContent>{achievementsTooltip}</TooltipContent>
+        </Tooltip>
+      ) : null}
+
+      {showNftRow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DorkFiButton
+              type="button"
+              variant={nftHasClaimable ? "moderate" : "secondary"}
+              size="sm"
+              className={cn(
+                "h-10 w-full min-w-0 gap-1.5 px-2",
+                nftHasClaimable &&
+                  "border-yellow-500/60 bg-yellow-400/90 text-slate-900 hover:bg-yellow-300"
+              )}
+              disabled={nftRewardsLoading}
+              onClick={onOpenNftRewards}
+              aria-label={`NFT rewards. ${nftTooltip}`}
+            >
+              {nftRewardsLoading ? (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
+              ) : (
+                <Gift className="h-4 w-4 shrink-0" aria-hidden />
+              )}
+              <span className="truncate">Rewards</span>
+            </DorkFiButton>
+          </TooltipTrigger>
+          <TooltipContent>{nftTooltip}</TooltipContent>
+        </Tooltip>
+      ) : null}
+    </div>
+  );
+
+  const chipGrid = (
+    <div
+      className={cn(
+        "grid gap-px overflow-hidden rounded-xl border border-border/60 bg-border/40",
+        visibleRows === 1 && "grid-cols-1",
+        visibleRows === 2 && "grid-cols-2",
+        visibleRows === 3 && "grid-cols-1 sm:grid-cols-3",
+        className
+      )}
+    >
+      {showNetworkRow ? (
+        <PortfolioInsightChip
+          label="Networks"
+          primary={
+            networkSummary.count === 0
+              ? "—"
+              : `${networkSummary.count} pool${networkSummary.count === 1 ? "" : "s"}`
+          }
+          secondary={
+            networkSummary.count === 0 ? "No pool data" : `${netFormatted} net`
+          }
+          onClick={() => setNetworkModalOpen(true)}
+          ariaLabel={`Networks, ${networkSummary.count} pools, ${netFormatted} net. Open breakdown.`}
+        />
+      ) : null}
+
+      {showAchievementsRow ? (
+        <PortfolioInsightChip
+          label="Achievements"
+          primary={
+            achievementsLoading ? "…" : `${earnedCount} / ${totalFamilies}`
+          }
+          secondary={
+            achievementsLoading
+              ? "Loading…"
+              : isViewOnly
+                ? "earned · viewing"
+                : "earned"
+          }
+          loading={achievementsLoading}
+          onClick={() => setAchievementsModalOpen(true)}
+          ariaLabel={
+            achievementsLoading
+              ? "Loading achievements"
+              : `Achievements, ${earnedCount} of ${totalFamilies} earned. Open details.`
+          }
+        />
+      ) : null}
+
+      {showNftRow ? (
+        <PortfolioInsightChip
+          label="NFT rewards"
+          primary={
+            nftRewardsLoading
+              ? "…"
+              : nftHasClaimable
+                ? nftClaimableDisplay ?? "Claimable"
+                : "—"
+          }
+          secondary={
+            nftRewardsLoading
+              ? "Loading…"
+              : nftHasClaimable
+                ? "Tap to claim UNIT"
+                : "Nothing to claim"
+          }
+          highlight={nftHasClaimable}
+          dimmed={!nftHasClaimable && !nftRewardsLoading}
+          loading={nftRewardsLoading}
+          onClick={onOpenNftRewards}
+          ariaLabel={
+            nftRewardsLoading
+              ? "Loading NFT holder rewards"
+              : nftHasClaimable
+                ? `Claim NFT holder rewards, ${nftClaimableDisplay} claimable`
+                : "NFT holder rewards, no balance claimable"
+          }
+        />
+      ) : null}
+    </div>
+  );
+
+  const surface =
+    layout === "toolbar" ? (
+      toolbar
+    ) : embedded ? (
+      chipGrid
+    ) : (
+      <DorkFiCard className="overflow-hidden border-2 border-ocean-teal/20 p-4 shadow-sm sm:p-5">
+        {chipGrid}
+      </DorkFiCard>
+    );
+
+  return (
+    <>
+      {surface}
+
+      {showNetworkRow ? (
+        <PortfolioNetworkBreakdownModal
+          open={networkModalOpen}
+          onOpenChange={setNetworkModalOpen}
+          pools={networkPortfolioPoolsFiltered}
+          networkFilter={positionsNetworkFilter}
+          marketFilter={positionsMarketFilter}
+          borrows={borrows}
+          healthFactor={healthFactor}
+          displayHealthFactor={displayHealthFactor}
+          totalBorrowed={totalBorrowed}
+          isMobile={isMobile}
+        />
+      ) : null}
+
+      {showAchievementsRow ? (
+        <AchievementsModal
+          open={achievementsModalOpen}
+          onOpenChange={setAchievementsModalOpen}
+          earned={earned}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default PortfolioInsightsHub;

--- a/src/components/portfolio/PortfolioNetworkBreakdownModal.tsx
+++ b/src/components/portfolio/PortfolioNetworkBreakdownModal.tsx
@@ -1,0 +1,520 @@
+import { useMemo } from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Info,
+  TrendingDown,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import DorkFiCard from "@/components/ui/DorkFiCard";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import {
+  portfolioMarketFilterLabel,
+  portfolioNetworkFilterLabel,
+  type PortfolioNetworkFilterValue,
+} from "@/utils/portfolioMarketFilter";
+import type {
+  PortfolioBorrowSummary,
+  PortfolioPoolBreakdownRow,
+} from "@/components/portfolio/portfolioPoolBreakdownTypes";
+import {
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+} from "recharts";
+
+const CHART_COLORS = [
+  "#0ea5e9",
+  "#8b5cf6",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#06b6d4",
+  "#a855f7",
+  "#14b8a6",
+];
+
+type PortfolioNetworkBreakdownModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pools: PortfolioPoolBreakdownRow[];
+  networkFilter: PortfolioNetworkFilterValue;
+  marketFilter: MarketFilter;
+  borrows: PortfolioBorrowSummary[];
+  healthFactor: number | null;
+  displayHealthFactor: number | null;
+  totalBorrowed: number;
+  isMobile: boolean;
+};
+
+const PortfolioNetworkBreakdownModal = ({
+  open,
+  onOpenChange,
+  pools,
+  networkFilter,
+  marketFilter,
+  borrows,
+  healthFactor,
+  displayHealthFactor,
+  totalBorrowed,
+  isMobile,
+}: PortfolioNetworkBreakdownModalProps) => {
+  const { formatNumber, formatCurrency, formatPercent } = useNumberI18n();
+
+  const allocationData = useMemo(
+    () =>
+      pools
+        .map((row) => ({
+          name: row.chartLabel,
+          value: row.collateral,
+          poolKey: row.poolKey,
+        }))
+        .filter((item) => item.value > 0)
+        .sort((a, b) => b.value - a.value),
+    [pools]
+  );
+
+  const totalAllocation = allocationData.reduce(
+    (sum, item) => sum + item.value,
+    0
+  );
+
+  const topBorrowedAsset =
+    borrows.length > 0
+      ? borrows.reduce((top, current) =>
+          current.value > (top?.value || 0) ? current : top
+        )
+      : null;
+
+  const topBorrowedPercentage =
+    topBorrowedAsset && totalBorrowed > 0
+      ? (topBorrowedAsset.value / totalBorrowed) * 100
+      : 0;
+
+  const closestToLiquidation =
+    borrows.length > 0 && healthFactor !== null && healthFactor < 2.0
+      ? { asset: "Portfolio", healthFactor }
+      : null;
+
+  const poolMargins = pools.map((row) => row.liquidationMargin);
+  const lowestLiquidationMargin =
+    poolMargins.length > 0 ? Math.min(...poolMargins) : null;
+
+  const activeFilterLabels = [
+    networkFilter !== "all"
+      ? portfolioNetworkFilterLabel(networkFilter)
+      : null,
+    marketFilter !== "all" ? portfolioMarketFilterLabel(marketFilter) : null,
+  ].filter(Boolean);
+
+  const filterNote =
+    activeFilterLabels.length === 0
+      ? "Showing all networks and markets. Change filters in Positions to narrow this view."
+      : `Filtered to ${activeFilterLabels.join(" · ")}. Change filters in Positions to adjust.`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[min(90vh,880px)] w-full max-w-[min(100vw-1.5rem,56rem)] flex-col overflow-hidden border border-gray-200/50 bg-gradient-to-br from-blue-50 to-cyan-50 p-0 shadow-xl dark:border-ocean-teal/20 dark:from-slate-900 dark:to-slate-800 sm:max-w-3xl">
+        <DialogHeader className="shrink-0 space-y-1.5 border-b border-gray-200/50 px-6 pb-4 pt-6 text-left dark:border-ocean-teal/20 sm:px-8">
+          <DialogTitle className="text-left text-xl sm:text-2xl">
+            Network portfolio
+          </DialogTitle>
+          <DialogDescription className="text-left text-sm">
+            Per-pool on-chain totals. {filterNote}
+          </DialogDescription>
+        </DialogHeader>
+
+        <TooltipProvider>
+          <div className="flex-1 overflow-y-auto px-6 pb-6 pt-4 sm:px-8">
+            <div className="mb-6 grid grid-cols-1 gap-4 sm:gap-6 lg:grid-cols-2">
+              <DorkFiCard className="p-4 sm:p-5">
+                <h3 className="mb-3 text-base font-semibold sm:mb-4 sm:text-lg">
+                  Collateral allocation
+                </h3>
+                {totalAllocation > 0 && allocationData.length > 0 ? (
+                  <div className="flex flex-col items-center">
+                    <ResponsiveContainer
+                      width="100%"
+                      height={isMobile ? 200 : 250}
+                    >
+                      <PieChart margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+                        <Pie
+                          data={allocationData}
+                          cx="50%"
+                          cy="50%"
+                          labelLine={false}
+                          label={false}
+                          outerRadius={80}
+                          fill="#8884d8"
+                          dataKey="value"
+                        >
+                          {allocationData.map((entry, index) => (
+                            <Cell
+                              key={entry.poolKey ?? `cell-${index}`}
+                              fill={CHART_COLORS[index % CHART_COLORS.length]}
+                            />
+                          ))}
+                        </Pie>
+                        <RechartsTooltip
+                          formatter={(value: number) => [
+                            formatCurrency(value, "USD", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            }),
+                            "Collateral",
+                          ]}
+                        />
+                      </PieChart>
+                    </ResponsiveContainer>
+                    <div className="mt-4 w-full space-y-2">
+                      {allocationData.map((item, index) => (
+                        <div
+                          key={item.poolKey ?? index}
+                          className="flex items-center justify-between text-sm"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div
+                              className="h-3 w-3 rounded-full"
+                              style={{
+                                backgroundColor:
+                                  CHART_COLORS[index % CHART_COLORS.length],
+                              }}
+                            />
+                            <span className="text-muted-foreground">
+                              {item.name}
+                            </span>
+                          </div>
+                          <span className="font-semibold">
+                            {formatPercent(item.value / totalAllocation, {
+                              maximumFractionDigits: 1,
+                            })}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex h-64 items-center justify-center text-muted-foreground">
+                    <p>No collateral data available</p>
+                  </div>
+                )}
+              </DorkFiCard>
+
+              <div className="space-y-4">
+                <h3 className="mb-4 text-lg font-semibold">Risk overview</h3>
+
+                {lowestLiquidationMargin !== null ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DorkFiCard className="cursor-help border-l-4 border-orange-500 p-4">
+                        <div className="flex items-start gap-3">
+                          <AlertTriangle className="mt-0.5 h-5 w-5 text-orange-500" />
+                          <div className="flex-1">
+                            <div className="mb-1 flex items-center gap-1 text-sm font-semibold text-orange-600 dark:text-orange-400">
+                              Lowest liquidation margin
+                              <Info className="h-3 w-3" />
+                            </div>
+                            <div className="text-base font-bold">
+                              {formatPercent(lowestLiquidationMargin / 100, {
+                                maximumFractionDigits: 2,
+                              })}
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              {networkFilter === "all"
+                                ? "Lowest among pools shown (all networks)"
+                                : "Lowest among pools on this network"}
+                            </div>
+                          </div>
+                        </div>
+                      </DorkFiCard>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      <p className="mb-1 font-semibold">Liquidation margin</p>
+                      <p className="text-sm">
+                        The safety buffer before liquidation. Keep this above
+                        10–15% for safety.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+
+                {topBorrowedAsset && topBorrowedPercentage > 0 ? (
+                  <DorkFiCard className="border-l-4 border-amber-500 p-4">
+                    <div className="flex items-start gap-3">
+                      <TrendingDown className="mt-0.5 h-5 w-5 text-amber-500" />
+                      <div className="flex-1">
+                        <div className="mb-1 text-sm font-semibold text-amber-600 dark:text-amber-400">
+                          Top borrowed asset
+                        </div>
+                        <div className="text-base font-bold">
+                          {topBorrowedAsset.asset}
+                        </div>
+                        <div className="mt-1 text-sm text-muted-foreground">
+                          {formatPercent(topBorrowedPercentage / 100, {
+                            maximumFractionDigits: 1,
+                          })}{" "}
+                          of total borrows
+                        </div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          $
+                          {formatNumber(topBorrowedAsset.value, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  </DorkFiCard>
+                ) : null}
+
+                {closestToLiquidation ? (
+                  <DorkFiCard className="border-l-4 border-red-500 p-4">
+                    <div className="flex items-start gap-3">
+                      <AlertCircle className="mt-0.5 h-5 w-5 text-red-500" />
+                      <div className="flex-1">
+                        <div className="mb-1 text-sm font-semibold text-red-600 dark:text-red-400">
+                          Closest to liquidation
+                        </div>
+                        <div className="text-base font-bold">
+                          {closestToLiquidation.asset}
+                        </div>
+                        <div className="mt-1 text-sm text-muted-foreground">
+                          Health factor:{" "}
+                          <span
+                            className={`font-semibold ${
+                              closestToLiquidation.healthFactor >= 1.5
+                                ? "text-green-600 dark:text-green-400"
+                                : closestToLiquidation.healthFactor >= 1.0
+                                  ? "text-yellow-600 dark:text-yellow-400"
+                                  : "text-red-600 dark:text-red-400"
+                            }`}
+                          >
+                            {formatNumber(closestToLiquidation.healthFactor, {
+                              maximumFractionDigits: 2,
+                            })}
+                          </span>
+                        </div>
+                        {closestToLiquidation.healthFactor < 1.5 ? (
+                          <div className="mt-1 text-xs text-red-500">
+                            Consider adding collateral or repaying debt
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  </DorkFiCard>
+                ) : null}
+
+                {healthFactor !== null ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DorkFiCard className="cursor-help border-l-4 border-ocean-teal p-4">
+                        <div className="flex items-start gap-3">
+                          <AlertTriangle className="mt-0.5 h-5 w-5 text-ocean-teal" />
+                          <div className="flex-1">
+                            <div className="mb-1 flex items-center gap-1 text-sm font-semibold text-ocean-teal">
+                              Portfolio risk score
+                              <Info className="h-3 w-3" />
+                            </div>
+                            <div className="mt-2 flex items-center gap-3">
+                              <div className="flex-1">
+                                <div className="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+                                  <div
+                                    className={`h-2.5 rounded-full transition-all ${
+                                      healthFactor >= 2.0
+                                        ? "bg-green-500"
+                                        : healthFactor >= 1.5
+                                          ? "bg-yellow-500"
+                                          : healthFactor >= 1.0
+                                            ? "bg-orange-500"
+                                            : "bg-red-500"
+                                    }`}
+                                    style={{
+                                      width: `${Math.min(
+                                        ((displayHealthFactor || 0) / 3.0) *
+                                          100,
+                                        100
+                                      )}%`,
+                                    }}
+                                  />
+                                </div>
+                              </div>
+                              <div className="text-sm font-semibold">
+                                {displayHealthFactor !== null
+                                  ? formatNumber(displayHealthFactor, {
+                                      maximumFractionDigits: 2,
+                                    })
+                                  : "N/A"}
+                              </div>
+                            </div>
+                            <div className="mt-2 text-xs text-muted-foreground">
+                              {healthFactor >= 2.0
+                                ? "Low risk"
+                                : healthFactor >= 1.5
+                                  ? "Moderate risk"
+                                  : healthFactor >= 1.0
+                                    ? "High risk"
+                                    : "Critical risk"}
+                            </div>
+                          </div>
+                        </div>
+                      </DorkFiCard>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      <p className="mb-1 font-semibold">Health factor</p>
+                      <p className="text-sm">
+                        Measures portfolio safety: (collateral × collateral
+                        factor) / total borrowed.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+
+                {!topBorrowedAsset &&
+                !closestToLiquidation &&
+                healthFactor === null ? (
+                  <DorkFiCard className="p-4">
+                    <div className="text-center text-muted-foreground">
+                      <p className="text-sm">No risk data available</p>
+                    </div>
+                  </DorkFiCard>
+                ) : null}
+              </div>
+            </div>
+
+            {pools.length === 0 ? (
+              <div className="py-8 text-center text-muted-foreground">
+                <p>No lending pools found for the selected filter.</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {pools.map((row) => (
+                  <DorkFiCard
+                    key={row.poolKey}
+                    className="border-2 p-4 transition-all hover:border-ocean-teal/50 sm:p-5"
+                  >
+                    <div className="space-y-4">
+                      <div>
+                        <h3 className="mb-1 text-lg font-semibold">
+                          {row.title}
+                        </h3>
+                        <p className="break-all font-mono text-xs text-muted-foreground">
+                          Pool {row.poolId}
+                        </p>
+                      </div>
+
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm text-muted-foreground">
+                            Collateral:
+                          </span>
+                          <span className="text-right text-sm font-semibold tabular-nums">
+                            {formatCurrency(row.collateral, "USD", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </span>
+                        </div>
+
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm text-muted-foreground">
+                            Borrowed:
+                          </span>
+                          <span className="text-right text-sm font-semibold tabular-nums">
+                            {formatCurrency(row.borrow, "USD", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </span>
+                        </div>
+
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm text-muted-foreground">
+                            Net value:
+                          </span>
+                          <span
+                            className={`text-right text-sm font-semibold tabular-nums ${
+                              row.netValue >= 0
+                                ? "text-green-600 dark:text-green-400"
+                                : "text-red-600 dark:text-red-400"
+                            }`}
+                          >
+                            {formatCurrency(row.netValue, "USD", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </span>
+                        </div>
+
+                        <div className="space-y-2 border-t border-border pt-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-sm text-muted-foreground">
+                              Health factor:
+                            </span>
+                            <span
+                              className={`text-sm font-semibold tabular-nums ${
+                                row.healthFactor === null
+                                  ? "text-muted-foreground"
+                                  : row.healthFactor >= 1.5
+                                    ? "text-green-600 dark:text-green-400"
+                                    : row.healthFactor >= 1.0
+                                      ? "text-yellow-600 dark:text-yellow-400"
+                                      : "text-red-600 dark:text-red-400"
+                              }`}
+                            >
+                              {row.healthFactor === null
+                                ? "N/A"
+                                : formatNumber(row.healthFactor, {
+                                    maximumFractionDigits: 2,
+                                  })}
+                            </span>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-sm text-muted-foreground">
+                              Liquidation margin:
+                            </span>
+                            <span
+                              className={`text-sm font-semibold tabular-nums ${
+                                row.liquidationMargin >= 20
+                                  ? "text-green-600 dark:text-green-400"
+                                  : row.liquidationMargin >= 10
+                                    ? "text-yellow-600 dark:text-yellow-400"
+                                    : row.liquidationMargin >= 0
+                                      ? "text-orange-600 dark:text-orange-400"
+                                      : "text-red-600 dark:text-red-400"
+                              }`}
+                            >
+                              {formatPercent(row.liquidationMargin / 100, {
+                                maximumFractionDigits: 2,
+                              })}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </DorkFiCard>
+                ))}
+              </div>
+            )}
+          </div>
+        </TooltipProvider>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PortfolioNetworkBreakdownModal;

--- a/src/components/portfolio/PortfolioNetworkFilterDropdown.tsx
+++ b/src/components/portfolio/PortfolioNetworkFilterDropdown.tsx
@@ -1,0 +1,143 @@
+import { ChevronDown, Globe } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { getNetworkConfig, type NetworkId } from "@/config";
+import { getNetworkLogoPath } from "@/utils/tokenImageUtils";
+import type { PortfolioNetworkFilterValue } from "@/utils/portfolioMarketFilter";
+import { cn } from "@/lib/utils";
+
+export type { PortfolioNetworkFilterValue };
+
+const PORTFOLIO_NETWORK_FILTER_OPTIONS: {
+  value: PortfolioNetworkFilterValue;
+  label: string;
+  networkId?: NetworkId;
+}[] = [
+  { value: "all", label: "All Networks" },
+  {
+    value: "algorand",
+    label: "Algorand Mainnet",
+    networkId: "algorand-mainnet",
+  },
+  { value: "voi", label: "VOI Network", networkId: "voi-mainnet" },
+];
+
+function optionForValue(value: PortfolioNetworkFilterValue) {
+  return (
+    PORTFOLIO_NETWORK_FILTER_OPTIONS.find((o) => o.value === value) ??
+    PORTFOLIO_NETWORK_FILTER_OPTIONS[0]
+  );
+}
+
+interface PortfolioNetworkFilterDropdownProps {
+  value: PortfolioNetworkFilterValue;
+  onChange: (value: PortfolioNetworkFilterValue) => void;
+  className?: string;
+  /** When true, show a section label above the trigger (desktop filter rows). */
+  showLabel?: boolean;
+  /** Compact inline toolbar style (Markets page). */
+  compact?: boolean;
+}
+
+const PortfolioNetworkFilterDropdown = ({
+  value,
+  onChange,
+  className,
+  showLabel = false,
+  compact = false,
+}: PortfolioNetworkFilterDropdownProps) => {
+  const active = optionForValue(value);
+  const activeNetworkId = active.networkId;
+
+  return (
+    <div className={cn("min-w-0", className)}>
+      {showLabel && (
+        <span className="mb-2 block text-sm font-medium">Network</span>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "justify-between gap-1.5 rounded-lg border-border bg-muted/40 px-2.5 text-xs dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35 sm:text-sm",
+              compact
+                ? "h-8 w-auto shrink-0"
+                : "h-9 w-full min-w-[10.5rem] sm:min-w-[12rem]"
+            )}
+            aria-label={`Network filter: ${active.label}`}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              {activeNetworkId ? (
+                <img
+                  src={getNetworkLogoPath(activeNetworkId)}
+                  alt=""
+                  className="h-4 w-4 shrink-0 rounded-full"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.src = "/placeholder.svg";
+                  }}
+                />
+              ) : (
+                <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className={cn("truncate font-medium", compact && "max-w-[9rem] sm:max-w-none")}>
+                {active.label}
+              </span>
+            </span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <div className="px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Network
+          </div>
+          <DropdownMenuSeparator />
+          {PORTFOLIO_NETWORK_FILTER_OPTIONS.map((option) => {
+            const isActive = value === option.value;
+            return (
+              <DropdownMenuItem
+                key={option.value}
+                onClick={() => onChange(option.value)}
+                className="flex cursor-pointer items-center justify-between"
+              >
+                <div className="flex items-center gap-2">
+                  {option.networkId ? (
+                    <img
+                      src={getNetworkLogoPath(option.networkId)}
+                      alt=""
+                      className="h-5 w-5 rounded-full"
+                      onError={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        target.src = "/placeholder.svg";
+                      }}
+                    />
+                  ) : (
+                    <Globe className="h-5 w-5 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="text-sm">
+                    {option.networkId
+                      ? getNetworkConfig(option.networkId).name
+                      : option.label}
+                  </span>
+                </div>
+                {isActive && (
+                  <span className="h-2 w-2 shrink-0 rounded-full bg-green-500" />
+                )}
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};
+
+export default PortfolioNetworkFilterDropdown;

--- a/src/components/portfolio/PortfolioNetworkFilterDropdown.tsx
+++ b/src/components/portfolio/PortfolioNetworkFilterDropdown.tsx
@@ -67,7 +67,7 @@ const PortfolioNetworkFilterDropdown = ({
             variant="outline"
             size="sm"
             className={cn(
-              "justify-between gap-1.5 rounded-lg border-border bg-muted/40 px-2.5 text-xs dark:bg-muted/25 hover:bg-muted/60 dark:hover:bg-muted/35 sm:text-sm",
+              "justify-between gap-1.5 rounded-lg border-border bg-muted/40 px-2.5 text-xs dark:bg-muted/25 hover:bg-muted/60 hover:text-foreground dark:hover:bg-muted/35 dark:hover:text-foreground data-[state=open]:bg-muted/60 data-[state=open]:text-foreground dark:data-[state=open]:bg-muted/35 sm:text-sm",
               compact
                 ? "h-8 w-auto shrink-0"
                 : "h-9 w-full min-w-[10.5rem] sm:min-w-[12rem]"

--- a/src/components/portfolio/PortfolioPositionsCardHeader.tsx
+++ b/src/components/portfolio/PortfolioPositionsCardHeader.tsx
@@ -1,0 +1,144 @@
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import PortfolioPositionsFilterBar from "@/components/portfolio/PortfolioPositionsFilterBar";
+import DorkFiButton from "@/components/ui/DorkFiButton";
+import { H1 } from "@/components/ui/Typography";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { RefreshCw } from "lucide-react";
+import type { PortfolioNetworkFilterValue } from "@/utils/portfolioMarketFilter";
+
+interface PortfolioPositionsCardHeaderProps {
+  portfolioPositionsTab: "supplied" | "borrowed";
+  onTabChange: (tab: "supplied" | "borrowed") => void;
+  hasBothPositionTypes: boolean;
+  hasSupplied: boolean;
+  hasBorrowed: boolean;
+  filteredSuppliedCount: number;
+  filteredBorrowedCount: number;
+  isViewOnly: boolean;
+  refreshingSection: string | null;
+  onRefreshSupplied: () => void;
+  onRefreshBorrowed: () => void;
+  networkFilter: PortfolioNetworkFilterValue;
+  onNetworkFilterChange: (value: PortfolioNetworkFilterValue) => void;
+  marketFilter: MarketFilter;
+  onMarketFilterChange: (value: MarketFilter) => void;
+  searchTerm: string;
+  onSearchTermChange: (value: string) => void;
+  hasDMarketTab: boolean;
+  isMobile: boolean;
+}
+
+const PortfolioPositionsCardHeader = ({
+  portfolioPositionsTab,
+  onTabChange,
+  hasBothPositionTypes,
+  hasSupplied,
+  hasBorrowed,
+  filteredSuppliedCount,
+  filteredBorrowedCount,
+  isViewOnly,
+  refreshingSection,
+  onRefreshSupplied,
+  onRefreshBorrowed,
+  networkFilter,
+  onNetworkFilterChange,
+  marketFilter,
+  onMarketFilterChange,
+  searchTerm,
+  onSearchTermChange,
+  hasDMarketTab,
+  isMobile,
+}: PortfolioPositionsCardHeaderProps) => {
+  const showToggle = hasBothPositionTypes;
+
+  const activeRefreshSection = showToggle
+    ? portfolioPositionsTab === "supplied"
+      ? "Supplied Assets"
+      : "Borrowed Assets"
+    : hasSupplied
+      ? "Supplied Assets"
+      : "Borrowed Assets";
+
+  const handleRefresh = () => {
+    if (showToggle) {
+      if (portfolioPositionsTab === "supplied") {
+        onRefreshSupplied();
+      } else {
+        onRefreshBorrowed();
+      }
+      return;
+    }
+    if (hasSupplied) onRefreshSupplied();
+    if (hasBorrowed) onRefreshBorrowed();
+  };
+
+  const refreshTitle = isViewOnly
+    ? "Refresh market data (view-only mode)"
+    : showToggle
+      ? portfolioPositionsTab === "supplied"
+        ? "Refresh market data for supplied assets"
+        : "Refresh market data for borrowed assets"
+      : "Refresh market data for positions";
+
+  return (
+    <div className="mb-4 md:mb-6">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+          <H1 className="m-0 shrink-0 text-xl md:text-2xl">Positions</H1>
+          {showToggle && (
+            <ToggleGroup
+              type="single"
+              value={portfolioPositionsTab}
+              onValueChange={(v) => {
+                if (v === "supplied" || v === "borrowed") {
+                  onTabChange(v);
+                }
+              }}
+              variant="outline"
+              className="inline-flex w-full max-w-md gap-0 rounded-lg border border-input bg-background p-1 shadow-sm sm:w-auto"
+              aria-label="Switch between supplied and borrowed positions"
+            >
+              <ToggleGroupItem
+                value="supplied"
+                className="flex-1 rounded-md px-4 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground sm:min-w-[8rem]"
+              >
+                Supplied ({filteredSuppliedCount})
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="borrowed"
+                className="flex-1 rounded-md px-4 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground sm:min-w-[8rem]"
+              >
+                Borrowed ({filteredBorrowedCount})
+              </ToggleGroupItem>
+            </ToggleGroup>
+          )}
+        </div>
+        <DorkFiButton
+          onClick={handleRefresh}
+          disabled={refreshingSection === activeRefreshSection}
+          variant="secondary"
+          size="sm"
+          className="shrink-0 self-start lg:self-auto"
+          title={refreshTitle}
+        >
+          <RefreshCw
+            className={`mr-1.5 h-3 w-3 ${refreshingSection === activeRefreshSection ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </DorkFiButton>
+      </div>
+      <PortfolioPositionsFilterBar
+        networkFilter={networkFilter}
+        onNetworkFilterChange={onNetworkFilterChange}
+        marketFilter={marketFilter}
+        onMarketFilterChange={onMarketFilterChange}
+        searchTerm={searchTerm}
+        onSearchTermChange={onSearchTermChange}
+        hasDMarketTab={hasDMarketTab}
+        isMobile={isMobile}
+      />
+    </div>
+  );
+};
+
+export default PortfolioPositionsCardHeader;

--- a/src/components/portfolio/PortfolioPositionsFilterBar.tsx
+++ b/src/components/portfolio/PortfolioPositionsFilterBar.tsx
@@ -1,0 +1,175 @@
+import { Search, X } from "lucide-react";
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import MarketsTierFilter from "@/components/markets/MarketsTierFilter";
+import PortfolioNetworkFilterDropdown from "@/components/portfolio/PortfolioNetworkFilterDropdown";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  hasActivePortfolioPositionFilters,
+  portfolioMarketFilterLabel,
+  portfolioNetworkFilterLabel,
+  type PortfolioNetworkFilterValue,
+} from "@/utils/portfolioMarketFilter";
+import { cn } from "@/lib/utils";
+
+interface PortfolioPositionsFilterBarProps {
+  networkFilter: PortfolioNetworkFilterValue;
+  onNetworkFilterChange: (value: PortfolioNetworkFilterValue) => void;
+  marketFilter: MarketFilter;
+  onMarketFilterChange: (value: MarketFilter) => void;
+  searchTerm: string;
+  onSearchTermChange: (value: string) => void;
+  hasDMarketTab: boolean;
+  isMobile?: boolean;
+  className?: string;
+}
+
+function ActiveFilterChip({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onRemove}
+      className="inline-flex items-center gap-1 rounded-full border border-ocean-teal/40 bg-ocean-teal/10 px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-ocean-teal/20"
+    >
+      <span>{label}</span>
+      <X className="h-3 w-3 shrink-0 opacity-70" aria-hidden />
+      <span className="sr-only">Remove {label} filter</span>
+    </button>
+  );
+}
+
+const PortfolioPositionsFilterBar = ({
+  networkFilter,
+  onNetworkFilterChange,
+  marketFilter,
+  onMarketFilterChange,
+  searchTerm,
+  onSearchTermChange,
+  hasDMarketTab,
+  isMobile = false,
+  className,
+}: PortfolioPositionsFilterBarProps) => {
+  const hasActiveFilters = hasActivePortfolioPositionFilters(
+    networkFilter,
+    marketFilter,
+    searchTerm
+  );
+
+  const clearAllFilters = () => {
+    onNetworkFilterChange("all");
+    onMarketFilterChange("all");
+    onSearchTermChange("");
+  };
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="rounded-xl border border-border/80 bg-muted/25 px-2.5 py-2 shadow-sm dark:bg-muted/10 sm:px-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <PortfolioNetworkFilterDropdown
+            value={networkFilter}
+            onChange={onNetworkFilterChange}
+            compact
+          />
+          <MarketsTierFilter
+            hideLabel
+            value={marketFilter}
+            onChange={onMarketFilterChange}
+            hasDMarketTab={hasDMarketTab}
+            isMobile={isMobile}
+            className="min-w-0"
+          />
+          <div className="relative min-w-0 flex-1 basis-[12rem] sm:max-w-md">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Search assets..."
+              value={searchTerm}
+              onChange={(e) => onSearchTermChange(e.target.value)}
+              className="h-8 border-border bg-background/80 pl-9 text-sm dark:bg-slate-800/40"
+            />
+          </div>
+          {hasActiveFilters && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={clearAllFilters}
+              className="h-8 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2 px-0.5">
+          {networkFilter !== "all" && (
+            <ActiveFilterChip
+              label={portfolioNetworkFilterLabel(networkFilter)}
+              onRemove={() => onNetworkFilterChange("all")}
+            />
+          )}
+          {marketFilter !== "all" && (
+            <ActiveFilterChip
+              label={portfolioMarketFilterLabel(marketFilter)}
+              onRemove={() => onMarketFilterChange("all")}
+            />
+          )}
+          {searchTerm.trim() !== "" && (
+            <ActiveFilterChip
+              label={`"${searchTerm.trim()}"`}
+              onRemove={() => onSearchTermChange("")}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export function PortfolioPositionsFilteredEmptyState({
+  totalCount,
+  entityLabel,
+  onClearFilters,
+}: {
+  totalCount: number;
+  entityLabel: string;
+  onClearFilters: () => void;
+}) {
+  if (totalCount === 0) {
+    return (
+      <div className="py-8 text-center text-muted-foreground">
+        <p>No {entityLabel}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-8 text-center">
+      <p className="font-medium text-foreground">
+        No {entityLabel} match your filters
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Try adjusting network, market, or search filters.
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4"
+        onClick={onClearFilters}
+      >
+        Clear filters
+      </Button>
+    </div>
+  );
+}
+
+export default PortfolioPositionsFilterBar;

--- a/src/components/portfolio/PortfolioTableMobileCard.tsx
+++ b/src/components/portfolio/PortfolioTableMobileCard.tsx
@@ -91,48 +91,46 @@ const PortfolioTableMobileCard = ({
   return (
     <DorkFiCard className={`p-4 ${bgColor} border`}>
       <div className="space-y-3">
-        {/* Header: Asset Icon above Ticker + Actions */}
-        <div className="flex items-center justify-between">
-          <div className="flex flex-col items-center gap-1">
-            <MarketRowTokenIcon
-              market={{
-                icon,
-                asset,
-                iconBadgeUrl: resolvedBadgeUrl,
-              }}
-              poolLetterLabel={marketLabel}
-              imgClassName="h-12 w-12 flex-shrink-0 rounded-full object-contain"
-            />
-            <div className="text-center">
-              <div className="font-semibold text-base text-slate-800 dark:text-white">
-                {asset}
-              </div>
-              {shouldShowConfigSymbolUnderDisplayAsset(asset, configSymbol) && (
-                  <div className="text-[10px] text-muted-foreground leading-tight">
-                    {configSymbol}
-                  </div>
-                )}
-              {network && (
-                <div className="text-xs text-muted-foreground">
-                  {network.split("-")[0].charAt(0).toUpperCase() +
-                    network.split("-")[0].slice(1)}
-                </div>
-              )}
-            </div>
-          </div>
+        {/* Header: centered icon + ticker; refresh pinned top-right */}
+        <div className="relative flex flex-col items-center gap-1">
           {onRefreshClick && (
             <DorkFiButton
               variant="secondary"
               size="sm"
               onClick={onRefreshClick}
               disabled={isRefreshing}
-              className="min-w-0 h-8 w-8 p-0"
+              className="absolute right-0 top-0 min-w-0 h-8 w-8 p-0"
             >
               <RefreshCw
                 className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`}
               />
             </DorkFiButton>
           )}
+          <MarketRowTokenIcon
+            market={{
+              icon,
+              asset,
+              iconBadgeUrl: resolvedBadgeUrl,
+            }}
+            poolLetterLabel={marketLabel}
+            imgClassName="h-12 w-12 flex-shrink-0 rounded-full object-contain"
+          />
+          <div className="text-center">
+            <div className="font-semibold text-base text-slate-800 dark:text-white">
+              {asset}
+            </div>
+            {shouldShowConfigSymbolUnderDisplayAsset(asset, configSymbol) && (
+              <div className="text-[10px] text-muted-foreground leading-tight">
+                {configSymbol}
+              </div>
+            )}
+            {network && (
+              <div className="text-xs text-muted-foreground">
+                {network.split("-")[0].charAt(0).toUpperCase() +
+                  network.split("-")[0].slice(1)}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Value and APY */}

--- a/src/components/portfolio/PortfolioWalletStatusBar.tsx
+++ b/src/components/portfolio/PortfolioWalletStatusBar.tsx
@@ -1,0 +1,95 @@
+import { cn } from "@/lib/utils";
+import { useNumberI18n } from "@/contexts/LocaleSettingsContext";
+import { XchainUsdcBridgeControls } from "@/components/xchain/XchainUsdcBridgeControls";
+
+export type PortfolioWalletStatus = {
+  hasComputedData: boolean;
+  hasUserGlobalData: boolean;
+  addressLabel: string;
+  globalNetPortfolioValue?: number | null;
+  showRiskMetrics: boolean;
+  weightedCollateralFactor: number;
+  weightedLiquidationThreshold: number;
+};
+
+export type PortfolioWalletStatusBarProps = PortfolioWalletStatus & {
+  className?: string;
+  /** When true, content is centered (desktop hero). Otherwise left-aligned (mobile strip). */
+  centered?: boolean;
+};
+
+const PortfolioWalletStatusBar = ({
+  className,
+  centered = false,
+  hasComputedData,
+  hasUserGlobalData,
+  addressLabel,
+  globalNetPortfolioValue,
+  showRiskMetrics,
+  weightedCollateralFactor,
+  weightedLiquidationThreshold,
+}: PortfolioWalletStatusBarProps) => {
+  const { formatCurrency, formatPercent } = useNumberI18n();
+
+  const dataSourceLabel = hasComputedData
+    ? "Global Portfolio Data"
+    : hasUserGlobalData
+      ? "Live Data"
+      : "No Data";
+
+  const hasLiveIndicator = hasComputedData || hasUserGlobalData;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground",
+        centered ? "justify-center" : "justify-start",
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          hasLiveIndicator ? "bg-green-500" : "bg-gray-500"
+        )}
+      />
+      <span className="min-w-0">
+        {dataSourceLabel} • {addressLabel}
+      </span>
+      {globalNetPortfolioValue !== undefined &&
+      globalNetPortfolioValue !== null ? (
+        <span className="shrink-0">
+          • Net Value:{" "}
+          {formatCurrency(Number(globalNetPortfolioValue), "USD", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+        </span>
+      ) : null}
+      {showRiskMetrics ? (
+        <span className={cn(centered ? "ml-2" : "w-full basis-full")}>
+          • Collateral Factor:{" "}
+          {formatPercent(weightedCollateralFactor, { maximumFractionDigits: 0 })}{" "}
+          • Liquidation Threshold:{" "}
+          {formatPercent(weightedLiquidationThreshold, {
+            maximumFractionDigits: 1,
+          })}
+        </span>
+      ) : null}
+      <div
+        className={cn(
+          "flex w-full shrink-0 basis-full px-0 empty:hidden",
+          centered
+            ? "mt-2 justify-center px-2 lg:mt-0 lg:ml-2 lg:w-auto lg:basis-auto lg:px-0 lg:justify-start"
+            : "mt-1 justify-start"
+        )}
+      >
+        <XchainUsdcBridgeControls
+          className={centered ? "justify-center lg:justify-start" : "justify-start"}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PortfolioWalletStatusBar;

--- a/src/components/portfolio/portfolioPoolBreakdownTypes.ts
+++ b/src/components/portfolio/portfolioPoolBreakdownTypes.ts
@@ -1,0 +1,19 @@
+export type PortfolioPoolBreakdownRow = {
+  poolKey: string;
+  poolId: string;
+  network: string;
+  networkDisplayName: string;
+  marketLabel: string | null;
+  title: string;
+  chartLabel: string;
+  collateral: number;
+  borrow: number;
+  netValue: number;
+  healthFactor: number | null;
+  liquidationMargin: number;
+};
+
+export type PortfolioBorrowSummary = {
+  asset: string;
+  value: number;
+};

--- a/src/components/portfolio/portfolioSectionTitle.ts
+++ b/src/components/portfolio/portfolioSectionTitle.ts
@@ -1,0 +1,3 @@
+/** Shared section heading for Portfolio hero card sections */
+export const portfolioSectionTitleClassName =
+  "text-2xl font-bold text-slate-800 dark:text-white";

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
@@ -29,4 +30,42 @@ const TooltipContent = React.forwardRef<
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+type DesktopTooltipProps = {
+  children: React.ReactElement
+  content: React.ReactNode
+} & Pick<
+  React.ComponentPropsWithoutRef<typeof TooltipContent>,
+  "side" | "className" | "sideOffset"
+>
+
+/** Hover tooltip for pointer devices only; renders children alone on mobile. */
+function DesktopTooltip({
+  children,
+  content,
+  side,
+  className,
+  sideOffset,
+}: DesktopTooltipProps) {
+  const isMobile = useIsMobile()
+
+  if (isMobile) {
+    return children
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} className={className} sideOffset={sideOffset}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+  DesktopTooltip,
+}

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -21,7 +21,7 @@ const PortfolioPage = () => {
 
       <Header activeTab={activeTab} onTabChange={handleTabChange} />
 
-      <main className="max-w-[1200px] mx-auto px-2 sm:px-4 md:px-6 py-4 md:py-8 relative z-10">
+      <main className="max-w-[1200px] mx-auto px-2 sm:px-4 md:px-6 py-2 sm:py-4 md:py-8 relative z-10">
         <div className="space-y-4 sm:space-y-6">
           <Portfolio />
         </div>

--- a/src/utils/__tests__/portfolioMarketFilter.test.ts
+++ b/src/utils/__tests__/portfolioMarketFilter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  positionMatchesMarketFilter,
+} from "@/utils/portfolioMarketFilter";
+
+describe("positionMatchesMarketFilter", () => {
+  it("returns true for all markets regardless of pool", () => {
+    expect(
+      positionMatchesMarketFilter("algorand-mainnet", "123", "all")
+    ).toBe(true);
+    expect(positionMatchesMarketFilter(undefined, undefined, "all")).toBe(
+      true
+    );
+  });
+
+  it("matches A/B/D by network pool label", () => {
+    expect(
+      positionMatchesMarketFilter(
+        "algorand-mainnet",
+        "3333688282",
+        "A"
+      )
+    ).toBe(true);
+    expect(
+      positionMatchesMarketFilter(
+        "algorand-mainnet",
+        "3333688282",
+        "B"
+      )
+    ).toBe(false);
+    expect(
+      positionMatchesMarketFilter(
+        "algorand-mainnet",
+        "3526240577",
+        "D"
+      )
+    ).toBe(true);
+  });
+
+  it("returns false when network or pool is missing for tier filter", () => {
+    expect(positionMatchesMarketFilter(undefined, "123", "A")).toBe(false);
+    expect(positionMatchesMarketFilter("algorand-mainnet", undefined, "A")).toBe(
+      false
+    );
+  });
+});

--- a/src/utils/__tests__/portfolioMarketFilter.test.ts
+++ b/src/utils/__tests__/portfolioMarketFilter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  itemMatchesPortfolioPositionFilters,
   positionMatchesMarketFilter,
+  positionMatchesNetworkFilter,
 } from "@/utils/portfolioMarketFilter";
 
 describe("positionMatchesMarketFilter", () => {
@@ -42,5 +44,110 @@ describe("positionMatchesMarketFilter", () => {
     expect(positionMatchesMarketFilter("algorand-mainnet", undefined, "A")).toBe(
       false
     );
+  });
+});
+
+describe("positionMatchesNetworkFilter", () => {
+  it("returns true for all networks", () => {
+    expect(positionMatchesNetworkFilter("algorand-mainnet", "all")).toBe(true);
+    expect(positionMatchesNetworkFilter(undefined, "all")).toBe(true);
+  });
+
+  it("matches algorand and voi by network id substring", () => {
+    expect(
+      positionMatchesNetworkFilter("algorand-mainnet", "algorand")
+    ).toBe(true);
+    expect(positionMatchesNetworkFilter("voi-mainnet", "voi")).toBe(true);
+    expect(positionMatchesNetworkFilter("algorand-mainnet", "voi")).toBe(
+      false
+    );
+  });
+
+  it("passes through when network is missing", () => {
+    expect(positionMatchesNetworkFilter(undefined, "algorand")).toBe(true);
+  });
+});
+
+describe("itemMatchesPortfolioPositionFilters", () => {
+  const baseItem = {
+    asset: "USDC",
+    poolId: "3333688282",
+    network: "algorand-mainnet",
+  };
+
+  it("matches when all filters are open", () => {
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        networkFilter: "all",
+        marketFilter: "all",
+      })
+    ).toBe(true);
+  });
+
+  it("filters by search term (trimmed, case-insensitive)", () => {
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        searchTerm: "usdc",
+        networkFilter: "all",
+      })
+    ).toBe(true);
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        searchTerm: "  algo  ",
+        networkFilter: "all",
+      })
+    ).toBe(false);
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        searchTerm: "   ",
+        networkFilter: "all",
+      })
+    ).toBe(true);
+  });
+
+  it("filters by network and market tier together", () => {
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        networkFilter: "algorand",
+        marketFilter: "A",
+      })
+    ).toBe(true);
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        networkFilter: "voi",
+        marketFilter: "A",
+      })
+    ).toBe(false);
+    expect(
+      itemMatchesPortfolioPositionFilters(baseItem, {
+        networkFilter: "algorand",
+        marketFilter: "B",
+      })
+    ).toBe(false);
+  });
+
+  it("passes network filter when row network is missing", () => {
+    expect(
+      itemMatchesPortfolioPositionFilters(
+        { asset: "USDC", poolId: "3333688282" },
+        {
+          networkFilter: "voi",
+          marketFilter: "all",
+        }
+      )
+    ).toBe(true);
+  });
+
+  it("uses marketNetworkFallback for tier matching", () => {
+    expect(
+      itemMatchesPortfolioPositionFilters(
+        { asset: "USDC", poolId: "3333688282" },
+        {
+          networkFilter: "all",
+          marketFilter: "A",
+          marketNetworkFallback: "algorand-mainnet",
+        }
+      )
+    ).toBe(true);
   });
 });

--- a/src/utils/healthFactorUx.ts
+++ b/src/utils/healthFactorUx.ts
@@ -68,3 +68,48 @@ export function formatHealthFactorBuffer(healthFactor: number | null): string {
   }
   return "Liquidation at HF = 1.0";
 }
+
+export type HealthFactorStatusPanel = {
+  message: string;
+  panelClassName: string;
+};
+
+/** Copy + panel styling for the hero gauge status slot (always visible). */
+export function getHealthFactorStatusPanel(
+  healthFactor: number | null
+): HealthFactorStatusPanel {
+  const band = getHealthFactorBand(healthFactor);
+  switch (band) {
+    case "none":
+      return {
+        message:
+          "No collateral yet. Supply assets to earn yield and borrow.",
+        panelClassName: "bg-slate-500/10 border-slate-500/30",
+      };
+    case "blocked":
+      return {
+        message:
+          "Your health factor is at or below 1.0. Withdrawals and new borrows are blocked until you supply collateral or repay debt.",
+        panelClassName: "bg-red-500/15 border-red-500/40",
+      };
+    case "at_risk":
+      return {
+        message:
+          "You are very close to liquidation. Repay debt or add collateral to increase your buffer.",
+        panelClassName: "bg-amber-500/15 border-amber-500/40",
+      };
+    case "warning":
+      return {
+        message:
+          "Warning: limited room before your health factor becomes critical. Consider repaying or supplying more.",
+        panelClassName: "bg-amber-500/15 border-amber-500/40",
+      };
+    case "safe":
+    default:
+      return {
+        message:
+          "Your position is healthy with room above liquidation (HF = 1.0).",
+        panelClassName: "bg-green-500/10 border-green-500/30",
+      };
+  }
+}

--- a/src/utils/portfolioMarketFilter.ts
+++ b/src/utils/portfolioMarketFilter.ts
@@ -1,0 +1,71 @@
+import type { MarketFilter } from "@/hooks/useOnDemandMarketData";
+import {
+  getEnabledNetworks,
+  getLendingPools,
+  getMarketLabel,
+  getNetworkConfig,
+  type NetworkId,
+} from "@/config";
+
+export type PortfolioNetworkFilterValue = "all" | "algorand" | "voi";
+
+export function enabledNetworksHaveDMarket(): boolean {
+  return (getEnabledNetworks() as NetworkId[]).some((networkId) =>
+    getLendingPools(networkId).some(
+      (poolId) => getMarketLabel(networkId, String(poolId)) === "D"
+    )
+  );
+}
+
+export function positionMatchesMarketFilter(
+  networkId: string | null | undefined,
+  poolId: string | null | undefined,
+  marketFilter: MarketFilter
+): boolean {
+  if (marketFilter === "all") return true;
+  if (!networkId || !poolId) return false;
+  return getMarketLabel(networkId as NetworkId, poolId) === marketFilter;
+}
+
+export function positionMatchesNetworkFilter(
+  networkId: string | null | undefined,
+  networkFilter: PortfolioNetworkFilterValue
+): boolean {
+  if (networkFilter === "all") return true;
+  if (!networkId) return true;
+  const normalizedNetwork = networkId.toLowerCase();
+  if (networkFilter === "algorand") {
+    return normalizedNetwork.includes("algorand");
+  }
+  if (networkFilter === "voi") {
+    return normalizedNetwork.includes("voi");
+  }
+  return true;
+}
+
+export function portfolioNetworkFilterLabel(
+  value: PortfolioNetworkFilterValue
+): string {
+  if (value === "all") return "All Networks";
+  if (value === "algorand") {
+    return getNetworkConfig("algorand-mainnet").name;
+  }
+  return getNetworkConfig("voi-mainnet").name;
+}
+
+export function portfolioMarketFilterLabel(value: MarketFilter): string {
+  if (value === "all") return "All Markets";
+  return `${value} Market`;
+}
+
+export function hasActivePortfolioPositionFilters(
+  networkFilter: PortfolioNetworkFilterValue,
+  marketFilter: MarketFilter,
+  searchTerm: string
+): boolean {
+  return (
+    networkFilter !== "all" ||
+    marketFilter !== "all" ||
+    searchTerm.trim() !== ""
+  );
+}

--- a/src/utils/portfolioMarketFilter.ts
+++ b/src/utils/portfolioMarketFilter.ts
@@ -69,3 +69,52 @@ export function hasActivePortfolioPositionFilters(
     searchTerm.trim() !== ""
   );
 }
+
+export type PortfolioPositionFilterItem = {
+  asset: string;
+  poolId?: string;
+  network?: string;
+};
+
+export type PortfolioPositionFilterOptions = {
+  searchTerm?: string;
+  networkFilter: PortfolioNetworkFilterValue;
+  marketFilter?: MarketFilter;
+  /** Used for market-tier matching when the row has no network field. */
+  marketNetworkFallback?: string;
+};
+
+/** Shared filter for supplied/borrowed rows, pool breakdown, and tab counts. */
+export function itemMatchesPortfolioPositionFilters(
+  item: PortfolioPositionFilterItem,
+  options: PortfolioPositionFilterOptions
+): boolean {
+  const search = options.searchTerm?.trim();
+  if (search && !item.asset.toLowerCase().includes(search.toLowerCase())) {
+    return false;
+  }
+
+  if (options.networkFilter !== "all" && item.network) {
+    if (
+      !positionMatchesNetworkFilter(item.network, options.networkFilter)
+    ) {
+      return false;
+    }
+  }
+
+  const marketFilter = options.marketFilter ?? "all";
+  if (marketFilter !== "all") {
+    const networkForMarket = item.network ?? options.marketNetworkFallback;
+    if (
+      !positionMatchesMarketFilter(
+        networkForMarket,
+        item.poolId,
+        marketFilter
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Extract filter bar, insights chips, and health-factor status helpers so portfolio and position overview share consistent filtering and risk messaging.

Commit 50cf4de — portfolio insights hub & position filters

This refactor cleans up the Portfolio page UI and adds shared filtering.

New capabilities

Position filters: network (All / Algorand / VOI), market tier (A/B/D), and asset search apply to supplied and borrowed tables, tab counts, and the network breakdown modal.
Insights hub: achievements, network breakdown, and NFT rewards are consolidated into PortfolioInsightsHub, shown as compact toolbar buttons inside the Position Overview hero card.
UI changes

The old collapsible network pie chart section is replaced by a Networks modal (PortfolioNetworkBreakdownModal).
Health factor status is always shown (including a new green “healthy” message when HF > 1.2).
Stats grid and insight chips use a consistent segmented-card layout.
Code structure

Large inline blocks were extracted from Portfolio.tsx into focused components plus portfolioMarketFilter utils (with unit tests).
Net: 14 files, +3,093 / −2,509 lines — mostly extraction and wiring, not new lending logic.
