### PR TITLE
fix(markets): prefer on-chain oracle USD for token prices

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -110,11 +110,57 @@ import {
   type MarketActionTokenParams,
 } from "@/utils/modalPrefetch";
 import { buildMarketHoverHandlers } from "@/utils/modalHoverHandlers";
+import { resolveUsdPerTokenFromMarketInfo } from "@/utils/assetDecimals";
 
 const MAX_CLAIMS_PER_TX = 3;
 
+/** Token decimals for oracle USD math — match `getAssetData` (config wins over stale API rows). */
+function resolveMarketRowTokenDecimals(
+  md: Record<string, unknown>,
+  networkId?: NetworkId
+): number {
+  if (networkId) {
+    const asset = String(md.asset ?? md.symbol ?? "");
+    const poolId =
+      md.poolId != null && String(md.poolId) !== ""
+        ? String(md.poolId)
+        : undefined;
+    const configSymbol =
+      typeof md.configSymbol === "string" ? md.configSymbol : undefined;
+    const rowKey = (md as { _sortKey?: string })._sortKey;
+    const mi = md.marketInfo as { marketId?: string | number } | undefined;
+    const marketContractId =
+      (rowKey ? marketContractIdFromRowCacheKey(rowKey) : undefined) ??
+      (mi?.marketId != null && String(mi.marketId).trim() !== ""
+        ? String(mi.marketId)
+        : undefined);
+
+    const token = resolveTokenForMarketPosition(networkId, {
+      asset,
+      poolId,
+      configSymbol,
+      marketContractId,
+    });
+    const fromConfig = Number(token?.decimals);
+    if (Number.isFinite(fromConfig) && fromConfig > 0) {
+      return fromConfig;
+    }
+  }
+
+  const mi = md.marketInfo as { decimals?: number } | undefined;
+  const fromMi = Number(mi?.decimals);
+  if (Number.isFinite(fromMi) && fromMi > 0) {
+    return fromMi;
+  }
+
+  return 6;
+}
+
 /** Map on-demand market row → PremiumMarketModal `MarketData` (USD fields in whole dollars like the markets table). */
-function normalizeMarketData(md: Record<string, unknown>) {
+function normalizeMarketData(
+  md: Record<string, unknown>,
+  networkId?: NetworkId
+) {
   const totalSupplyUSD = Number(md.totalSupplyUSD ?? 0);
   const totalBorrowUSD = Number(md.totalBorrowUSD ?? 0);
   const supplyUsdWhole = Math.max(0, Math.round(totalSupplyUSD / 1_000_000));
@@ -126,7 +172,9 @@ function normalizeMarketData(md: Record<string, unknown>) {
   const assetSym = String(md.asset ?? md.symbol ?? "").toUpperCase();
   const isWad = assetSym === "WAD";
 
-  let price = 1;
+  const tokenDecimals = resolveMarketRowTokenDecimals(md, networkId);
+
+  let price = 0;
   if (isWad) {
     // WAD-only: oracle is often micro-USD per token; TVL from hook is micro-USD.
     const oracleStr =
@@ -135,28 +183,28 @@ function normalizeMarketData(md: Record<string, unknown>) {
       oracleStr !== "" ? Number.parseFloat(oracleStr) : Number.NaN;
     if (Number.isFinite(oracleUsd) && oracleUsd > 0) {
       price = normalizeWadUsdPerToken(oracleUsd);
-    } else if (
-      supplyTokensHuman > 0 &&
-      Number.isFinite(totalSupplyUSD) &&
-      totalSupplyUSD > 0
-    ) {
-      price = totalSupplyUSD / 1_000_000 / supplyTokensHuman;
     }
-  } else {
-    // All other markets: original TVL + scaled oracle fallback (unchanged).
+  } else if (mi?.price != null) {
+    price = resolveUsdPerTokenFromMarketInfo(
+      {
+        price: String(mi.price),
+        oracleUsdPerToken:
+          typeof mi.oracleUsdPerToken === "number"
+            ? mi.oracleUsdPerToken
+            : undefined,
+      },
+      tokenDecimals
+    );
+  }
+
+  // Fallback: TVL-implied price when oracle field is missing.
+  if (!(price > 0 && Number.isFinite(price))) {
     if (
       supplyTokensHuman > 0 &&
       Number.isFinite(totalSupplyUSD) &&
       totalSupplyUSD > 0
     ) {
       price = totalSupplyUSD / 1_000_000 / supplyTokensHuman;
-    } else if (mi?.price != null) {
-      const tokenPrice = parseFloat(String(mi.price)) || 0;
-      const decimals = Number(mi.decimals ?? 6);
-      if (tokenPrice > 0 && Number.isFinite(decimals)) {
-        price =
-          (tokenPrice * Math.pow(10, decimals + 6)) / Math.pow(10, 12);
-      }
     }
   }
 
@@ -270,6 +318,20 @@ function findMarketRowOnPage(
   }
   const found = pageMarkets.find((m) => String(m.asset) === asset);
   return found ?? null;
+}
+
+/** Prefer full `marketsData` cache (all rows); fall back to current page. */
+function findMarketRow(
+  marketsData: Record<string, Record<string, unknown>>,
+  pageMarkets: Record<string, unknown>[],
+  asset: string,
+  poolId?: string,
+  marketRowKey?: string
+): Record<string, unknown> | null {
+  if (marketRowKey && marketsData[marketRowKey]) {
+    return { ...marketsData[marketRowKey], _sortKey: marketRowKey };
+  }
+  return findMarketRowOnPage(pageMarkets, asset, poolId, marketRowKey);
 }
 
 function networkIdToChainId(
@@ -808,6 +870,7 @@ const MarketsTable = () => {
     loadVisibleMarkets,
     loadAllMarkets,
     isLoading,
+    marketsData,
     wadMintMarket,
     newMarketsCount,
     rewardMarketsCount,
@@ -1605,7 +1668,7 @@ const MarketsTable = () => {
     });
     // Fresh on-chain read for modal (fetchMarketInfo(..., "contract") via useOnDemandMarketData).
     void loadMarketDataWithBypass(
-      marketKeyForOnDemandLoad(poolId, configSymbol, asset)
+      rowKey ?? marketKeyForOnDemandLoad(poolId, configSymbol, asset)
     );
     if (activeAccount?.address) {
       const addr = activeAccount.address;
@@ -1644,15 +1707,17 @@ const MarketsTable = () => {
   // Key off `lastFetched` only — `markets` is remapped often (rewards APR) with new object refs.
   const detailModalRowLastFetched = useMemo(() => {
     if (!detailModal.isOpen || !detailModal.asset) return undefined;
-    const fresh = findMarketRowOnPage(
-      markets as Record<string, unknown>[],
+    const fresh = findMarketRow(
+      marketsData as Record<string, Record<string, unknown>>,
+      marketsForLookup as Record<string, unknown>[],
       detailModal.asset,
       detailModal.poolId,
       detailModal.marketRowKey
     );
     return (fresh as { lastFetched?: number } | undefined)?.lastFetched;
   }, [
-    markets,
+    marketsData,
+    marketsForLookup,
     detailModal.isOpen,
     detailModal.asset,
     detailModal.poolId,
@@ -1662,8 +1727,9 @@ const MarketsTable = () => {
   useEffect(() => {
     if (!detailModal.isOpen || !detailModal.asset) return;
     if (detailModalRowLastFetched === undefined) return;
-    const fresh = findMarketRowOnPage(
-      markets as Record<string, unknown>[],
+    const fresh = findMarketRow(
+      marketsData as Record<string, Record<string, unknown>>,
+      marketsForLookup as Record<string, unknown>[],
       detailModal.asset,
       detailModal.poolId,
       detailModal.marketRowKey
@@ -1686,6 +1752,8 @@ const MarketsTable = () => {
     detailModal.asset,
     detailModal.poolId,
     detailModal.marketRowKey,
+    marketsData,
+    marketsForLookup,
   ]);
 
   // Load all markets when component mounts
@@ -2922,15 +2990,16 @@ const MarketsTable = () => {
       }
 
       // Calculate USD value (same display asset may map to multiple rows)
-      const marketForPrice = marketRowKey
-        ? markets.find(
-            (m) => (m as { _sortKey?: string })._sortKey === marketRowKey
-          )
-        : markets.find((m) => m.asset === asset);
+      const marketForPrice = findMarketRow(
+        marketsData as Record<string, Record<string, unknown>>,
+        marketsForLookup as Record<string, unknown>[],
+        asset,
+        poolId,
+        marketRowKey
+      );
       const tokenPrice = marketForPrice
-        ? (marketForPrice.totalSupplyUSD / marketForPrice.totalSupply || 1) /
-          10 ** 6
-        : 1;
+        ? normalizeMarketData(marketForPrice, currentNetwork as NetworkId).price
+        : 0;
       const balanceUSD = balance * tokenPrice;
 
       console.log({
@@ -3233,7 +3302,7 @@ const MarketsTable = () => {
       portfolioHealthFactor: number | null,
       maxWithdrawUnderlying: number | null
     ): MarketDetailUserPosition => {
-      const norm = normalizeMarketData(row);
+      const norm = normalizeMarketData(row, currentNetwork as NetworkId);
       const price =
         norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
       const assetData = getAssetData(asset, poolId, detailModal.marketRowKey);
@@ -3379,7 +3448,7 @@ const MarketsTable = () => {
             if (maxWithdrawResult?.maxWithdrawUnderlying == null) return;
             setDetailModalUserPosition((prev) => {
               if (!prev) return prev;
-              const norm = normalizeMarketData(row);
+              const norm = normalizeMarketData(row, currentNetwork as NetworkId);
               const price =
                 norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
               const dep =
@@ -3877,7 +3946,10 @@ const MarketsTable = () => {
             chainId={networkIdToChainId(currentNetwork)}
             networkId={currentNetwork}
             rawMarket={detailModal.marketData}
-            marketData={normalizeMarketData(detailModal.marketData)}
+            marketData={normalizeMarketData(
+              detailModal.marketData,
+              currentNetwork as NetworkId
+            )}
             userPosition={detailModalUserPosition ?? undefined}
             userPositionLoadState={detailModalUserPositionLoad}
             onDeposit={() =>

--- a/src/components/market-modal/MarketHeader.tsx
+++ b/src/components/market-modal/MarketHeader.tsx
@@ -4,82 +4,6 @@ import { MarketPoolBadge } from '@/components/markets/MarketPoolBadge';
 import { formatUsdPerTokenDisplay } from '@/lib/utils';
 import { MarketData } from './types';
 
-const SPARK_W = 60;
-const SPARK_H = 18;
-
-const sparklineColorClass = (change24h: number) =>
-  change24h >= 0
-    ? 'text-green-600 dark:text-green-400'
-    : 'text-red-600 dark:text-red-400';
-
-/** Renders last N points of USD price over 24h; flat line if insufficient data. */
-function PriceSparkline({
-  points,
-  change24h,
-}: {
-  points: { time: number; price: number }[];
-  change24h: number;
-}) {
-  const strokeClass = sparklineColorClass(change24h);
-
-  if (points.length < 2) {
-    return (
-      <svg
-        width={SPARK_W}
-        height={SPARK_H}
-        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
-        fill="none"
-        className={`${strokeClass} shrink-0`}
-        aria-hidden
-      >
-        <line
-          x1="0"
-          y1={SPARK_H / 2}
-          x2={String(SPARK_W)}
-          y2={SPARK_H / 2}
-          stroke="currentColor"
-          strokeWidth="2"
-        />
-      </svg>
-    );
-  }
-
-  const prices = points.map((p) => p.price);
-  const minP = Math.min(...prices);
-  const maxP = Math.max(...prices);
-  const range = maxP - minP;
-  const pad = range < 1e-12 ? Math.max(minP * 1e-6, 1e-8) : 0;
-  const lo = minP - pad;
-  const hi = maxP + pad;
-  const denom = hi - lo || 1;
-  const padding = 2;
-
-  const coords = points.map((p, i) => {
-    const x = (i / (points.length - 1)) * SPARK_W;
-    const norm = (p.price - lo) / denom;
-    const y = SPARK_H - padding - norm * (SPARK_H - 2 * padding);
-    return `${x},${y}`;
-  });
-
-  return (
-    <svg
-      width={SPARK_W}
-      height={SPARK_H}
-      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
-      fill="none"
-      className={`${strokeClass} shrink-0`}
-      aria-hidden
-    >
-      <polyline
-        points={coords.join(' ')}
-        stroke="currentColor"
-        strokeWidth="2"
-        fill="none"
-      />
-    </svg>
-  );
-}
-
 export const MarketHeader = ({
   marketData,
   chainId,
@@ -116,24 +40,8 @@ export const MarketHeader = ({
           </div>
         </div>
       </div>
-      <div className="flex flex-row items-center justify-between gap-3 min-w-0 w-full sm:w-auto sm:max-w-[min(100%,11rem)] sm:flex-col sm:items-end sm:justify-center sm:gap-0.5 sm:text-right shrink-0">
-        <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums break-all">
-          ${formatUsdPerTokenDisplay(Number(marketData.price ?? 0))}
-        </div>
-        <div
-          className={`text-sm font-medium flex items-center gap-1 shrink-0 tabular-nums ${
-            marketData.priceChange24h >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}
-        >
-          {marketData.priceChange24h >= 0 ? '+' : ''}
-          {marketData.priceChange24h?.toFixed(2)}%
-          <span className="inline-block align-middle shrink-0" title="24h vs USDC (Mimir)">
-            <PriceSparkline
-              points={marketData.priceHistory ?? []}
-              change24h={marketData.priceChange24h ?? 0}
-            />
-          </span>
-        </div>
+      <div className="text-xl sm:text-2xl font-bold text-foreground tabular-nums break-all sm:text-right shrink-0">
+        ${formatUsdPerTokenDisplay(Number(marketData.price ?? 0))}
       </div>
     </div>
   );

--- a/src/components/market-modal/PremiumMarketModal.tsx
+++ b/src/components/market-modal/PremiumMarketModal.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { getAllTokensWithDisplayInfo, getMarketLabel, type NetworkId } from '@/config';
-import { useMimirTokenPrice24h } from '@/hooks/useMimirTokenPrice24h';
 import { MarketData, UserPosition, UserPositionLoadState } from './types';
 import { MarketHeader } from './MarketHeader';
 import { UserPositionBar } from './UserPositionBar';
@@ -64,34 +63,6 @@ export const PremiumMarketModal = ({
     return getMarketLabel(networkId, poolId);
   }, [rawMarket, networkId]);
 
-  const mimirPriceSymbol = useMemo(() => {
-    const cs = rawMarket?.configSymbol;
-    return typeof cs === "string" && cs.trim() !== ""
-      ? cs.trim()
-      : marketData.symbol;
-  }, [rawMarket, marketData.symbol]);
-
-  const {
-    priceChange24h: mimirChange24h,
-    priceHistory: mimirHistory,
-  } = useMimirTokenPrice24h(mimirPriceSymbol, isOpen, {
-    networkId,
-    configSymbol:
-      typeof rawMarket?.configSymbol === "string"
-        ? rawMarket.configSymbol
-        : undefined,
-  });
-
-  const headerMarketData = useMemo((): MarketData => {
-    const mergedHistory =
-      mimirHistory.length > 0 ? mimirHistory : (marketData.priceHistory ?? []);
-    return {
-      ...marketData,
-      priceChange24h: mimirChange24h,
-      priceHistory: mergedHistory,
-    };
-  }, [marketData, mimirChange24h, mimirHistory]);
-
   const explorerIds = useMemo(() => {
     if (!networkId) {
       return { poolAppId: undefined as string | undefined, underlyingAssetId: undefined as string | undefined };
@@ -118,13 +89,13 @@ export const PremiumMarketModal = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl w-full min-w-0 min-h-0 max-h-[min(90dvh,90vh)] flex flex-col overflow-hidden px-0 py-0 dorkfi-dark-bg-modal rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl card-hover hover:shadow-lg hover:border-ocean-teal/40 transition-all">
+      <DialogContent className="max-w-2xl w-full min-w-0 min-h-0 max-h-[min(90dvh,90vh)] flex flex-col overflow-hidden px-0 py-0 bg-gradient-to-br from-blue-50 to-cyan-50 dark:from-slate-900 dark:to-slate-800 text-slate-800 dark:text-white rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl card-hover hover:shadow-lg hover:border-ocean-teal/40 transition-all">
         <DialogTitle className="sr-only">{marketData.symbol} Market Details</DialogTitle>
         <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain rounded-xl">
           <div className="flex flex-col gap-3 sm:gap-4 px-3 pb-4 pt-10 pr-11 sm:px-4 sm:pt-4 sm:pr-10 min-w-0 w-full max-w-full box-border">
 
             <MarketHeader
-              marketData={headerMarketData}
+              marketData={marketData}
               chainId={chainId}
               marketLabel={marketLabel}
             />

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { fetchMarketInfo } from '@/services/lendingService';
 import { getAllTokensWithDisplayInfo } from '@/config';
 import { useNetwork } from '@/contexts/NetworkContext';
-import { usdPerTokenFromMarketInfoPrice } from '@/utils/assetDecimals';
+import { resolveUsdPerTokenFromMarketInfo } from '@/utils/assetDecimals';
 import { withRpcReadCache } from '@/utils/rpcReadCache';
 
 interface UseTokenPriceResult {
@@ -39,7 +39,7 @@ async function fetchTokenPriceUsd(
         );
         const decimals = otherToken.decimals ?? 6;
         if (marketInfo) {
-          const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
+          const usd = resolveUsdPerTokenFromMarketInfo(marketInfo, decimals);
           const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
           if (marketPrice != null && marketPrice > 0) {
             return marketPrice;
@@ -59,7 +59,7 @@ async function fetchTokenPriceUsd(
 
   const decimals = token.decimals ?? 6;
   if (marketInfo) {
-    const usd = usdPerTokenFromMarketInfoPrice(marketInfo.price, decimals);
+    const usd = resolveUsdPerTokenFromMarketInfo(marketInfo, decimals);
     const marketPrice = Number.isFinite(usd) && usd > 0 ? usd : null;
     if (marketPrice != null && marketPrice > 0) {
       return marketPrice;

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { formatUsdPerTokenDisplay } from "../utils";
+
+describe("formatUsdPerTokenDisplay", () => {
+  it("uses 2 decimals for prices ≥ $1", () => {
+    expect(formatUsdPerTokenDisplay(1)).toBe("1.00");
+    expect(formatUsdPerTokenDisplay(66_610.128)).toBe("66,610.13");
+  });
+
+  it("keeps 3–4 decimals for $0.01–$1 (e.g. UNIT)", () => {
+    expect(formatUsdPerTokenDisplay(0.616)).toBe("0.616");
+    expect(formatUsdPerTokenDisplay(0.6164)).toBe("0.6164");
+    expect(formatUsdPerTokenDisplay(0.62)).toBe("0.620");
+  });
+
+  it("uses extra precision below $0.01", () => {
+    expect(formatUsdPerTokenDisplay(0.00123)).toBe("0.00123");
+  });
+
+  it("handles zero and non-finite", () => {
+    expect(formatUsdPerTokenDisplay(0)).toBe("0.00");
+    expect(formatUsdPerTokenDisplay(NaN)).toBe("0.00");
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,10 +11,6 @@ function stripTrailingZerosDecimal(s: string): string {
   return s.replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.$/, "")
 }
 
-/**
- * Format USD price per whole token for UI: 2 decimals when ≥ $0.01; extra decimals
- * when the value would otherwise show as $0.00 (e.g. VOI).
- */
 /** Round a USD amount to the nearest cent (half-up). */
 export function roundUsdToCents(value: number): number {
   if (value == null || !Number.isFinite(value)) return 0;
@@ -50,24 +46,32 @@ export function normalizeWadUsdPerToken(priceUsd: number): number {
   return priceUsd;
 }
 
+/**
+ * Format USD price per whole token for UI.
+ * - ≥ $1: 2 decimals (e.g. USDC, BTC)
+ * - $0.01–$1: 3–4 decimals so mid-priced assets (e.g. UNIT $0.616) are not rounded to cents
+ * - < $0.01: enough decimals to avoid showing $0.00 (e.g. VOI)
+ */
 export function formatUsdPerTokenDisplay(price: number): string {
   if (price == null || !Number.isFinite(price)) return "0.00"
   if (price === 0) return "0.00"
 
   const abs = Math.abs(price)
-  if (abs >= 0.01) {
+  if (abs >= 1) {
     return price.toLocaleString("en-US", {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     })
   }
-
-  for (let d = 3; d <= 10; d++) {
-    const s = price.toFixed(d)
-    if (parseFloat(s) !== 0) {
-      return stripTrailingZerosDecimal(s)
-    }
+  if (abs >= 0.01) {
+    return price.toLocaleString("en-US", {
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 4,
+    })
   }
+
+  const dust = stripTrailingZerosDecimal(price.toFixed(8))
+  if (dust !== "0" && dust !== "0.0") return dust
 
   return stripTrailingZerosDecimal(price.toExponential(4))
 }

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -44,6 +44,11 @@ import {
   UserData,
   GlobalUserData,
 } from "@/clients/DorkFiLendingPoolClient";
+import { APP_SPEC as PriceOracleAppSpec } from "@/clients/PriceOracleClient";
+import {
+  marketInfoFormattedPriceFromUsdPerToken,
+  usdPerTokenFromOracleContractRaw,
+} from "@/utils/assetDecimals";
 import algosdk from "algosdk";
 import BigNumber from "bignumber.js";
 import { withRpcReadCache } from "@/utils/rpcReadCache";
@@ -167,6 +172,10 @@ export interface MarketInfo {
   reservesAmount?: string;
   /** Market `lastUpdateTime` from chain as ISO 8601. */
   chainLastUpdateIso?: string;
+  /** USD per token from price-oracle contract when fresher than `get_market.price`. */
+  oracleUsdPerToken?: number;
+  /** Unix seconds from price-oracle `get_price_with_timestamp`. */
+  oraclePriceTimestampSec?: number;
   // APY calculation results
   apyCalculation?: APYCalculationResult;
   borrowApyCalculation?: APYCalculationResult;
@@ -460,6 +469,132 @@ export const enhanceAVMMarketInfo = (
 
 /** Which on-chain read to use for market state in {@link fetchMarketInfoFromContract}. */
 export type FetchMarketInfoContractMethod = "sync_market" | "get_market";
+
+const ORACLE_PRICE_CACHE_TTL_MS = 60_000;
+
+/**
+ * On Pool A, fWBTC's price-oracle feed tracks spot BTC; goBTC's own oracle entry can lag.
+ * When resolving goBTC display price, also consider these reference market contract IDs.
+ */
+const ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS: Partial<
+  Record<string, string[]>
+> = {
+  "3333688282": ["3575837891"],
+};
+
+async function readOracleUsdPerToken(
+  networkId: NetworkId,
+  oracleKey: string,
+  tokenDecimals: number
+): Promise<{ usd: number; timestampSec: number } | null> {
+  if (!oracleKey || !Number.isFinite(Number(oracleKey))) return null;
+  const networkConfig = getNetworkConfig(networkId);
+  const oracleAppId = networkConfig.contracts?.priceOracle;
+  if (!oracleAppId || !isAlgorandCompatibleNetwork(networkId)) return null;
+
+  const cacheKey = `oracleUsd:${networkId}:${oracleKey}:${tokenDecimals}`;
+  return withRpcReadCache(
+    cacheKey,
+    async () => {
+      try {
+        const clients = await algorandService.initializeClientsForReads(
+          networkConfig.walletNetworkId as AlgorandNetwork
+        );
+        const ci = new CONTRACT(
+          Number(oracleAppId),
+          clients.algod,
+          undefined,
+          { ...PriceOracleAppSpec.contract, events: [] },
+          {
+            addr: algosdk.encodeAddress(
+              algosdk.getApplicationAddress(Number(oracleAppId)).publicKey
+            ),
+            sk: new Uint8Array(),
+          }
+        );
+        ci.setFee(5000);
+        const result = await ci.get_price_with_timestamp(Number(oracleKey));
+        if (!result.success || !result.returnValue) return null;
+        const [price, timestamp] = result.returnValue as [bigint, bigint];
+        if (price === 0n || timestamp === 0n) return null;
+        const usd = usdPerTokenFromOracleContractRaw(price, tokenDecimals);
+        if (!Number.isFinite(usd) || usd <= 0) return null;
+        return { usd, timestampSec: Number(timestamp) };
+      } catch (error) {
+        console.warn("readOracleUsdPerToken failed", {
+          networkId,
+          oracleKey,
+          error,
+        });
+        return null;
+      }
+    },
+    ORACLE_PRICE_CACHE_TTL_MS
+  );
+}
+
+/** Prefer price-oracle USD when available (e.g. goBTC oracle tracks spot closer than stale `get_market`). */
+async function applyOraclePriceToMarketInfo(
+  marketInfo: MarketInfo,
+  market: MarketData,
+  token: {
+    underlyingContractId?: string;
+    assetId?: string;
+    underlyingAssetId?: string;
+  },
+  tokenConfig: TokenConfig | undefined,
+  networkId: NetworkId
+): Promise<void> {
+  const tokenDecimals = marketInfo.decimals || 6;
+  const oracleKeys = [
+    marketInfo.marketId,
+    token.underlyingContractId,
+    tokenConfig?.contractId,
+    token.underlyingAssetId,
+    token.assetId,
+    tokenConfig?.assetId,
+  ]
+    .map((k) => (k != null ? String(k).trim() : ""))
+    .filter((k, i, arr) => k !== "" && arr.indexOf(k) === i);
+
+  const candidates: Array<{ usd: number; timestampSec: number }> = [];
+
+  for (const key of oracleKeys) {
+    const oracle = await readOracleUsdPerToken(networkId, key, tokenDecimals);
+    if (oracle) candidates.push(oracle);
+  }
+
+  const sym = marketInfo.symbol.toUpperCase();
+  const btcRefMarkets =
+    ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS[marketInfo.poolId];
+  if (btcRefMarkets && sym === "GOBTC") {
+    for (const refMarketId of btcRefMarkets) {
+      if (oracleKeys.includes(refMarketId)) continue;
+      const refOracle = await readOracleUsdPerToken(
+        networkId,
+        refMarketId,
+        tokenDecimals
+      );
+      if (refOracle) candidates.push(refOracle);
+    }
+  }
+
+  if (candidates.length === 0) return;
+
+  const best = candidates.reduce((a, b) => {
+    if (b.timestampSec !== a.timestampSec) {
+      return b.timestampSec > a.timestampSec ? b : a;
+    }
+    return b.usd > a.usd ? b : a;
+  });
+
+  marketInfo.oracleUsdPerToken = best.usd;
+  marketInfo.oraclePriceTimestampSec = best.timestampSec;
+  marketInfo.price = marketInfoFormattedPriceFromUsdPerToken(
+    best.usd,
+    tokenDecimals
+  );
+}
 
 export const fetchMarketInfoFromContract = async (
   poolId: string,
@@ -850,6 +985,14 @@ export const fetchMarketInfo = async (
         apyCalculation,
         borrowApyCalculation,
       };
+
+      await applyOraclePriceToMarketInfo(
+        marketInfo,
+        market,
+        token,
+        tokenConfig,
+        networkId
+      );
 
       console.log("fetchMarketInfo marketInfo", { marketInfo, marketData });
 

--- a/src/utils/__tests__/assetDecimals.test.ts
+++ b/src/utils/__tests__/assetDecimals.test.ts
@@ -9,6 +9,9 @@ import {
   getTokenPriceFromOracle,
   usdPerTokenFromMarketInfoFormattedPrice,
   usdPerTokenFromMarketInfoPrice,
+  usdPerTokenFromOracleContractRaw,
+  marketInfoFormattedPriceFromUsdPerToken,
+  resolveUsdPerTokenFromMarketInfo,
   usdValueForHumanTokenAmount,
 } from "../assetDecimals";
 
@@ -148,5 +151,44 @@ describe("usdValueForHumanTokenAmount", () => {
     expect(usdValueForHumanTokenAmount(1, 0)).toBe(0);
     expect(usdValueForHumanTokenAmount(NaN, 1)).toBe(0);
     expect(usdValueForHumanTokenAmount(1, NaN)).toBe(0);
+  });
+});
+
+describe("usdPerTokenFromOracleContractRaw", () => {
+  it("converts goBTC oracle raw to ~USD (÷10^4 for 8 decimals)", () => {
+    const raw = 643_689_073;
+    expect(usdPerTokenFromOracleContractRaw(raw, 8)).toBeCloseTo(64_368.91, 1);
+  });
+
+  it("converts 6-decimal oracle raw (÷10^6)", () => {
+    expect(usdPerTokenFromOracleContractRaw(7_120_000, 6)).toBe(7.12);
+  });
+});
+
+describe("resolveUsdPerTokenFromMarketInfo", () => {
+  it("prefers oracleUsdPerToken when set", () => {
+    expect(
+      resolveUsdPerTokenFromMarketInfo(
+        { price: "629064979", oracleUsdPerToken: 64_368.91 },
+        8
+      )
+    ).toBe(64_368.91);
+  });
+
+  it("falls back to market price field", () => {
+    expect(
+      resolveUsdPerTokenFromMarketInfo({ price: "7120000" }, 6)
+    ).toBe(7.12);
+  });
+});
+
+describe("marketInfoFormattedPriceFromUsdPerToken", () => {
+  it("round-trips with usdPerTokenFromMarketInfoFormattedPrice", () => {
+    const usd = 64_368.9073;
+    const formatted = marketInfoFormattedPriceFromUsdPerToken(usd, 8);
+    expect(usdPerTokenFromMarketInfoFormattedPrice(formatted, 8)).toBeCloseTo(
+      usd,
+      4
+    );
   });
 });

--- a/src/utils/assetDecimals.ts
+++ b/src/utils/assetDecimals.ts
@@ -74,6 +74,50 @@ export function usdPerTokenFromMarketInfoFormattedPrice(
  * Do **not** return the formatted number as-is when it is below 1e9 — values like `7120000`
  * are common and skipping the oracle divisor inflates USD by ~1e6 for 6-decimal assets.
  */
+/**
+ * USD per 1 token from the on-chain price oracle contract (`get_price_with_timestamp`).
+ * Raw integer uses the same 12-decimal scale as `get_market` (÷ 10^(12 − tokenDecimals)).
+ */
+export function usdPerTokenFromOracleContractRaw(
+  rawPrice: string | number | bigint,
+  tokenDecimals: number
+): number {
+  const rawStr =
+    typeof rawPrice === "bigint"
+      ? rawPrice.toString()
+      : String(rawPrice).replace(/,/g, "").trim();
+  if (rawStr === "" || rawStr === "0") return 0;
+  const n = Number(rawStr);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return getTokenPriceFromOracle(n, tokenDecimals);
+}
+
+/** Encode human USD/token as `MarketInfo.price` (post-÷1e18 oracle scale) for existing callers. */
+export function marketInfoFormattedPriceFromUsdPerToken(
+  usdPerToken: number,
+  tokenDecimals: number
+): string {
+  if (!Number.isFinite(usdPerToken) || usdPerToken <= 0) return "0";
+  return new BigNumber(usdPerToken)
+    .multipliedBy(new BigNumber(10).pow(12 - tokenDecimals))
+    .toFixed(12);
+}
+
+/**
+ * Prefer fresher price-oracle USD when `fetchMarketInfo` attached it; otherwise decode
+ * `marketInfo.price` from the lending pool `get_market` field.
+ */
+export function resolveUsdPerTokenFromMarketInfo(
+  marketInfo: { price: string; oracleUsdPerToken?: number },
+  tokenDecimals: number
+): number {
+  const oracle = marketInfo.oracleUsdPerToken;
+  if (typeof oracle === "number" && Number.isFinite(oracle) && oracle > 0) {
+    return oracle;
+  }
+  return usdPerTokenFromMarketInfoPrice(marketInfo.price, tokenDecimals);
+}
+
 export function usdPerTokenFromMarketInfoPrice(
   priceField: string | number | undefined | null,
   tokenDecimals: number


### PR DESCRIPTION
## Summary
- Read fresher USD/token from the on-chain price oracle in `fetchMarketInfo` (with goBTC → fWBTC reference fallback on Pool A) and prefer that over stale `get_market.price`.
- Normalize market modal/table USD using config token decimals and shared `resolveUsdPerTokenFromMarketInfo` helpers so oracle scaling matches asset decimals.
- Improve `formatUsdPerTokenDisplay` for mid-priced tokens ($0.01–$1) and remove the Mimir 24h change/sparkline from the market modal header.

## Test plan
- [ ] Open goBTC (and other BTC-related) market modal on Algorand Pool A — USD/token should track spot more closely than before
- [ ] Spot-check USDC, UNIT, and a low-priced asset (e.g. VOI) — header price formatting looks correct (2 / 3–4 / dust decimals)
- [ ] Confirm market modal no longer shows 24h % or sparkline; price still updates from market data
- [ ] Supply/borrow USD estimates in markets table align with the modal price for the same row
- [ ] Run `assetDecimals` and `formatUsdPerTokenDisplay` unit tests


Made with [Cursor](https://cursor.com)