### PR TITLE
fix: Algorand Max Repay, repay modal scroll, and success confirmation

### DIFF
--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -1968,62 +1968,66 @@ const PortfolioModals = ({
             Number(txn.txn.applicationCall.appIndex) === parseInt(token.poolId)
         )
         ?.txn.txID();
+
+      // Metadata indexing is best-effort; do not block the success confirmation UI.
       if (poolTxnID) {
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-        // Retry until metadata update succeeds
-        let metadataUpdated = false;
-        let retryCount = 0;
-        const maxRetries = 10;
         const apiBaseUrl =
           import.meta.env.VITE_DORKFI_API_URL ||
           "https://dorkfi-api.nautilus.sh";
         const networkParam = networkToUse ? `?network=${networkToUse}` : "";
+        void (async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5000));
+          let metadataUpdated = false;
+          let retryCount = 0;
+          const maxRetries = 10;
+          while (!metadataUpdated && retryCount < maxRetries) {
+            try {
+              const response = await fetch(
+                `${apiBaseUrl}/transaction-metadata/${poolTxnID}${networkParam}`,
+                {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                }
+              );
 
-        while (!metadataUpdated && retryCount < maxRetries) {
-          try {
-            const response = await fetch(
-              `${apiBaseUrl}/transaction-metadata/${poolTxnID}${networkParam}`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
+              if (response.ok) {
+                const result = await response.json();
+                console.log(
+                  "Transaction metadata successfully updated:",
+                  result.data
+                );
+                metadataUpdated = true;
+              } else {
+                const error = await response.json();
+                throw new Error(
+                  error.error || "Failed to update transaction metadata"
+                );
               }
-            );
-
-            if (response.ok) {
-              const result = await response.json();
-              console.log(
-                "Transaction metadata successfully updated:",
-                result.data
-              );
-              metadataUpdated = true;
-            } else {
-              const error = await response.json();
-              throw new Error(
-                error.error || "Failed to update transaction metadata"
-              );
-            }
-          } catch (error) {
-            retryCount++;
-            if (retryCount < maxRetries) {
-              const delay = 1000 * Math.pow(2, retryCount - 1); // Exponential backoff
-              console.warn(
-                `Metadata update attempt ${retryCount} failed, retrying in ${delay}ms:`,
-                error
-              );
-              await new Promise((resolve) => setTimeout(resolve, delay));
-            } else {
-              console.error(
-                "Failed to update transaction metadata after all retries:",
-                error
-              );
+            } catch (error) {
+              retryCount++;
+              if (retryCount < maxRetries) {
+                const delay = 1000 * Math.pow(2, retryCount - 1);
+                console.warn(
+                  `Metadata update attempt ${retryCount} failed, retrying in ${delay}ms:`,
+                  error
+                );
+                await new Promise((resolve) => setTimeout(resolve, delay));
+              } else {
+                console.error(
+                  "Failed to update transaction metadata after all retries:",
+                  error
+                );
+              }
             }
           }
-        }
+        })();
       }
 
       console.log("Repay transaction confirmed:", res);
+
+      setRepayRainbowkitOverlaySuppressed(false);
 
       // Refresh wallet balance after successful repayment
       if (onRefreshWalletBalance) {

--- a/src/components/RepayModal.tsx
+++ b/src/components/RepayModal.tsx
@@ -42,6 +42,7 @@ import {
   getAnyFolksAdapter,
   getFolksAdapterForPhase,
   tokenAdapterStableId,
+  tokenStandardUsesNativeWalletBalance,
 } from "@/config";
 import { useWallet } from "@txnlab/use-wallet-react";
 import { isRainbowkitXchainWallet } from "@/wallet/xchainSignUi";
@@ -66,6 +67,11 @@ import {
   DEPOSIT_ESTIMATED_HEALTH_CRITICAL_MAX,
   estimatePoolHealthAfterRepay,
 } from "@/utils/depositModalPoolHealthEstimate";
+import {
+  computeMaxRepayHuman,
+  roundRepayHuman6,
+  shouldUseRepayAllPath,
+} from "@/utils/repayMaxAmount";
 
 /** Amount field is in underlying (e.g. ALGO) vs market f-asset; convert to f-asset human for caps / HF. */
 function repayInputToMarketTokenHuman(
@@ -131,7 +137,10 @@ interface RepayModalProps {
    */
   folksMintOneUnderlyingAtomic?: string;
   /** Full token row; used to resolve Folks pool via deposit adapter (stable vs repay-only list). */
-  repayTokenConfig?: Pick<TokenConfig, "adapter" | "adapters"> | null;
+  repayTokenConfig?: Pick<
+    TokenConfig,
+    "adapter" | "adapters" | "tokenStandard"
+  > | null;
   /** When provided, show asset dropdown like Supply/Withdraw modals */
   availableAssets?: {
     asset: string;
@@ -255,6 +264,10 @@ const RepayModal = ({
   const [nativeAlgoWalletHuman, setNativeAlgoWalletHuman] = useState<
     number | undefined
   >(undefined);
+  /** Spendable native L1 balance for market-token repay (e.g. ALGO on Algorand). */
+  const [marketTokenSpendableHuman, setMarketTokenSpendableHuman] = useState<
+    number | undefined
+  >(undefined);
   const [xalgoRepayConsensusState, setXalgoRepayConsensusState] =
     useState<ConsensusState | null>(null);
 
@@ -277,6 +290,13 @@ const RepayModal = ({
   const repayWalletBasis = isXalgoConsensusRepayAlgoRoute
     ? "underlying"
     : (selectedRepayAdapter?.repayWalletBasis ?? "market_token");
+
+  const usesNativeMarketTokenWallet =
+    repayWalletBasis === "market_token" &&
+    repayTokenConfig?.tokenStandard != null &&
+    tokenStandardUsesNativeWalletBalance(repayTokenConfig.tokenStandard);
+
+  const reserveNativeTxnFee = usesNativeMarketTokenWallet;
 
   const walletUnitSymbol = isXalgoConsensusRepayAlgoRoute
     ? "ALGO"
@@ -346,6 +366,7 @@ const RepayModal = ({
       setFolksMintedFAssetPerOneUnderlying(null);
       setFolksMintRatioStatus("idle");
       setNativeAlgoWalletHuman(undefined);
+      setMarketTokenSpendableHuman(undefined);
       setXalgoRepayConsensusState(null);
       setExpandedDetails({
         borrowAPY: false,
@@ -483,6 +504,43 @@ const RepayModal = ({
   }, [isOpen, xalgoRepayRoutesActive, networkToUse]);
 
   useEffect(() => {
+    if (
+      !isOpen ||
+      !usesNativeMarketTokenWallet ||
+      !activeAccount?.address
+    ) {
+      setMarketTokenSpendableHuman(undefined);
+      return;
+    }
+    const aln = getAlgorandNetworkFromNetworkId(networkToUse as NetworkId);
+    if (!aln) {
+      setMarketTokenSpendableHuman(undefined);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const { algod } = algorandService.initializeClients(aln as AlgorandNetwork);
+        const accountInfo = await algod
+          .accountInformation(activeAccount.address)
+          .do();
+        const human = spendableAlgoHumanFromAccount(accountInfo);
+        if (!cancelled) setMarketTokenSpendableHuman(human);
+      } catch {
+        if (!cancelled) setMarketTokenSpendableHuman(0);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isOpen,
+    usesNativeMarketTokenWallet,
+    activeAccount?.address,
+    networkToUse,
+  ]);
+
+  useEffect(() => {
     if (!isOpen || repayWalletBasis !== "underlying" || !activeAccount?.address) {
       setNativeAlgoWalletHuman(undefined);
       return;
@@ -618,10 +676,32 @@ const RepayModal = ({
     if (repayWalletBasis === "underlying") {
       return nativeAlgoWalletHuman ?? 0;
     }
+    if (marketTokenSpendableHuman != null) {
+      return marketTokenSpendableHuman;
+    }
     return walletBalance;
-  }, [repayWalletBasis, nativeAlgoWalletHuman, walletBalance]);
+  }, [
+    repayWalletBasis,
+    nativeAlgoWalletHuman,
+    marketTokenSpendableHuman,
+    walletBalance,
+  ]);
 
-  const maxRepayAmount = Math.min(maxDebtInInputUnits, effectiveWalletBalance);
+  const maxRepayAmount = useMemo(
+    () =>
+      computeMaxRepayHuman({
+        debtHuman: maxDebtInInputUnits,
+        spendableWalletHuman: effectiveWalletBalance,
+        decimals: repayTokenDecimals,
+        reserveNativeTxnFee,
+      }),
+    [
+      maxDebtInInputUnits,
+      effectiveWalletBalance,
+      repayTokenDecimals,
+      reserveNativeTxnFee,
+    ]
+  );
 
   /**
    * Repay amount in **input field units** that covers accrued interest (capped by wallet + total debt).
@@ -723,10 +803,19 @@ const RepayModal = ({
   ]);
 
   const handleMaxClick = () => {
-    const roundedMax = Math.round(maxRepayAmount * 1000000) / 1000000;
+    const roundedMax = roundRepayHuman6(maxRepayAmount);
     setAmount(roundedMax);
-    const roundedDebtCap = Math.round(maxDebtInInputUnits * 1000000) / 1000000;
-    setIsRepayAll(roundedMax === roundedDebtCap);
+    const roundedDebtCap = roundRepayHuman6(maxDebtInInputUnits);
+    const shouldMaxUseRepayAll =
+      !isXalgoConsensusRepayAlgoRoute &&
+      shouldUseRepayAllPath({
+        amountHuman: roundedMax,
+        debtHuman: roundedDebtCap,
+        spendableWalletHuman: effectiveWalletBalance,
+        decimals: repayTokenDecimals,
+        reserveNativeTxnFee,
+      });
+    setIsRepayAll(shouldMaxUseRepayAll);
   };
 
   const handleInterestOnlyClick = () => {
@@ -739,10 +828,16 @@ const RepayModal = ({
   };
 
   const handleConfirmRepay = async () => {
-    const roundedAmount = Math.round(numAmount * 1000000) / 1000000;
-    const roundedDebtCap = Math.round(maxDebtInInputUnits * 1000000) / 1000000;
+    const roundedAmount = roundRepayHuman6(numAmount);
     const shouldUseRepayAll =
-      !isXalgoConsensusRepayAlgoRoute && roundedAmount === roundedDebtCap;
+      !isXalgoConsensusRepayAlgoRoute &&
+      shouldUseRepayAllPath({
+        amountHuman: roundedAmount,
+        debtHuman: maxDebtInInputUnits,
+        spendableWalletHuman: effectiveWalletBalance,
+        decimals: repayTokenDecimals,
+        reserveNativeTxnFee,
+      });
 
     const amountStr = amount !== "" ? amount.toString() : "0";
     console.log(`Repay ${amountStr} ${tokenSymbol}${shouldUseRepayAll ? " (repayAll)" : ""}`);
@@ -763,6 +858,7 @@ const RepayModal = ({
         repayAdapterId: repayAdapterIdOpt,
       });
       setTransactionId(txId);
+      setWorkflowStep("amount");
 
       if (isRainbowkitXchainWallet(activeWallet)) {
         toast({
@@ -805,8 +901,8 @@ const RepayModal = ({
     setWorkflowStep("amount");
   };
 
-  const roundedAmount = Math.round(numAmount * 1000000) / 1000000;
-  const roundedMaxRepay = Math.round(maxRepayAmount * 1000000) / 1000000;
+  const roundedAmount = roundRepayHuman6(numAmount);
+  const roundedMaxRepay = roundRepayHuman6(maxRepayAmount);
   const isValidAmount =
     amount !== "" &&
     numAmount > 0 &&
@@ -893,22 +989,26 @@ const RepayModal = ({
   const repayPoolHealthLoading =
     poolGlobalUserData === undefined && Boolean(poolId);
 
+  /** Block Radix dismiss while a repay is in flight (wallet popup steals focus on mobile). */
+  const handleDialogOpenChange = (open: boolean) => {
+    if (open || isLoading) return;
+    onClose();
+  };
+
   return (
     <>
     <Dialog
       open={isOpen && !rainbowkitHostOverlaySuppressed}
-      onOpenChange={onClose}
+      onOpenChange={handleDialogOpenChange}
     >
       <DialogContent
         className={cn(
-          "bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl max-w-[95vw] overflow-hidden flex flex-col px-0 py-0",
-          showSuccess
-            ? "md:max-w-md h-auto max-h-[min(90vh,90dvh)]"
-            : "md:max-w-lg lg:max-w-4xl h-[90vh] md:h-auto md:max-h-[85vh]"
+          "bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl max-w-[95vw] h-[min(90vh,90dvh)] max-h-[min(90vh,90dvh)] min-h-0 overflow-x-hidden overflow-hidden flex flex-col px-0 py-0 overscroll-contain md:h-auto md:max-h-[min(85vh,85dvh)]",
+          showSuccess ? "md:max-w-md" : "md:max-w-lg lg:max-w-4xl"
         )}
       >
         {showSuccess ? (
-          <div className="p-6 overflow-y-auto">
+          <div className="max-h-[min(90vh,90dvh)] overflow-y-auto overscroll-contain p-6">
             <SupplyBorrowCongrats
               transactionType="repay"
               asset={tokenSymbol}
@@ -921,8 +1021,8 @@ const RepayModal = ({
             />
           </div>
         ) : (
-          <div className="flex flex-col h-full">
-            <div className="sticky top-0 z-20 bg-card dark:bg-slate-900 pt-6 px-6 md:px-8 lg:px-10 pb-4 border-b border-gray-200/50 dark:border-slate-700/50">
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="sticky top-0 z-20 shrink-0 bg-card dark:bg-slate-900 pt-6 px-6 md:px-8 lg:px-10 pb-4 border-b border-gray-200/50 dark:border-slate-700/50">
               <DialogHeader className="pb-0">
                 {availableAssets &&
                 availableAssets.length > 0 &&
@@ -1019,7 +1119,7 @@ const RepayModal = ({
               </DialogHeader>
             </div>
 
-            <div className="flex-1 overflow-y-auto overscroll-contain pt-2 px-6 md:px-8 lg:px-10 pb-6 md:pb-8 touch-pan-y">
+            <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pt-2 px-6 md:px-8 lg:px-10 pb-6 md:pb-8 touch-pan-y [scrollbar-gutter:stable]">
               <div className="flex flex-col lg:flex-row lg:gap-8 space-y-6 lg:space-y-0">
                 {/* Left Column: Input Form */}
                 <div className="flex-1 space-y-6 min-w-0">

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -15,6 +15,7 @@ import {
   getPortfolioVisibleTokens,
   getAllTokensWithDisplayInfo,
 } from "@/config";
+import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
 import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
 
 export interface PortfolioPosition {
@@ -321,9 +322,8 @@ export const usePortfolioData = () => {
             const accountInfo = await clients.algod
               .accountInformation(activeAccount.address)
               .do();
-            // Convert from micro-units to units (divide by 1,000,000)
-            balance = Number(accountInfo.amount) / 1_000_000;
-            console.log(`Network token balance for ${asset}: ${balance}`);
+            balance = spendableAlgoHumanFromAccount(accountInfo);
+            console.log(`Network token spendable balance for ${asset}: ${balance}`);
           } catch (error) {
             console.error(
               `Error fetching network token balance for ${asset}:`,

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -77,6 +77,12 @@ import {
   buildTalgoMintUnsignedWithOptionalOptIn,
   fetchMinTalgoOutMintFloorFromChain,
 } from "./tinymanTalgoAdapter";
+import { spendableAlgoMicroAlgosFromAccount } from "@/utils/algorandWalletBalance";
+import { getAccountAssetHoldingAmountAtomic } from "@/utils/algodAccountAssetAmount";
+import {
+  computeRepayAllArc200Units,
+  repayAllSurplusAtomic,
+} from "@/utils/repayMaxAmount";
 
 export interface MarketData {
   appId: string;
@@ -6519,7 +6525,7 @@ export const repay = async (
         }
       }
       if (!customR.success) {
-        throw new Error("Failed to create repay transaction");
+        throw new Error(repayAllSimulationError(customR));
       }
       return {
         success: true,
@@ -6892,6 +6898,97 @@ export const repayOnBehalf = async (
 };
 
 
+/** Spendable wallet units (atomic) for the asset used to fund a repay / repayAll. */
+async function fetchRepaySpendableWalletAtomic(
+  algod: algosdk.Algodv2,
+  userAddress: string,
+  tokenStandard: TokenStandard,
+  token: {
+    underlyingContractId?: string;
+    underlyingAssetId?: string;
+    decimals: number;
+  }
+): Promise<bigint> {
+  if (tokenStandardUsesNativeWalletBalance(tokenStandard)) {
+    const accountInfo = await algod.accountInformation(userAddress).do();
+    return spendableAlgoMicroAlgosFromAccount(accountInfo);
+  }
+
+  if (tokenStandard === "arc200") {
+    const contractId = String(token.underlyingContractId ?? "").trim();
+    if (contractId === "") return 0n;
+    const bal = await ARC200Service.getBalance(userAddress, contractId);
+    return bal != null ? BigInt(bal) : 0n;
+  }
+
+  if (
+    tokenStandardUsesAsaStyleNt200Txns(tokenStandard) ||
+    tokenStandard === "asa" ||
+    tokenStandard === "arc200-exchange"
+  ) {
+    const assetId = Number(token.underlyingAssetId);
+    if (!Number.isFinite(assetId) || assetId <= 0) return 0n;
+    try {
+      const holding = await algod
+        .accountAssetInformation(userAddress, assetId)
+        .do();
+      const atomic = getAccountAssetHoldingAmountAtomic(holding);
+      return atomic != null ? atomic : 0n;
+    } catch {
+      return 0n;
+    }
+  }
+
+  if (tokenStandardUsesNt200Arc200Balance(tokenStandard)) {
+    const contractId = String(token.underlyingContractId ?? "").trim();
+    if (contractId === "") return 0n;
+    const clients = { algod };
+    ARC200Service.initialize(clients);
+    const bal = await ARC200Service.getBalance(userAddress, contractId);
+    return bal != null ? BigInt(bal) : 0n;
+  }
+
+  return 0n;
+}
+
+async function fetchOnChainBorrowAtomic(
+  poolId: string,
+  userAddress: string,
+  marketId: string,
+  algod: algosdk.Algodv2
+): Promise<bigint> {
+  const ci = new CONTRACT(
+    Number(poolId),
+    algod,
+    undefined,
+    { ...LendingPoolAppSpec.contract, events: [] },
+    {
+      addr: userAddress,
+      sk: new Uint8Array(),
+    }
+  );
+  ci.setFee(2000);
+  const borrowAmountR = await ci.get_user_borrow_amount(
+    userAddress,
+    Number(marketId)
+  );
+  if (
+    borrowAmountR.success &&
+    borrowAmountR.returnValue !== undefined &&
+    borrowAmountR.returnValue !== null
+  ) {
+    return BigInt(String(borrowAmountR.returnValue as bigint));
+  }
+  return 0n;
+}
+
+function repayAllSimulationError(customR: { success: boolean; error?: string }): string {
+  const detail = customR.error?.trim();
+  return detail
+    ? `Failed to create repay transaction: ${detail}`
+    : "Failed to create repay transaction";
+}
+
 /**
  * Repay borrowed tokens to a lending market
  */
@@ -6987,21 +7084,7 @@ export const repayAll = async (
           ? Number(token.underlyingAssetId)
           : NaN;
 
-      // TODO use calculated value based on interest per minute
-      const bigAmountSurplus = BigInt(
-        new BigNumber(amount)
-          .multipliedBy(10 ** token.decimals)
-          .multipliedBy(0.01)
-          .plus(1)
-          .toFixed(0)
-      );
-
-      let repayArc200Units = BigInt(
-        new BigNumber(amount)
-          .multipliedBy(10 ** token.decimals)
-          .plus(bigAmountSurplus)
-          .toFixed(0)
-      );
+      let repayArc200Units = BigInt(0);
 
       let folksMintTxns: algosdk.Transaction[] | null = null;
 
@@ -7073,9 +7156,54 @@ export const repayAll = async (
             underlyingAmount: underlyingAtomic,
             algod: clients.algod,
           });
-          const surplusF = (mintedFAsset * 1n) / 100n + 1n;
-          repayArc200Units = mintedFAsset + surplusF;
+          repayArc200Units =
+            mintedFAsset + repayAllSurplusAtomic(mintedFAsset);
         }
+      }
+
+      const onChainBorrowAtomic = await fetchOnChainBorrowAtomic(
+        poolId,
+        userAddress,
+        marketId,
+        clients.algod
+      );
+      const spendableWalletAtomic = await fetchRepaySpendableWalletAtomic(
+        clients.algod,
+        userAddress,
+        tokenStandard,
+        token
+      );
+      const reserveNativeTxnFee = tokenStandardUsesNativeWalletBalance(
+        tokenStandard
+      );
+
+      if (folksForRepay && folksForRepay.repayWalletBasis !== "market_token") {
+        const fAssetWallet = await fetchRepaySpendableWalletAtomic(
+          clients.algod,
+          userAddress,
+          "arc200",
+          { ...token, underlyingContractId: token.underlyingContractId }
+        );
+        if (repayArc200Units <= 0n) {
+          repayArc200Units = computeRepayAllArc200Units({
+            onChainBorrowAtomic,
+            spendableWalletAtomic: fAssetWallet,
+            reserveNativeTxnFee: false,
+          });
+        } else if (repayArc200Units > fAssetWallet) {
+          repayArc200Units = fAssetWallet;
+        }
+        if (repayArc200Units < onChainBorrowAtomic) {
+          throw new Error(
+            "Insufficient balance to close full debt; try a smaller repay amount"
+          );
+        }
+      } else {
+        repayArc200Units = computeRepayAllArc200Units({
+          onChainBorrowAtomic,
+          spendableWalletAtomic,
+          reserveNativeTxnFee,
+        });
       }
 
       const symbol = token.symbol;
@@ -7344,7 +7472,7 @@ export const repayAll = async (
         }
       }
       if (!customR.success) {
-        throw new Error("Failed to create repay transaction");
+        throw new Error(repayAllSimulationError(customR));
       }
       return {
         success: true,

--- a/src/utils/__tests__/repayMaxAmount.qa.test.ts
+++ b/src/utils/__tests__/repayMaxAmount.qa.test.ts
@@ -1,0 +1,170 @@
+/**
+ * QA / smoke scenarios for Max Repay (#501).
+ * Mirrors Algorand market decimals and reported user flows.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeMaxRepayHuman,
+  computeRepayAllArc200Units,
+  humanToRepayAtomic,
+  repayAllDepositAtomicFromBase,
+  repayAllSurplusAtomic,
+  shouldUseRepayAllPath,
+} from "@/utils/repayMaxAmount";
+
+const D6 = 6;
+const D8 = 8;
+
+describe("repayMaxAmount QA smoke scenarios", () => {
+  describe("issue #501 — wallet-limited partial max (wallet < debt)", () => {
+    it("ALGO: wallet 40, debt 100 → max spendable minus txn fee, repay() path", () => {
+      const max = computeMaxRepayHuman({
+        debtHuman: 100,
+        spendableWalletHuman: 40,
+        decimals: D6,
+        reserveNativeTxnFee: true,
+      });
+      // 40 spendable − 0.1 ALGO group fee reserve
+      expect(max).toBe(39.9);
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: max,
+          debtHuman: 100,
+          spendableWalletHuman: 40,
+          decimals: D6,
+          reserveNativeTxnFee: true,
+        })
+      ).toBe(false);
+    });
+
+    it("UNIT (8 dec): wallet 0.5, debt 2 → max 0.5", () => {
+      const max = computeMaxRepayHuman({
+        debtHuman: 2,
+        spendableWalletHuman: 0.5,
+        decimals: D8,
+      });
+      expect(max).toBe(0.5);
+    });
+  });
+
+  describe("issue #501 — exact-balance full close failure mode (fixed)", () => {
+    it("ALGO: wallet equals debt — old bug used repayAll with surplus overflow", () => {
+      const debt = 50;
+      const wallet = 50;
+      const max = computeMaxRepayHuman({
+        debtHuman: debt,
+        spendableWalletHuman: wallet,
+        decimals: D6,
+        reserveNativeTxnFee: true,
+      });
+      // Cannot fund debt + 1% + fee with only 50 spendable
+      expect(max).toBeLessThan(debt);
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: max,
+          debtHuman: debt,
+          spendableWalletHuman: wallet,
+          decimals: D6,
+          reserveNativeTxnFee: true,
+        })
+      ).toBe(false);
+    });
+
+    it("ALGO: wallet 50.2, debt 50 — not enough for full close (fee + surplus)", () => {
+      const debt = 50;
+      const wallet = 50.2;
+      const max = computeMaxRepayHuman({
+        debtHuman: debt,
+        spendableWalletHuman: wallet,
+        decimals: D6,
+        reserveNativeTxnFee: true,
+      });
+      // Need ~50.6 spendable for debt + 1% surplus + 0.1 fee; caps below debt
+      expect(max).toBeLessThan(debt);
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: max,
+          debtHuman: debt,
+          spendableWalletHuman: wallet,
+          decimals: D6,
+          reserveNativeTxnFee: true,
+        })
+      ).toBe(false);
+    });
+
+    it("ALGO: wallet 51, debt 50 — enough headroom for full close", () => {
+      const debt = 50;
+      const wallet = 51;
+      const max = computeMaxRepayHuman({
+        debtHuman: debt,
+        spendableWalletHuman: wallet,
+        decimals: D6,
+        reserveNativeTxnFee: true,
+      });
+      expect(max).toBe(50);
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: max,
+          debtHuman: debt,
+          spendableWalletHuman: wallet,
+          decimals: D6,
+          reserveNativeTxnFee: true,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("repayAll on-chain sizing", () => {
+    it("never requests more than spendable wallet", () => {
+      const onChain = 100_000_000n; // 100 ALGO
+      const wallet = 100_500_000n; // 100.5 ALGO
+      const units = computeRepayAllArc200Units({
+        onChainBorrowAtomic: onChain,
+        spendableWalletAtomic: wallet,
+        reserveNativeTxnFee: true,
+      });
+      expect(units).toBeLessThanOrEqual(wallet - 100_000n);
+      expect(units).toBeGreaterThanOrEqual(onChain);
+    });
+
+    it("throws when wallet cannot cover on-chain debt", () => {
+      expect(() =>
+        computeRepayAllArc200Units({
+          onChainBorrowAtomic: 100_000_000n,
+          spendableWalletAtomic: 50_000_000n,
+        })
+      ).toThrow(/Insufficient balance to close full debt/);
+    });
+
+    it("surplus formula matches repayAll implementation (1% + 1)", () => {
+      const base = 1_000_000n;
+      expect(repayAllSurplusAtomic(base)).toBe(10_000n + 1n);
+      expect(repayAllDepositAtomicFromBase(base)).toBe(1_010_001n);
+    });
+  });
+
+  describe("regression — Voi-style headroom (no native fee reserve)", () => {
+    it("arc200: wallet 102, debt 100 → full close via repayAll", () => {
+      const max = computeMaxRepayHuman({
+        debtHuman: 100,
+        spendableWalletHuman: 102,
+        decimals: D6,
+      });
+      expect(max).toBe(100);
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: 100,
+          debtHuman: 100,
+          spendableWalletHuman: 102,
+          decimals: D6,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("atomic round-trip sanity", () => {
+    it("humanToRepayAtomic floors partial micro units", () => {
+      expect(humanToRepayAtomic(1.0000009, D6)).toBe(1_000_000n);
+    });
+  });
+});

--- a/src/utils/__tests__/repayMaxAmount.test.ts
+++ b/src/utils/__tests__/repayMaxAmount.test.ts
@@ -1,0 +1,94 @@
+import BigNumber from "bignumber.js";
+import {
+  computeMaxRepayHuman,
+  roundRepayHuman6,
+  shouldUseRepayAllPath,
+} from "@/utils/repayMaxAmount";
+
+describe("repayMaxAmount", () => {
+  const decimals = 6;
+
+  describe("computeMaxRepayHuman", () => {
+    it("returns full wallet when wallet is below debt", () => {
+      expect(
+        computeMaxRepayHuman({
+          debtHuman: 100,
+          spendableWalletHuman: 40,
+          decimals,
+        })
+      ).toBe(40);
+    });
+
+    it("returns full debt when wallet covers debt plus repayAll surplus", () => {
+      expect(
+        computeMaxRepayHuman({
+          debtHuman: 100,
+          spendableWalletHuman: 102,
+          decimals,
+        })
+      ).toBe(100);
+    });
+
+    it("caps below debt when wallet cannot fund repayAll surplus", () => {
+      const max = computeMaxRepayHuman({
+        debtHuman: 100,
+        spendableWalletHuman: 100.5,
+        decimals,
+      });
+      expect(max).toBeLessThan(100);
+      expect(max).toBeGreaterThan(99);
+    });
+
+    it("reserves native txn fee from spendable", () => {
+      expect(
+        computeMaxRepayHuman({
+          debtHuman: 10,
+          spendableWalletHuman: 0.05,
+          decimals,
+          reserveNativeTxnFee: true,
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe("shouldUseRepayAllPath", () => {
+    it("is false when amount is below debt", () => {
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: 50,
+          debtHuman: 100,
+          spendableWalletHuman: 200,
+          decimals,
+        })
+      ).toBe(false);
+    });
+
+    it("is true when repaying full debt with sufficient wallet", () => {
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: 100,
+          debtHuman: 100,
+          spendableWalletHuman: 102,
+          decimals,
+        })
+      ).toBe(true);
+    });
+
+    it("is false when full debt exceeds wallet surplus headroom", () => {
+      expect(
+        shouldUseRepayAllPath({
+          amountHuman: 100,
+          debtHuman: 100,
+          spendableWalletHuman: 100.5,
+          decimals,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("roundRepayHuman6", () => {
+    it("rounds to 6 decimal places", () => {
+      expect(roundRepayHuman6(1.123456789)).toBe(1.123457);
+    });
+  });
+});

--- a/src/utils/repayMaxAmount.ts
+++ b/src/utils/repayMaxAmount.ts
@@ -1,0 +1,161 @@
+import BigNumber from "bignumber.js";
+
+/** Fee set on lending repay / repayAll groups (`ci.setFee(1e5)`). */
+export const REPAY_LENDING_GROUP_FEE_MICRO = 100_000n;
+
+/** 1% + 1 atomic unit buffer used by repayAll deposit/approve sizing. */
+export function repayAllSurplusAtomic(amountAtomic: bigint): bigint {
+  if (amountAtomic <= 0n) return 0n;
+  return amountAtomic / 100n + 1n;
+}
+
+/** Total deposit/approve units when repayAll adds its surplus on a base amount. */
+export function repayAllDepositAtomicFromBase(baseAtomic: bigint): bigint {
+  if (baseAtomic <= 0n) return 0n;
+  return baseAtomic + repayAllSurplusAtomic(baseAtomic);
+}
+
+/**
+ * Largest base (debt) amount such that `base + surplus(base)` fits in `spendableAtomic`.
+ */
+export function maxBaseAtomicForRepayAllSurplus(
+  spendableAtomic: bigint
+): bigint {
+  if (spendableAtomic <= 1n) return 0n;
+  return ((spendableAtomic - 1n) * 100n) / 101n;
+}
+
+export function humanToRepayAtomic(human: number, decimals: number): bigint {
+  if (!(human > 0) || !Number.isFinite(human)) return 0n;
+  return BigInt(
+    new BigNumber(human)
+      .times(10 ** decimals)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toFixed(0)
+  );
+}
+
+export function repayAtomicToHuman(atomic: bigint, decimals: number): number {
+  return Number(atomic) / 10 ** decimals;
+}
+
+export function roundRepayHuman6(n: number): number {
+  return Math.round(n * 1e6) / 1e6;
+}
+
+export type ComputeMaxRepayHumanParams = {
+  debtHuman: number;
+  spendableWalletHuman: number;
+  decimals: number;
+  /** When true, subtract {@link REPAY_LENDING_GROUP_FEE_MICRO} from native-coin spendable. */
+  reserveNativeTxnFee?: boolean;
+};
+
+/**
+ * Max repay input (human units): all spendable wallet up to debt, with repayAll surplus
+ * and native txn fee headroom when closing the full position.
+ */
+export function computeMaxRepayHuman({
+  debtHuman,
+  spendableWalletHuman,
+  decimals,
+  reserveNativeTxnFee = false,
+}: ComputeMaxRepayHumanParams): number {
+  if (!(debtHuman > 0) || !(spendableWalletHuman > 0)) return 0;
+
+  let spendableAtomic = humanToRepayAtomic(spendableWalletHuman, decimals);
+  if (spendableAtomic <= 0n) return 0;
+
+  if (reserveNativeTxnFee) {
+    if (spendableAtomic <= REPAY_LENDING_GROUP_FEE_MICRO) return 0;
+    spendableAtomic -= REPAY_LENDING_GROUP_FEE_MICRO;
+  }
+
+  const debtAtomic = humanToRepayAtomic(debtHuman, decimals);
+  if (debtAtomic <= 0n) return 0;
+
+  let maxAtomic: bigint;
+  if (spendableAtomic < debtAtomic) {
+    maxAtomic = spendableAtomic;
+  } else {
+    const depositForFullDebt = repayAllDepositAtomicFromBase(debtAtomic);
+    if (depositForFullDebt <= spendableAtomic) {
+      maxAtomic = debtAtomic;
+    } else {
+      maxAtomic = maxBaseAtomicForRepayAllSurplus(spendableAtomic);
+      if (maxAtomic > debtAtomic) maxAtomic = debtAtomic;
+    }
+  }
+
+  if (maxAtomic <= 0n) return 0;
+  return roundRepayHuman6(repayAtomicToHuman(maxAtomic, decimals));
+}
+
+export type ShouldUseRepayAllPathParams = {
+  amountHuman: number;
+  debtHuman: number;
+  spendableWalletHuman: number;
+  decimals: number;
+  reserveNativeTxnFee?: boolean;
+};
+
+/** True when amount equals full debt and wallet can fund repayAll deposit/approve sizing. */
+export function shouldUseRepayAllPath({
+  amountHuman,
+  debtHuman,
+  spendableWalletHuman,
+  decimals,
+  reserveNativeTxnFee = false,
+}: ShouldUseRepayAllPathParams): boolean {
+  const roundedAmount = roundRepayHuman6(amountHuman);
+  const roundedDebt = roundRepayHuman6(debtHuman);
+  if (roundedAmount !== roundedDebt || roundedDebt <= 0) return false;
+
+  let spendableAtomic = humanToRepayAtomic(spendableWalletHuman, decimals);
+  if (spendableAtomic <= 0n) return false;
+
+  if (reserveNativeTxnFee) {
+    if (spendableAtomic <= REPAY_LENDING_GROUP_FEE_MICRO) return false;
+    spendableAtomic -= REPAY_LENDING_GROUP_FEE_MICRO;
+  }
+
+  const debtAtomic = humanToRepayAtomic(roundedDebt, decimals);
+  if (debtAtomic <= 0n) return false;
+
+  return repayAllDepositAtomicFromBase(debtAtomic) <= spendableAtomic;
+}
+
+/**
+ * repayAll deposit/approve units: on-chain debt + surplus, capped at spendable wallet.
+ */
+export function computeRepayAllArc200Units(params: {
+  onChainBorrowAtomic: bigint;
+  spendableWalletAtomic: bigint;
+  reserveNativeTxnFee?: boolean;
+}): bigint {
+  const { onChainBorrowAtomic, reserveNativeTxnFee = false } = params;
+  let spendable = params.spendableWalletAtomic;
+
+  if (onChainBorrowAtomic <= 0n) {
+    throw new Error("No outstanding borrow to repay");
+  }
+  if (spendable <= 0n) {
+    throw new Error("Insufficient wallet balance to repay");
+  }
+
+  if (reserveNativeTxnFee) {
+    if (spendable <= REPAY_LENDING_GROUP_FEE_MICRO) {
+      throw new Error("Insufficient ALGO for repay transaction fee");
+    }
+    spendable -= REPAY_LENDING_GROUP_FEE_MICRO;
+  }
+
+  if (spendable < onChainBorrowAtomic) {
+    throw new Error(
+      "Insufficient balance to close full debt; try a smaller repay amount"
+    );
+  }
+
+  const target = repayAllDepositAtomicFromBase(onChainBorrowAtomic);
+  return target <= spendable ? target : spendable;
+}


### PR DESCRIPTION
## Summary
- Fix Max Repay on Algorand markets by sizing `repayAll` from on-chain borrow amount and spendable wallet balance, with shared max/repayAll math so deposit/approve no longer exceeds what the UI offers
- Max fills all spendable wallet funds when wallet balance is below debt (partial repay), using spendable native ALGO instead of gross balance
- Repay modal scrolls correctly on small screens; success confirmation shows immediately after chain confirm; modal cannot be dismissed while signing
- Surface simulation errors from `repayAll` instead of a generic failure message

Closes #501

## Test plan
- [x] `npm test` — 169/169 passed (includes 18 `repayMaxAmount` unit/QA tests)
- [x] `npm run build` passed
- [x] Manual QA: Max Repay on Algorand market (UNIT/ALGO), partial repay when wallet < debt, modal scroll on mobile, success screen after signing
- [ ] Reviewer: confirm Max Repay on an Algorand borrow position with wallet balance near debt
- [ ] Reviewer: confirm Voi markets still repay as expected

## Notes
- Full close via `repayAll` may require ~debt × 1.01 + fee headroom in spendable balance; when wallet ≈ debt, Max intentionally offers partial repay to avoid a failed `repayAll` simulation