### PR TITLE
Fix/nft marketplace links 562 563

### DIFF
--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -13,6 +13,7 @@ import { useNetwork } from '@/contexts/NetworkContext';
 import { useWallet } from '@txnlab/use-wallet-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Loader2, Image as ImageIcon, AlertCircle, ExternalLink, RefreshCw } from 'lucide-react';
+import { getDorkNftMarketplaceLinks } from '@/config/dorkNftMarketplaceLinks';
 
 interface NFTSelectionModalProps {
   open: boolean;
@@ -43,6 +44,7 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
   const isLoading = isLoadingNFTs || (requiresName && isLoadingName);
   const hasNFTs = nfts && nfts.length > 0;
   const meetsRequirements = (isAlgorand || ownsName) && hasNFTs;
+  const marketplaceLinks = getDorkNftMarketplaceLinks(currentNetwork);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -169,33 +171,18 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                   </div>
                   {!hasNFTs && (
                     <div className="flex flex-wrap gap-2 mt-3">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="text-xs"
-                        onClick={() => window.open('https://nautilus.sh/#/collection/313597/trade', '_blank', 'noopener,noreferrer')}
-                      >
-                        Dorks
-                        <ExternalLink className="w-3 h-3 ml-1" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="text-xs"
-                        onClick={() => window.open('https://nautilus.sh/#/collection/894888/trade', '_blank', 'noopener,noreferrer')}
-                      >
-                        Dorks V2
-                        <ExternalLink className="w-3 h-3 ml-1" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="text-xs"
-                        onClick={() => window.open('https://nautilus.sh/#/collection/313705/trade', '_blank', 'noopener,noreferrer')}
-                      >
-                        Chubs
-                        <ExternalLink className="w-3 h-3 ml-1" />
-                      </Button>
+                      {marketplaceLinks.map(({ id, label, url }) => (
+                        <Button
+                          key={id}
+                          size="sm"
+                          variant="outline"
+                          className="text-xs"
+                          onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
+                        >
+                          {label}
+                          <ExternalLink className="w-3 h-3 ml-1" />
+                        </Button>
+                      ))}
                     </div>
                   )}
                 </div>

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -170,9 +170,9 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="grid grid-cols-3 gap-3 mt-3">
+                    <div className="mt-3 grid min-w-0 grid-cols-3 gap-2 sm:gap-3">
                       {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
-                        <div key={id} className="flex flex-col items-center gap-2">
+                        <div key={id} className="flex min-w-0 flex-col items-center gap-2">
                           <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
                             <img
                               src={imageUrl}
@@ -184,11 +184,17 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            className="w-full text-xs"
+                            className="h-auto w-full min-w-0 px-2 py-2 text-xs max-[374px]:flex-col max-[374px]:gap-1.5 max-[374px]:whitespace-normal min-[375px]:whitespace-nowrap"
                             onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
                           >
-                            {label}
-                            <ExternalLink className="w-3 h-3 ml-1" />
+                            <span className="text-center leading-tight">{label}</span>
+                            <span
+                              aria-hidden
+                              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-input bg-background min-[375px]:hidden"
+                            >
+                              <ExternalLink className="!size-3" />
+                            </span>
+                            <ExternalLink className="!size-3 ml-1 hidden shrink-0 min-[375px]:inline-block" />
                           </Button>
                         </div>
                       ))}

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -170,13 +170,13 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="mt-3 flex flex-col gap-6 md:grid md:grid-cols-3 md:items-stretch md:gap-3">
+                    <div className="mt-3 flex flex-col gap-4 sm:gap-5 md:grid md:grid-cols-3 md:items-stretch md:gap-3 lg:gap-4">
                       {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
                         <div
                           key={id}
                           className="flex min-w-0 flex-col items-center gap-2 md:h-full"
                         >
-                          <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
+                          <div className="mx-auto aspect-square w-[min(100%,42vw,10rem)] overflow-hidden rounded-lg border border-border/50 bg-muted/30 sm:w-[min(100%,36vw,11rem)] md:mx-0 md:w-full lg:max-w-none">
                             <img
                               src={imageUrl}
                               alt={`${label} collection`}
@@ -187,7 +187,7 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            className="h-10 w-full whitespace-nowrap px-3 text-xs md:mt-auto md:px-2"
+                            className="h-10 w-[min(100%,42vw,10rem)] whitespace-nowrap px-3 text-xs sm:w-[min(100%,36vw,11rem)] md:mt-auto md:w-full md:px-2"
                             onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
                           >
                             <span className="truncate">{label}</span>

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -170,10 +170,13 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="mt-3 grid min-w-0 grid-cols-3 items-stretch gap-2 sm:gap-3">
+                    <div className="mt-3 grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3 md:items-stretch">
                       {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
-                        <div key={id} className="flex h-full min-w-0 flex-col items-center gap-2">
-                          <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
+                        <div
+                          key={id}
+                          className="flex min-w-0 items-center gap-3 rounded-lg border border-border/50 p-3 md:h-full md:flex-col md:items-center md:gap-2 md:border-0 md:p-0"
+                        >
+                          <div className="h-20 w-20 shrink-0 overflow-hidden rounded-lg border border-border/50 bg-muted/30 md:aspect-square md:h-auto md:w-full">
                             <img
                               src={imageUrl}
                               alt={`${label} collection`}
@@ -184,19 +187,11 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            className="mt-auto h-auto w-full min-w-0 px-2 py-2 text-xs max-[374px]:flex-col max-[374px]:gap-1.5 max-[374px]:whitespace-normal min-[375px]:whitespace-nowrap"
+                            className="h-10 min-w-0 flex-1 whitespace-nowrap px-3 text-xs md:mt-auto md:w-full md:flex-none md:px-2"
                             onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
                           >
-                            <span className="flex w-full items-center justify-center text-center leading-tight max-[374px]:h-10">
-                              {label}
-                            </span>
-                            <span
-                              aria-hidden
-                              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-input bg-background min-[375px]:hidden"
-                            >
-                              <ExternalLink className="!size-3" />
-                            </span>
-                            <ExternalLink className="!size-3 ml-1 hidden shrink-0 min-[375px]:inline-block" />
+                            <span className="truncate">{label}</span>
+                            <ExternalLink className="!size-3 shrink-0" />
                           </Button>
                         </div>
                       ))}

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -170,9 +170,9 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="mt-3 grid min-w-0 grid-cols-3 gap-2 sm:gap-3">
+                    <div className="mt-3 grid min-w-0 grid-cols-3 items-stretch gap-2 sm:gap-3">
                       {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
-                        <div key={id} className="flex min-w-0 flex-col items-center gap-2">
+                        <div key={id} className="flex h-full min-w-0 flex-col items-center gap-2">
                           <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
                             <img
                               src={imageUrl}
@@ -184,10 +184,12 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            className="h-auto w-full min-w-0 px-2 py-2 text-xs max-[374px]:flex-col max-[374px]:gap-1.5 max-[374px]:whitespace-normal min-[375px]:whitespace-nowrap"
+                            className="mt-auto h-auto w-full min-w-0 px-2 py-2 text-xs max-[374px]:flex-col max-[374px]:gap-1.5 max-[374px]:whitespace-normal min-[375px]:whitespace-nowrap"
                             onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
                           >
-                            <span className="text-center leading-tight">{label}</span>
+                            <span className="flex w-full items-center justify-center text-center leading-tight max-[374px]:h-10">
+                              {label}
+                            </span>
                             <span
                               aria-hidden
                               className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-input bg-background min-[375px]:hidden"

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -122,7 +122,7 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
               <p className="text-muted-foreground mb-4">
                 To customize your profile, you need to meet the following requirements:
               </p>
-              <div className="space-y-2 text-left max-w-md mx-auto mb-6">
+              <div className="space-y-2 text-left max-w-2xl mx-auto mb-6">
                 {requiresName && (
                 <div className={`p-3 rounded-lg ${
                   ownsName ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'
@@ -170,18 +170,27 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="flex flex-wrap gap-2 mt-3">
-                      {marketplaceLinks.map(({ id, label, url }) => (
-                        <Button
-                          key={id}
-                          size="sm"
-                          variant="outline"
-                          className="text-xs"
-                          onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
-                        >
-                          {label}
-                          <ExternalLink className="w-3 h-3 ml-1" />
-                        </Button>
+                    <div className="grid grid-cols-3 gap-3 mt-3">
+                      {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
+                        <div key={id} className="flex flex-col items-center gap-2">
+                          <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
+                            <img
+                              src={imageUrl}
+                              alt={`${label} collection`}
+                              className="h-full w-full object-cover"
+                              loading="lazy"
+                            />
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="w-full text-xs"
+                            onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
+                          >
+                            {label}
+                            <ExternalLink className="w-3 h-3 ml-1" />
+                          </Button>
+                        </div>
                       ))}
                     </div>
                   )}

--- a/src/components/liquidation/NFTSelectionModal.tsx
+++ b/src/components/liquidation/NFTSelectionModal.tsx
@@ -170,13 +170,13 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                     </span>
                   </div>
                   {!hasNFTs && (
-                    <div className="mt-3 grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3 md:items-stretch">
+                    <div className="mt-3 flex flex-col gap-6 md:grid md:grid-cols-3 md:items-stretch md:gap-3">
                       {marketplaceLinks.map(({ id, label, url, imageUrl }) => (
                         <div
                           key={id}
-                          className="flex min-w-0 items-center gap-3 rounded-lg border border-border/50 p-3 md:h-full md:flex-col md:items-center md:gap-2 md:border-0 md:p-0"
+                          className="flex min-w-0 flex-col items-center gap-2 md:h-full"
                         >
-                          <div className="h-20 w-20 shrink-0 overflow-hidden rounded-lg border border-border/50 bg-muted/30 md:aspect-square md:h-auto md:w-full">
+                          <div className="w-full aspect-square overflow-hidden rounded-lg border border-border/50 bg-muted/30">
                             <img
                               src={imageUrl}
                               alt={`${label} collection`}
@@ -187,7 +187,7 @@ const NFTSelectionModal: React.FC<NFTSelectionModalProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            className="h-10 min-w-0 flex-1 whitespace-nowrap px-3 text-xs md:mt-auto md:w-full md:flex-none md:px-2"
+                            className="h-10 w-full whitespace-nowrap px-3 text-xs md:mt-auto md:px-2"
                             onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
                           >
                             <span className="truncate">{label}</span>

--- a/src/components/tools/UnitNftDripTool.tsx
+++ b/src/components/tools/UnitNftDripTool.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
 import { getAlgorandNetworkFromNetworkId } from "@/config";
+import { getVoiNautilusCollectionTradeUrl } from "@/config/dorkNftMarketplaceLinks";
 import type { UnitNftDripCampaignConfig } from "@/config/nftDrips";
 import {
   fetchUserNFTs,
@@ -379,7 +380,7 @@ export function UnitNftDripTool({ config, requiredAddress, compact }: UnitNftDri
     };
   }, [ownerAddress, addressOk, tokens, dripRefreshTrigger, config, getAlgod]);
 
-  const collectionUrl = `https://nautilus.sh/#/collection/${config.nftContractId}/trade`;
+  const collectionUrl = getVoiNautilusCollectionTradeUrl(config.nftContractId);
 
   return (
     <div className={cn(compact ? "px-0 py-0" : "mx-auto max-w-3xl px-4 py-8")}>

--- a/src/config/__tests__/dorkNftMarketplaceLinks.test.ts
+++ b/src/config/__tests__/dorkNftMarketplaceLinks.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDorkNftMarketplaceLinks,
+  getVoiNautilusCollectionTradeUrl,
+} from "../dorkNftMarketplaceLinks";
+
+describe("getDorkNftMarketplaceLinks", () => {
+  it("returns DownBad links on Algorand mainnet", () => {
+    const links = getDorkNftMarketplaceLinks("algorand-mainnet");
+
+    expect(links).toHaveLength(3);
+    expect(links.map((link) => link.url)).toEqual([
+      "https://www.downbad.farm/collection/dorks",
+      "https://www.downbad.farm/collection/dorks-v2",
+      "https://www.downbad.farm/collection/chub",
+    ]);
+  });
+
+  it("returns app.nautilus.sh links on Voi mainnet", () => {
+    const links = getDorkNftMarketplaceLinks("voi-mainnet");
+
+    expect(links).toHaveLength(3);
+    expect(links.every((link) => link.url.startsWith("https://app.nautilus.sh/"))).toBe(
+      true
+    );
+    expect(links.map((link) => link.url)).toEqual([
+      "https://app.nautilus.sh/#/collection/313597/trade",
+      "https://app.nautilus.sh/#/collection/894888/trade",
+      "https://app.nautilus.sh/#/collection/313705/trade",
+    ]);
+  });
+});
+
+describe("getVoiNautilusCollectionTradeUrl", () => {
+  it("builds a trade URL for the given contract id", () => {
+    expect(getVoiNautilusCollectionTradeUrl(313597)).toBe(
+      "https://app.nautilus.sh/#/collection/313597/trade"
+    );
+  });
+});

--- a/src/config/__tests__/dorkNftMarketplaceLinks.test.ts
+++ b/src/config/__tests__/dorkNftMarketplaceLinks.test.ts
@@ -5,28 +5,33 @@ import {
 } from "../dorkNftMarketplaceLinks";
 
 describe("getDorkNftMarketplaceLinks", () => {
-  it("returns DownBad links on Algorand mainnet", () => {
+  it("returns DownBad links in Dorks, Chubs, Dorks V2 order on Algorand mainnet", () => {
     const links = getDorkNftMarketplaceLinks("algorand-mainnet");
 
     expect(links).toHaveLength(3);
+    expect(links.map((link) => link.label)).toEqual(["Dorks", "Chubs", "Dorks V2"]);
     expect(links.map((link) => link.url)).toEqual([
       "https://www.downbad.farm/collection/dorks",
-      "https://www.downbad.farm/collection/dorks-v2",
       "https://www.downbad.farm/collection/chub",
+      "https://www.downbad.farm/collection/dorks-v2",
     ]);
+    expect(links.every((link) => link.imageUrl.startsWith("https://ipfs.algonode.xyz/"))).toBe(
+      true
+    );
   });
 
-  it("returns app.nautilus.sh links on Voi mainnet", () => {
+  it("returns app.nautilus.sh links in Dorks, Chubs, Dorks V2 order on Voi mainnet", () => {
     const links = getDorkNftMarketplaceLinks("voi-mainnet");
 
     expect(links).toHaveLength(3);
+    expect(links.map((link) => link.label)).toEqual(["Dorks", "Chubs", "Dorks V2"]);
     expect(links.every((link) => link.url.startsWith("https://app.nautilus.sh/"))).toBe(
       true
     );
     expect(links.map((link) => link.url)).toEqual([
       "https://app.nautilus.sh/#/collection/313597/trade",
-      "https://app.nautilus.sh/#/collection/894888/trade",
       "https://app.nautilus.sh/#/collection/313705/trade",
+      "https://app.nautilus.sh/#/collection/894888/trade",
     ]);
   });
 });

--- a/src/config/dorkNftMarketplaceLinks.ts
+++ b/src/config/dorkNftMarketplaceLinks.ts
@@ -1,0 +1,60 @@
+import type { DorkNftCollectionId } from "@/data/dorkNftAlgorandRegistry";
+import type { NetworkId } from "@/config";
+
+export interface DorkNftMarketplaceLink {
+  id: DorkNftCollectionId;
+  label: string;
+  url: string;
+}
+
+export const VOI_NAUTILUS_MARKETPLACE_ORIGIN = "https://app.nautilus.sh";
+
+const ALGORAND_MAINNET_LINKS: DorkNftMarketplaceLink[] = [
+  {
+    id: "dorks_v1",
+    label: "Dorks",
+    url: "https://www.downbad.farm/collection/dorks",
+  },
+  {
+    id: "dorks_v2",
+    label: "Dorks V2",
+    url: "https://www.downbad.farm/collection/dorks-v2",
+  },
+  {
+    id: "lil_chubs",
+    label: "Chubs",
+    url: "https://www.downbad.farm/collection/chub",
+  },
+];
+
+const VOI_MAINNET_LINKS: DorkNftMarketplaceLink[] = [
+  {
+    id: "dorks_v1",
+    label: "Dorks",
+    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/313597/trade`,
+  },
+  {
+    id: "dorks_v2",
+    label: "Dorks V2",
+    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/894888/trade`,
+  },
+  {
+    id: "lil_chubs",
+    label: "Chubs",
+    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/313705/trade`,
+  },
+];
+
+export function getVoiNautilusCollectionTradeUrl(contractId: number): string {
+  return `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/${contractId}/trade`;
+}
+
+export function getDorkNftMarketplaceLinks(
+  networkId: NetworkId
+): DorkNftMarketplaceLink[] {
+  if (networkId === "algorand-mainnet") {
+    return ALGORAND_MAINNET_LINKS;
+  }
+
+  return VOI_MAINNET_LINKS;
+}

--- a/src/config/dorkNftMarketplaceLinks.ts
+++ b/src/config/dorkNftMarketplaceLinks.ts
@@ -5,45 +5,48 @@ export interface DorkNftMarketplaceLink {
   id: DorkNftCollectionId;
   label: string;
   url: string;
+  imageUrl: string;
 }
 
 export const VOI_NAUTILUS_MARKETPLACE_ORIGIN = "https://app.nautilus.sh";
 
-const ALGORAND_MAINNET_LINKS: DorkNftMarketplaceLink[] = [
+const COLLECTION_MARKETPLACE_ENTRIES = [
   {
-    id: "dorks_v1",
+    id: "dorks_v1" as const,
     label: "Dorks",
-    url: "https://www.downbad.farm/collection/dorks",
+    imageUrl:
+      "https://ipfs.algonode.xyz/ipfs/bafkreiaefdqglsg35ziv6hxud6n2zplimujns2mt553mqzxj2hyvkzophi?optimizer=image&width=400",
+    algorandUrl: "https://www.downbad.farm/collection/dorks",
+    voiContractId: 313597,
   },
   {
-    id: "dorks_v2",
-    label: "Dorks V2",
-    url: "https://www.downbad.farm/collection/dorks-v2",
-  },
-  {
-    id: "lil_chubs",
+    id: "lil_chubs" as const,
     label: "Chubs",
-    url: "https://www.downbad.farm/collection/chub",
+    imageUrl:
+      "https://ipfs.algonode.xyz/ipfs/bafybeibyq4imsplnfqpvrdkavjmupjwzzz3thhf35ea3evr2tbtdfbd53a?optimizer=image&width=400",
+    algorandUrl: "https://www.downbad.farm/collection/chub",
+    voiContractId: 313705,
   },
-];
+  {
+    id: "dorks_v2" as const,
+    label: "Dorks V2",
+    imageUrl:
+      "https://ipfs.algonode.xyz/ipfs/bafybeibl4szt2eayrfnzwqcgbod4wiookybnyjc3ud7xylmqds6ba7jqqe?optimizer=image&width=400",
+    algorandUrl: "https://www.downbad.farm/collection/dorks-v2",
+    voiContractId: 894888,
+  },
+] as const;
 
-const VOI_MAINNET_LINKS: DorkNftMarketplaceLink[] = [
-  {
-    id: "dorks_v1",
-    label: "Dorks",
-    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/313597/trade`,
-  },
-  {
-    id: "dorks_v2",
-    label: "Dorks V2",
-    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/894888/trade`,
-  },
-  {
-    id: "lil_chubs",
-    label: "Chubs",
-    url: `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/313705/trade`,
-  },
-];
+function buildMarketplaceLinks(
+  resolveUrl: (entry: (typeof COLLECTION_MARKETPLACE_ENTRIES)[number]) => string
+): DorkNftMarketplaceLink[] {
+  return COLLECTION_MARKETPLACE_ENTRIES.map((entry) => ({
+    id: entry.id,
+    label: entry.label,
+    imageUrl: entry.imageUrl,
+    url: resolveUrl(entry),
+  }));
+}
 
 export function getVoiNautilusCollectionTradeUrl(contractId: number): string {
   return `${VOI_NAUTILUS_MARKETPLACE_ORIGIN}/#/collection/${contractId}/trade`;
@@ -53,8 +56,10 @@ export function getDorkNftMarketplaceLinks(
   networkId: NetworkId
 ): DorkNftMarketplaceLink[] {
   if (networkId === "algorand-mainnet") {
-    return ALGORAND_MAINNET_LINKS;
+    return buildMarketplaceLinks((entry) => entry.algorandUrl);
   }
 
-  return VOI_MAINNET_LINKS;
+  return buildMarketplaceLinks((entry) =>
+    getVoiNautilusCollectionTradeUrl(entry.voiContractId)
+  );
 }


### PR DESCRIPTION
Summary

Point NFT marketplace links to the correct venues (DownBad on Algorand, app.nautilus.sh on Voi) for Edit Profile and the Voi drip tool.
Centralize marketplace URL helpers with tests, and show collection preview images.
Improve responsive layout for marketplace collection cards across breakpoints.