### PR TITLE
perf(portfolio): faster market hydrate and safer borrow max UX

### DIFF
--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -109,6 +109,7 @@ import {
 import {
   createDebouncedPrefetch,
   warmMarketDetailUserPositionRpc,
+  warmBorrowModalMaxAndPool,
   poolIdFromMarketRow,
   marketRowKeyFromMarket,
   type MarketActionTokenParams,
@@ -1305,11 +1306,15 @@ const MarketsTable = () => {
     void (async () => {
       try {
         if (activeAccount?.address) {
-          const globalData = await fetchUserGlobalData(
-            activeAccount.address,
-            currentNetwork
-          );
-          setUserGlobalData(globalData);
+          warmBorrowModalMaxAndPool({
+            userAddress: activeAccount.address,
+            networkId: currentNetwork as NetworkId,
+            asset,
+            poolId,
+            configSymbol,
+            marketId: marketContractIdFromRowCacheKey(marketRowKey),
+            marketRowKey,
+          });
 
           const token = resolveTokenForDisplayedAsset(
             asset,
@@ -1317,33 +1322,36 @@ const MarketsTable = () => {
             marketRowKey
           );
 
-          if (token && token.poolId && token.underlyingContractId) {
-            const borrowData = await fetchUserBorrowBalance(
-              activeAccount.address,
-              token.poolId,
-              token.underlyingContractId,
-              currentNetwork
-            );
-            setUserBorrowBalance(borrowData?.balance || 0);
-          } else {
-            setUserBorrowBalance(0);
-          }
+          const [globalData, borrowData, poolCollateralRows] =
+            await Promise.all([
+              fetchUserGlobalData(activeAccount.address, currentNetwork),
+              token && token.poolId && token.underlyingContractId
+                ? fetchUserBorrowBalance(
+                    activeAccount.address,
+                    token.poolId,
+                    token.underlyingContractId,
+                    currentNetwork
+                  )
+                : Promise.resolve(null),
+              poolId != null && poolId !== ""
+                ? fetchPoolCollateralMarketRowsForDeposit(
+                    activeAccount.address,
+                    currentNetwork as NetworkId,
+                    poolId
+                  ).catch((e) => {
+                    console.error(
+                      "Error loading pool collateral markets for borrow:",
+                      e
+                    );
+                    return null;
+                  })
+                : Promise.resolve(null),
+            ]);
 
-          if (poolId != null && poolId !== "") {
-            try {
-              const poolCollateralRows =
-                await fetchPoolCollateralMarketRowsForDeposit(
-                  activeAccount.address,
-                  currentNetwork as NetworkId,
-                  poolId
-                );
-              setDepositPoolCollateralMarkets(poolCollateralRows);
-            } catch (e) {
-              console.error(
-                "Error loading pool collateral markets for borrow:",
-                e
-              );
-            }
+          setUserGlobalData(globalData);
+          setUserBorrowBalance(borrowData?.balance || 0);
+          if (poolCollateralRows) {
+            setDepositPoolCollateralMarkets(poolCollateralRows);
           }
         } else {
           setUserGlobalData(null);

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -27,6 +27,7 @@ import { signAndSendSyncUserMarketsForPriceChangeTx } from "@/utils/syncUserMark
 import {
   fetchUserGlobalData,
   fetchAllMarkets,
+  collectPositionMarketKeys,
   fetchUserBorrowBalance,
   fetchUserDepositBalance,
   enhanceAVMMarketInfo,
@@ -35,7 +36,17 @@ import {
   liquidateCrossMarket,
   fetchUserDataFromChain,
   postRefreshMarketDataSnapshot,
+  type MarketInfo,
 } from "@/services/lendingService";
+import {
+  hydratePortfolioNetworkMarketsPhaseA,
+  refinePortfolioMarketsPhaseB,
+  gapFillPortfolioMarkets,
+  readPortfolioMarketsSessionCache,
+  writePortfolioMarketsSessionCache,
+  marketInfosFromMarketsTableSession,
+  mergePortfolioMarketRows,
+} from "@/utils/portfolioMarketHydrate";
 import {
   estimateFolksDepositMintedFAssetAmount,
   folksFAssetHumanToUnderlyingHuman,
@@ -84,10 +95,14 @@ import {
   PortfolioPositionsFilteredEmptyState,
 } from "@/components/portfolio/PortfolioPositionsFilterBar";
 import PortfolioPositionsCardHeader from "@/components/portfolio/PortfolioPositionsCardHeader";
-import { usdPerTokenFromMarketInfoPrice } from "@/utils/assetDecimals";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
+import {
+  portfolioUsdCacheKey,
+  resolveWithLastGoodPortfolioUsd,
+} from "@/utils/portfolioUsdCache";
 import {
   createDebouncedPrefetch,
   warmBorrowModalMaxAndPool,
@@ -245,9 +260,130 @@ function folksUnderlyingUsdFallbackSamePool(
     marketId: ref.underlyingContractId,
     poolId,
     displaySymbol: ref.symbol,
-  }) as { price?: string | number } | undefined;
-  if (!m?.price) return 0;
-  return usdPerTokenFromMarketInfoPrice(m.price, ref.decimals);
+  });
+  return usdPerTokenFromPortfolioMarketRow(m, ref.decimals, {
+    displaySymbol: ref.symbol,
+  });
+}
+
+/** When wBTC/goBTC market price is missing, reuse a same-pool BTC-family market with a valid price. */
+function btcFamilyUsdFallbackSamePool(
+  marketRows: unknown[],
+  networkId: NetworkId,
+  poolId: string,
+  currentUnderlyingMarketId: string
+): number {
+  const tokens = getAllTokensWithDisplayInfo(networkId);
+  const preferred = tokens.filter((t) => {
+    if (String(t.poolId) !== String(poolId)) return false;
+    if (
+      String(t.underlyingContractId ?? "") === String(currentUnderlyingMarketId)
+    ) {
+      return false;
+    }
+    const key = String(t.configKey ?? t.originalSymbol ?? t.symbol).toUpperCase();
+    return key === "GOBTC" || key === "WBTC" || key === "BTC";
+  });
+  // Prefer goBTC / fWBTC (Folks) rows — fresher BTC oracle feed on Pool A
+  const ordered = [...preferred].sort((a, b) => {
+    const score = (t: (typeof preferred)[number]) => {
+      const id = String(t.underlyingContractId ?? "");
+      if (id === "3575837891") return 0;
+      const key = String(t.configKey ?? t.originalSymbol ?? "").toUpperCase();
+      if (key === "GOBTC") return 1;
+      return 2;
+    };
+    return score(a) - score(b);
+  });
+  for (const ref of ordered) {
+    if (!ref.underlyingContractId) continue;
+    const m = marketRowForPortfolioPosition(marketRows, {
+      marketId: ref.underlyingContractId,
+      poolId,
+      displaySymbol: ref.symbol,
+    });
+    const usd = usdPerTokenFromPortfolioMarketRow(m, ref.decimals, {
+      displaySymbol: ref.symbol,
+    });
+    if (usd > 0) return usd;
+  }
+  return 0;
+}
+
+function resolvePortfolioPositionUsdPerToken(options: {
+  market: unknown;
+  tokenDecimals: number;
+  networkId: NetworkId;
+  poolId?: string | null;
+  marketId?: string | null;
+  configKey?: string;
+  originalSymbol?: string;
+  displaySymbol?: string;
+  marketRows: unknown[];
+}): number {
+  let tokenPrice = usdPerTokenFromPortfolioMarketRow(
+    options.market,
+    options.tokenDecimals,
+    { displaySymbol: options.displaySymbol }
+  );
+
+  const cacheKey =
+    options.poolId != null && options.marketId
+      ? portfolioUsdCacheKey(
+          String(options.networkId),
+          String(options.poolId),
+          String(options.marketId)
+        )
+      : null;
+
+  if (tokenPrice > 0) {
+    return resolveWithLastGoodPortfolioUsd(tokenPrice, cacheKey);
+  }
+
+  const cfgRaw = getTokenConfig(
+    options.networkId,
+    options.configKey ?? options.originalSymbol ?? options.displaySymbol ?? ""
+  );
+  const tc = Array.isArray(cfgRaw)
+    ? cfgRaw.find((c) => String(c.poolId) === String(options.poolId)) ??
+      cfgRaw[0]
+    : cfgRaw;
+  if (
+    getAnyFolksAdapter(tc ?? {}) &&
+    options.poolId != null &&
+    options.marketId
+  ) {
+    tokenPrice = folksUnderlyingUsdFallbackSamePool(
+      options.marketRows,
+      options.networkId,
+      String(options.poolId),
+      String(options.marketId)
+    );
+    if (tokenPrice > 0) {
+      return resolveWithLastGoodPortfolioUsd(tokenPrice, cacheKey);
+    }
+  }
+
+  const sym = String(
+    options.configKey ?? options.originalSymbol ?? options.displaySymbol ?? ""
+  ).toUpperCase();
+  if (
+    (sym === "WBTC" || sym === "GOBTC" || sym === "BTC") &&
+    options.poolId != null &&
+    options.marketId
+  ) {
+    tokenPrice = btcFamilyUsdFallbackSamePool(
+      options.marketRows,
+      options.networkId,
+      String(options.poolId),
+      String(options.marketId)
+    );
+    if (tokenPrice > 0) {
+      return resolveWithLastGoodPortfolioUsd(tokenPrice, cacheKey);
+    }
+  }
+
+  return resolveWithLastGoodPortfolioUsd(0, cacheKey);
 }
 
 function isExcludedPortfolioPositionRow(pos: {
@@ -697,10 +833,13 @@ const Portfolio = () => {
 
   console.log("marketData", marketData);
 
-  // Human USD per 1 underlying token for `MarketInfo` rows (see `usdPerTokenFromMarketInfoPrice`).
+  // Human USD per 1 underlying token for `MarketInfo` rows (oracle-aware).
   const formatPriceFromContract = useCallback(
     (contractPrice: string | number, tokenDecimals: number) =>
-      usdPerTokenFromMarketInfoPrice(contractPrice, tokenDecimals),
+      usdPerTokenFromPortfolioMarketRow(
+        { price: contractPrice },
+        tokenDecimals
+      ),
     []
   );
 
@@ -901,35 +1040,22 @@ const Portfolio = () => {
               networkId
             );
 
-            let tokenPrice = market?.price
-              ? usdPerTokenFromMarketInfoPrice(market.price, token.decimals)
-              : 0;
-            if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-              const cfg = getTokenConfig(
-                networkId as NetworkId,
-                token.configKey ?? token.originalSymbol ?? ""
-              );
-              const tc = Array.isArray(cfg)
-                ? cfg.find((c) => String(c.poolId) === String(token.poolId)) ??
-                cfg[0]
-                : cfg;
-              if (getAnyFolksAdapter(tc ?? {})) {
-                tokenPrice = folksUnderlyingUsdFallbackSamePool(
-                  markets,
-                  networkId as NetworkId,
-                  String(token.poolId),
-                  String(token.underlyingContractId)
-                );
-              }
-            }
-            if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-              tokenPrice = 1;
-            }
+            let tokenPrice = resolvePortfolioPositionUsdPerToken({
+              market,
+              tokenDecimals: token.decimals,
+              networkId: networkId as NetworkId,
+              poolId: token.poolId,
+              marketId: token.underlyingContractId,
+              configKey: token.configKey,
+              originalSymbol: token.originalSymbol,
+              displaySymbol: token.symbol,
+              marketRows: markets,
+            });
 
             console.log(`Deposit position for ${token.symbol}:`, {
               depositBalance,
               nTokenBalance,
-              marketPrice: market?.price,
+              marketPrice: (market as { price?: unknown } | undefined)?.price,
               tokenPrice: tokenPrice,
               calculatedValue: depositBalance * tokenPrice,
               marketFound: !!market,
@@ -957,30 +1083,17 @@ const Portfolio = () => {
 
           // Add borrow position if user has borrows
           if (borrowBalance && borrowBalance > 0) {
-            let tokenPrice = market?.price
-              ? usdPerTokenFromMarketInfoPrice(market.price, token.decimals)
-              : 0;
-            if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-              const cfg = getTokenConfig(
-                networkId as NetworkId,
-                token.configKey ?? token.originalSymbol ?? ""
-              );
-              const tc = Array.isArray(cfg)
-                ? cfg.find((c) => String(c.poolId) === String(token.poolId)) ??
-                cfg[0]
-                : cfg;
-              if (getAnyFolksAdapter(tc ?? {})) {
-                tokenPrice = folksUnderlyingUsdFallbackSamePool(
-                  markets,
-                  networkId as NetworkId,
-                  String(token.poolId),
-                  String(token.underlyingContractId)
-                );
-              }
-            }
-            if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-              tokenPrice = 1;
-            }
+            let tokenPrice = resolvePortfolioPositionUsdPerToken({
+              market,
+              tokenDecimals: token.decimals,
+              networkId: networkId as NetworkId,
+              poolId: token.poolId,
+              marketId: token.underlyingContractId,
+              configKey: token.configKey,
+              originalSymbol: token.originalSymbol,
+              displaySymbol: token.symbol,
+              marketRows: markets,
+            });
 
             console.log(`Borrow position for ${token.symbol}:`, {
               borrowBalance,
@@ -1132,9 +1245,9 @@ const Portfolio = () => {
           // Find token matching marketId and poolId
           const token = tokens.find(
             (t) =>
-              (t.underlyingContractId === marketId ||
-                t.originalContractId === marketId) &&
-              t.poolId === appId
+              (String(t.underlyingContractId ?? "") === String(marketId) ||
+                String(t.originalContractId ?? "") === String(marketId)) &&
+              String(t.poolId ?? "") === String(appId)
           );
 
           if (!token) {
@@ -1238,30 +1351,18 @@ const Portfolio = () => {
             return; // Skip zero balances
           }
 
-          // Get token price (MarketInfo.price is already human USD/token; Folks f-asset may need ALGO oracle fallback)
-          let tokenPrice = market?.price
-            ? usdPerTokenFromMarketInfoPrice(market.price, token.decimals)
-            : 0;
-          if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            const cfg = getTokenConfig(
-              networkId as NetworkId,
-              token.configKey ?? token.originalSymbol ?? ""
-            );
-            const tc = Array.isArray(cfg)
-              ? cfg.find((c) => String(c.poolId) === String(appId)) ?? cfg[0]
-              : cfg;
-            if (getAnyFolksAdapter(tc ?? {})) {
-              tokenPrice = folksUnderlyingUsdFallbackSamePool(
-                marketData,
-                networkId as NetworkId,
-                appId,
-                marketId
-              );
-            }
-          }
-          if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            tokenPrice = 1;
-          }
+          // Get token price (oracle-aware; Folks/BTC family fallbacks — never invent $1)
+          const tokenPrice = resolvePortfolioPositionUsdPerToken({
+            market,
+            tokenDecimals: token.decimals,
+            networkId: networkId as NetworkId,
+            poolId: appId,
+            marketId,
+            configKey: token.configKey,
+            originalSymbol: token.originalSymbol,
+            displaySymbol: token.symbol,
+            marketRows: marketData,
+          });
 
           // Get APY
           const apy =
@@ -1386,9 +1487,9 @@ const Portfolio = () => {
           // Find token matching marketId and poolId
           const token = tokens.find(
             (t) =>
-              (t.underlyingContractId === marketId ||
-                t.originalContractId === marketId) &&
-              t.poolId === appId
+              (String(t.underlyingContractId ?? "") === String(marketId) ||
+                String(t.originalContractId ?? "") === String(marketId)) &&
+              String(t.poolId ?? "") === String(appId)
           );
 
           if (!token) {
@@ -1481,30 +1582,18 @@ const Portfolio = () => {
             return; // Skip zero balances
           }
 
-          // Get token price
-          let tokenPrice = market?.price
-            ? usdPerTokenFromMarketInfoPrice(market.price, token.decimals)
-            : 0;
-          if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            const cfg = getTokenConfig(
-              networkId as NetworkId,
-              token.configKey ?? token.originalSymbol ?? ""
-            );
-            const tc = Array.isArray(cfg)
-              ? cfg.find((c) => String(c.poolId) === String(appId)) ?? cfg[0]
-              : cfg;
-            if (getAnyFolksAdapter(tc ?? {})) {
-              tokenPrice = folksUnderlyingUsdFallbackSamePool(
-                marketData,
-                networkId as NetworkId,
-                appId,
-                marketId
-              );
-            }
-          }
-          if (!Number.isFinite(tokenPrice) || tokenPrice <= 0) {
-            tokenPrice = 1;
-          }
+          // Get token price (oracle-aware; Folks/BTC family fallbacks — never invent $1)
+          const tokenPrice = resolvePortfolioPositionUsdPerToken({
+            market,
+            tokenDecimals: token.decimals,
+            networkId: networkId as NetworkId,
+            poolId: appId,
+            marketId,
+            configKey: token.configKey,
+            originalSymbol: token.originalSymbol,
+            displaySymbol: token.symbol,
+            marketRows: marketData,
+          });
 
           // Get APY
           const apy =
@@ -2930,18 +3019,18 @@ const Portfolio = () => {
         marketId: token.underlyingContractId,
         poolId: token.poolId,
         displaySymbol: asset,
-      }) as { price?: string | number } | undefined;
-      let tokenPrice = 1;
-
-      if (market?.price) {
-        tokenPrice = formatPriceFromContract(market.price, token.decimals);
-      } else if (networkToUse !== currentNetwork) {
-        // If market not found and we're on a different network, try to get price from token config or use default
-        console.warn(
-          `Market data not found for ${asset} on ${networkToUse}, using default price`
-        );
-        tokenPrice = 1;
-      }
+      });
+      const tokenPrice = resolvePortfolioPositionUsdPerToken({
+        market,
+        tokenDecimals: token.decimals,
+        networkId: networkToUse as NetworkId,
+        poolId: token.poolId,
+        marketId: token.underlyingContractId,
+        configKey: (token as { configKey?: string }).configKey,
+        originalSymbol: (token as { originalSymbol?: string }).originalSymbol,
+        displaySymbol: asset,
+        marketRows: marketData,
+      });
 
       //console.log({ market, tokenPrice, marketData, asset });
 
@@ -3075,29 +3164,30 @@ const Portfolio = () => {
       // Fetch user positions from all enabled networks (not just currentNetwork)
       // This ensures VOI items don't disappear when doing Algorand transactions
       const enabledNetworks = getEnabledNetworks();
-      const allPositions = [];
+      const networkPositionResults = await Promise.all(
+        enabledNetworks.map(async (networkId) => {
+          try {
+            const networkMarkets = filterPortfolioVisibleMarketRows(
+              networkId as NetworkId,
+              await fetchAllMarkets(networkId)
+            );
+            return await fetchUserPositions(
+              displayAddress,
+              networkId,
+              networkMarkets
+            );
+          } catch (error) {
+            console.error(
+              `Error fetching positions for network ${networkId}:`,
+              error
+            );
+            return [];
+          }
+        })
+      );
+      const allPositions = networkPositionResults.flat();
 
-      for (const networkId of enabledNetworks) {
-        try {
-          const networkMarkets = filterPortfolioVisibleMarketRows(
-            networkId as NetworkId,
-            await fetchAllMarkets(networkId)
-          );
-          const networkPositions = await fetchUserPositions(
-            displayAddress,
-            networkId,
-            networkMarkets
-          );
-          allPositions.push(...networkPositions);
-        } catch (error) {
-          console.error(
-            `Error fetching positions for network ${networkId}:`,
-            error
-          );
-        }
-      }
-
-      setMarketData(marketData);
+      setMarketData((prev) => mergePortfolioMarketRows(prev, marketData));
       setUserPositions(allPositions);
       setUserGlobalData(freshGlobalData);
     } catch (error) {
@@ -4064,55 +4154,135 @@ const Portfolio = () => {
     fetchUser(displayAddress);
   }, [displayAddress]);
 
-  // Fetch market data for all enabled networks when user data is available.
-  // Also fires after a 6s timeout so markets load even if fetchUser stalls (xChain race).
+  // Fast market hydrate: session cache → bulk Phase A (no oracle) → gap-fill
+  // position keys → background Phase B oracle refine. Avoids N×(GET+oracle)
+  // before Value (USD) / APY can paint.
   useEffect(() => {
-    const fetchMarketDataForAllNetworks = async () => {
-      // Proceed if user data is ready OR address is present (markets don't require user data)
-      if (!displayAddress && !user?.computed) {
-        return;
-      }
+    if (!displayAddress) return;
 
+    let cancelled = false;
+    const isCancelled = () => cancelled;
+
+    const mergeVisible = (incoming: MarketInfo[]) => {
+      if (cancelled || incoming.length === 0) return;
+      setMarketData((prev) => mergePortfolioMarketRows(prev, incoming));
+    };
+
+    const hydrate = async () => {
       try {
-        const enabledNetworks = getEnabledNetworks();
+        const enabledNetworks = getEnabledNetworks() as NetworkId[];
+        const positionKeys = collectPositionMarketKeys([
+          ...((user?.computed?.deposits as Record<string, unknown>[]) ?? []),
+          ...((user?.computed?.borrows as Record<string, unknown>[]) ?? []),
+        ]);
 
-        // Market POST `/market-data/...` for visible table rows is handled in
-        // `usePortfolioVisibleChainLive` (intersection) before user-data fetch.
+        await Promise.all(
+          enabledNetworks.map(async (networkId) => {
+            // Instant remount / after Markets visit
+            mergeVisible(marketInfosFromMarketsTableSession(networkId));
+            const sessionCached = readPortfolioMarketsSessionCache(networkId);
+            if (sessionCached?.length) {
+              mergeVisible(
+                filterPortfolioVisibleMarketRows(networkId, sessionCached)
+              );
+            }
 
-        // GET-backed `fetchAllMarkets` for portfolio display
-        const allMarketData: unknown[] = [];
-        for (const networkId of enabledNetworks) {
-          try {
-            const markets = filterPortfolioVisibleMarketRows(
-              networkId as NetworkId,
-              await fetchAllMarkets(networkId as NetworkId)
+            let phaseAMarkets: MarketInfo[] = [];
+            let refineJobs: Awaited<
+              ReturnType<typeof hydratePortfolioNetworkMarketsPhaseA>
+            >["refineJobs"] = [];
+
+            try {
+              const phaseA =
+                await hydratePortfolioNetworkMarketsPhaseA(networkId);
+              if (cancelled) return;
+              phaseAMarkets = phaseA.markets;
+              refineJobs = phaseA.refineJobs;
+              mergeVisible(phaseAMarkets);
+              // Merge into session so Phase A refresh cannot wipe prior oracle refine.
+              const sessionPrev =
+                readPortfolioMarketsSessionCache(networkId) ?? [];
+              writePortfolioMarketsSessionCache(
+                networkId,
+                mergePortfolioMarketRows(sessionPrev, phaseAMarkets) as MarketInfo[]
+              );
+            } catch (error) {
+              console.error(
+                `[Portfolio] Phase A bulk hydrate failed for ${networkId}:`,
+                error
+              );
+            }
+
+            // Gap-fill only open positions missing from bulk (not the full token list).
+            const phaseAKeySet = new Set(
+              phaseAMarkets.map(
+                (m) => `${m.networkId}|${m.poolId}|${m.marketId}`
+              )
             );
-            allMarketData.push(...markets);
-          } catch (error) {
-            console.error(
-              `Error fetching market data for network ${networkId}:`,
-              error
+            const keysToFill = positionKeys.filter(
+              (k) =>
+                k.networkId === networkId &&
+                !phaseAKeySet.has(`${k.networkId}|${k.poolId}|${k.marketId}`)
             );
-          }
-        }
 
-        console.log("[Portfolio] Fetched market data for all networks:", {
-          count: allMarketData.length,
-          networks: enabledNetworks,
-        });
+            if (keysToFill.length > 0) {
+              try {
+                const filled = await gapFillPortfolioMarkets(keysToFill);
+                if (cancelled) return;
+                mergeVisible(filled);
+                if (filled.length > 0) {
+                  const sessionPrev =
+                    readPortfolioMarketsSessionCache(networkId) ?? [];
+                  writePortfolioMarketsSessionCache(
+                    networkId,
+                    mergePortfolioMarketRows(sessionPrev, [
+                      ...phaseAMarkets,
+                      ...filled,
+                    ]) as MarketInfo[]
+                  );
+                }
+              } catch (error) {
+                console.error(
+                  `[Portfolio] Gap-fill failed for ${networkId}:`,
+                  error
+                );
+              }
+            }
 
-        setMarketData(allMarketData);
+            // Phase B: oracle refine — non-blocking; merge never replaces oracle with bulk
+            if (refineJobs.length > 0) {
+              void refinePortfolioMarketsPhaseB(
+                refineJobs,
+                (market) => {
+                  mergeVisible([market]);
+                  const sessionPrev =
+                    readPortfolioMarketsSessionCache(networkId) ?? [];
+                  writePortfolioMarketsSessionCache(
+                    networkId,
+                    mergePortfolioMarketRows(sessionPrev, [market]) as MarketInfo[]
+                  );
+                },
+                isCancelled
+              );
+            }
+
+            console.log("[Portfolio] Bulk market hydrate:", {
+              networkId,
+              phaseA: phaseAMarkets.length,
+              refineJobs: refineJobs.length,
+              gapFill: keysToFill.length,
+            });
+          })
+        );
       } catch (error) {
         console.error("Error fetching market data:", error);
       }
     };
 
-    fetchMarketDataForAllNetworks();
-    // Fallback: if user data hasn't resolved in 6s (xChain wallet init race), load markets anyway
-    const fallbackTimer = setTimeout(() => {
-      if (displayAddress) void fetchMarketDataForAllNetworks();
-    }, 6000);
-    return () => clearTimeout(fallbackTimer);
+    void hydrate();
+    return () => {
+      cancelled = true;
+    };
   }, [user?.computed, activeAccount?.address, displayAddress]);
 
   // Fetch user global data and market data when wallet connects
@@ -4594,11 +4764,14 @@ const Portfolio = () => {
     void (async () => {
       try {
         if (activeAccount?.address) {
-          const globalData = await fetchUserGlobalData(
-            activeAccount.address,
-            networkToUse
-          );
-          setUserGlobalData(globalData);
+          warmBorrowModalMaxAndPool({
+            userAddress: activeAccount.address,
+            networkId: networkToUse,
+            asset,
+            poolId,
+            configSymbol,
+            marketId,
+          });
 
           const tokens = getAllTokensWithDisplayInfo(networkToUse);
           const token = resolveSupplyBorrowToken(
@@ -4609,17 +4782,20 @@ const Portfolio = () => {
             marketId
           );
 
-          if (token && token.poolId && token.underlyingContractId) {
-            const borrowData = await fetchUserBorrowBalance(
-              activeAccount.address,
-              token.poolId,
-              token.underlyingContractId,
-              networkToUse
-            );
-            setUserBorrowBalance(borrowData?.balance || 0);
-          } else {
-            setUserBorrowBalance(0);
-          }
+          const [globalData, borrowData] = await Promise.all([
+            fetchUserGlobalData(activeAccount.address, networkToUse),
+            token && token.poolId && token.underlyingContractId
+              ? fetchUserBorrowBalance(
+                  activeAccount.address,
+                  token.poolId,
+                  token.underlyingContractId,
+                  networkToUse
+                )
+              : Promise.resolve(null),
+          ]);
+
+          setUserGlobalData(globalData);
+          setUserBorrowBalance(borrowData?.balance || 0);
         } else {
           setUserGlobalData(null);
           setUserBorrowBalance(0);
@@ -5040,17 +5216,16 @@ const Portfolio = () => {
         collateralTokenStandard: collateralTokenConfig?.tokenStandard,
       });
 
-      // Get token price
-      let debtTokenPrice = 0;
-      if (debtMarket.price) {
-        debtTokenPrice = formatPriceFromContract(
-          debtMarket.price,
+      // Get token price (oracle-aware)
+      let debtTokenPrice = usdPerTokenFromPortfolioMarketRow(
+        debtMarket,
+        debtToken.decimals ?? 6
+      );
+      if (!(debtTokenPrice > 0) && debtMarket.marketInfo) {
+        debtTokenPrice = usdPerTokenFromPortfolioMarketRow(
+          debtMarket.marketInfo,
           debtToken.decimals ?? 6
         );
-      } else if (debtMarket.marketInfo?.price) {
-        const rawPrice = parseFloat(debtMarket.marketInfo.price);
-        debtTokenPrice =
-          rawPrice > 1000000 ? rawPrice / Math.pow(10, 6) : rawPrice;
       }
 
       if (debtTokenPrice === 0) {
@@ -5096,17 +5271,16 @@ const Portfolio = () => {
         }
       }
 
-      // Get collateral token price
-      let collateralTokenPrice = 0;
-      if (collateralMarket?.price) {
-        collateralTokenPrice = formatPriceFromContract(
-          collateralMarket.price,
+      // Get collateral token price (oracle-aware)
+      let collateralTokenPrice = usdPerTokenFromPortfolioMarketRow(
+        collateralMarket,
+        collateralToken.decimals ?? 6
+      );
+      if (!(collateralTokenPrice > 0) && collateralMarket?.marketInfo) {
+        collateralTokenPrice = usdPerTokenFromPortfolioMarketRow(
+          collateralMarket.marketInfo,
           collateralToken.decimals ?? 6
         );
-      } else if (collateralMarket?.marketInfo?.price) {
-        const rawPrice = parseFloat(collateralMarket.marketInfo.price);
-        collateralTokenPrice =
-          rawPrice > 1000000 ? rawPrice / Math.pow(10, 6) : rawPrice;
       }
 
       if (collateralTokenPrice === 0) {
@@ -9445,35 +9619,30 @@ const Portfolio = () => {
                   networkId as NetworkId
                 ).find((t) => t.symbol === debtSymbol);
 
-                // Try multiple price sources
-                if (debtMarket.price) {
-                  // Price from contract (needs formatting)
-                  debtTokenPrice = formatPriceFromContract(
-                    debtMarket.price,
+                debtTokenPrice = resolvePortfolioPositionUsdPerToken({
+                  market: debtMarket,
+                  tokenDecimals: token?.decimals || 6,
+                  networkId: networkId as NetworkId,
+                  poolId: debtMarket.appId?.toString?.() ?? debtMarket.poolId,
+                  marketId:
+                    debtMarket.marketId ??
+                    debtMarket.underlyingContractId ??
+                    token?.underlyingContractId,
+                  configKey: token?.configKey,
+                  originalSymbol: token?.originalSymbol,
+                  displaySymbol: debtSymbol,
+                  marketRows: marketData,
+                });
+                if (!(debtTokenPrice > 0) && debtMarket.marketInfo) {
+                  debtTokenPrice = usdPerTokenFromPortfolioMarketRow(
+                    debtMarket.marketInfo,
                     token?.decimals || 6
                   );
-                  console.log("Using market.price:", {
-                    raw: debtMarket.price,
-                    formatted: debtTokenPrice,
-                    decimals: token?.decimals || 6,
-                  });
-                } else if (debtMarket.marketInfo?.price) {
-                  // MarketInfo price is already formatted (scaled by 10^6)
-                  const rawPrice = parseFloat(debtMarket.marketInfo.price);
-                  // If it's a large number, it might still be scaled
-                  if (rawPrice > 1000000) {
-                    debtTokenPrice = rawPrice / Math.pow(10, 6);
-                  } else {
-                    debtTokenPrice = rawPrice;
-                  }
-                  console.log("Using marketInfo.price:", {
-                    raw: debtMarket.marketInfo.price,
-                    parsed: rawPrice,
-                    final: debtTokenPrice,
-                  });
-                } else {
-                  console.warn("No price found in debtMarket:", debtMarket);
                 }
+                console.log("Resolved debt token price:", {
+                  debtTokenPrice,
+                  decimals: token?.decimals || 6,
+                });
               } else {
                 console.warn("Debt market not found:", {
                   debtSymbol,
@@ -9753,19 +9922,23 @@ const Portfolio = () => {
                 token = tokens.find((t) => t.symbol === debtSymbol);
               }
 
-              // Get token price
-              let tokenPrice = 1;
-              if (debtMarket?.price) {
-                tokenPrice =
-                  parseFloat(debtMarket.price) / Math.pow(10, 6);
-              } else if (debtMarket?.marketInfo?.price) {
-                const rawPrice = parseFloat(debtMarket.marketInfo.price);
-                tokenPrice =
-                  rawPrice > 1000000 ? rawPrice / Math.pow(10, 6) : rawPrice;
-              }
+              // Get token price (oracle-aware; never invent $1)
+              const tokenPrice = resolvePortfolioPositionUsdPerToken({
+                market: debtMarket,
+                tokenDecimals: token?.decimals ?? 6,
+                networkId,
+                poolId:
+                  selectedRepayPosition.appId?.toString() ?? token?.poolId,
+                marketId: debtMarketId ?? token?.underlyingContractId,
+                configKey: token?.configKey,
+                originalSymbol: token?.originalSymbol,
+                displaySymbol: debtSymbol,
+                marketRows: marketData,
+              });
 
-              // Calculate token amount from USD value
-              const calculatedTokenAmount = borrowValueUsd / tokenPrice;
+              // Calculate token amount from USD value (0 price → 0 amount; UI disables action)
+              const calculatedTokenAmount =
+                tokenPrice > 0 ? borrowValueUsd / tokenPrice : 0;
 
               // Use minimum of calculated amount and wallet balance
               const tokenAmount = repayWalletBalance !== null

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1040,7 +1040,7 @@ const Portfolio = () => {
               networkId
             );
 
-            let tokenPrice = resolvePortfolioPositionUsdPerToken({
+            const tokenPrice = resolvePortfolioPositionUsdPerToken({
               market,
               tokenDecimals: token.decimals,
               networkId: networkId as NetworkId,
@@ -1083,7 +1083,7 @@ const Portfolio = () => {
 
           // Add borrow position if user has borrows
           if (borrowBalance && borrowBalance > 0) {
-            let tokenPrice = resolvePortfolioPositionUsdPerToken({
+            const tokenPrice = resolvePortfolioPositionUsdPerToken({
               market,
               tokenDecimals: token.decimals,
               networkId: networkId as NetworkId,

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -68,6 +68,7 @@ import {
   liquidationThresholdToPercent,
 } from "@/utils/poolCollateralMarketRows";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
 import { warmWithdrawModalRpc } from "@/utils/modalPrefetch";
 import { withRainbowkitHostDialogDismissed } from "@/wallet/xchainSignUi";
@@ -788,36 +789,31 @@ const PortfolioModals = ({
     // Use the deposit's network so we get the correct token config (e.g. 8 decimals for goBTC on Algorand)
     // and match the Supplied Assets table USD value.
     const depositNetwork = depositAny?.network || currentNetwork;
-    let tokenPrice = deposit?.tokenPrice || 1;
-    if (market?.price) {
-      try {
-        // Get token config from the deposit's network (not currentNetwork)
-        const tokens = getAllTokensWithDisplayInfo(depositNetwork);
-        const token = resolveSupplyBorrowToken(
-          tokens,
-          asset,
-          poolId,
-          (depositAny as { configSymbol?: string })?.configSymbol,
-          marketId
-        );
-
-        const tokenDecimals = token?.decimals ?? 6; // Default to 6 if not found
-
-        // Oracle stores price in 12-decimal scale; convert to human price using token decimals
-        const targetAdjustment = 12 - tokenDecimals;
-        const divisor = Math.pow(10, targetAdjustment);
-
-        const price = parseFloat(market.price);
-        if (price && price > 0) {
-          tokenPrice = price / divisor;
-        }
-      } catch (error) {
-        console.error("Error calculating tokenPrice:", error);
-        // Fallback: use deposit.tokenPrice if available, else 10^6 divisor
-        tokenPrice =
-          deposit?.tokenPrice ||
-          parseFloat(market.price) / Math.pow(10, 6);
-      }
+    let tokenPrice = 0;
+    try {
+      const tokens = getAllTokensWithDisplayInfo(depositNetwork);
+      const token = resolveSupplyBorrowToken(
+        tokens,
+        asset,
+        poolId,
+        (depositAny as { configSymbol?: string })?.configSymbol,
+        marketId
+      );
+      const tokenDecimals = token?.decimals ?? 6;
+      tokenPrice = usdPerTokenFromPortfolioMarketRow(market, tokenDecimals, {
+        displaySymbol: asset,
+      });
+    } catch (error) {
+      console.error("Error calculating tokenPrice:", error);
+    }
+    if (!(tokenPrice > 0)) {
+      const fromDeposit = deposit?.tokenPrice;
+      tokenPrice =
+        typeof fromDeposit === "number" &&
+        Number.isFinite(fromDeposit) &&
+        fromDeposit > 0
+          ? fromDeposit
+          : 0;
     }
 
     // Safely resolve APY - avoid NaN when rates are undefined
@@ -1048,6 +1044,39 @@ const PortfolioModals = ({
       return Number.isFinite(n) && n >= 0 ? n : undefined;
     };
 
+    // Same oracle-aware USD/token path as Portfolio — never invent $1 or hardcode ÷1e6.
+    const borrowNetwork =
+      (borrow as { network?: string } | undefined)?.network || currentNetwork;
+    let tokenPrice = 0;
+    try {
+      const tokens = getAllTokensWithDisplayInfo(borrowNetwork as NetworkId);
+      const token = resolveSupplyBorrowToken(
+        tokens,
+        asset,
+        poolId,
+        (borrow as { configSymbol?: string } | undefined)?.configSymbol,
+        marketId
+      );
+      const tokenDecimals = token?.decimals ?? 6;
+      tokenPrice = usdPerTokenFromPortfolioMarketRow(market, tokenDecimals, {
+        displaySymbol: asset,
+      });
+    } catch (error) {
+      console.error(
+        "[PortfolioModals] getMarketStatsForBorrow tokenPrice:",
+        error
+      );
+    }
+    if (!(tokenPrice > 0)) {
+      const fromBorrow = borrow?.tokenPrice;
+      tokenPrice =
+        typeof fromBorrow === "number" &&
+        Number.isFinite(fromBorrow) &&
+        fromBorrow > 0
+          ? fromBorrow
+          : 0;
+    }
+
     const stats = {
       borrowAPY:
         market?.borrowApyCalculation?.apy ||
@@ -1057,9 +1086,7 @@ const PortfolioModals = ({
       liquidationMargin: liquidationMargin,
       healthFactor: healthFactor,
       currentLTV: currentLTV,
-      tokenPrice: market?.price
-        ? parseFloat(market.price) / Math.pow(10, 6)
-        : borrow?.tokenPrice || 1,
+      tokenPrice,
       collateralFactor: market?.collateralFactor
         ? market.collateralFactor * 100
         : undefined,

--- a/src/components/RepayModal.tsx
+++ b/src/components/RepayModal.tsx
@@ -30,7 +30,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { cn, formatUsdPerTokenDisplay } from "@/lib/utils";
+import { usdValueForHumanTokenAmount } from "@/utils/assetDecimals";
 import type { PoolCollateralMarketRow } from "@/utils/poolCollateralMarketRows";
 import type {
   FolksTokenAdapterConfig,
@@ -561,13 +562,38 @@ const RepayModal = ({
     }));
   };
 
+  /** Single USD/token for header, fiat lines, and HF — oracle first, then marketStats. */
+  const displayTokenPrice = useMemo(() => {
+    if (oracleTokenPrice > 0 && Number.isFinite(oracleTokenPrice)) {
+      return oracleTokenPrice;
+    }
+    return marketStats.tokenPrice > 0 &&
+      Number.isFinite(marketStats.tokenPrice)
+      ? marketStats.tokenPrice
+      : 0;
+  }, [oracleTokenPrice, marketStats.tokenPrice]);
+
+  const formatRepayUsd = (usd: number): string => {
+    if (!Number.isFinite(usd) || usd <= 0) return "0.00";
+    if (usd >= 0.01) {
+      return usd.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+    }
+    return usd.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 6,
+    });
+  };
+
   useEffect(() => {
     if (amount !== "" && typeof amount === "number") {
-      setFiatValue(amount * marketStats.tokenPrice);
+      setFiatValue(usdValueForHumanTokenAmount(amount, displayTokenPrice));
     } else {
       setFiatValue(0);
     }
-  }, [amount, marketStats.tokenPrice]);
+  }, [amount, displayTokenPrice]);
 
   const numAmount = amount !== "" && typeof amount === "number" ? amount : 0;
 
@@ -832,16 +858,6 @@ const RepayModal = ({
     setWorkflowStep("confirm");
   };
 
-  const hfTokenPrice = useMemo(() => {
-    if (oracleTokenPrice > 0 && Number.isFinite(oracleTokenPrice)) {
-      return oracleTokenPrice;
-    }
-    return marketStats.tokenPrice > 0 &&
-      Number.isFinite(marketStats.tokenPrice)
-      ? marketStats.tokenPrice
-      : 0;
-  }, [oracleTokenPrice, marketStats.tokenPrice]);
-
   const liquidationSummaryForRepay = useMemo(
     () =>
       buildLiquidationThresholdSummaryForDeposit(
@@ -863,7 +879,7 @@ const RepayModal = ({
       poolGlobalUserData,
       liquidationSummaryForRepay,
       repayAmountMarketHuman,
-      hfTokenPrice
+      displayTokenPrice
     );
     if (!meta) {
       return {
@@ -876,7 +892,7 @@ const RepayModal = ({
     poolGlobalUserData,
     liquidationSummaryForRepay,
     repayAmountMarketHuman,
-    hfTokenPrice,
+    displayTokenPrice,
   ]);
 
   const showPoolHealthEstimate =
@@ -901,10 +917,10 @@ const RepayModal = ({
     >
       <DialogContent
         className={cn(
-          "bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl max-w-[95vw] overflow-hidden flex flex-col px-0 py-0",
+          "bg-card dark:bg-slate-900 rounded-xl border border-gray-200/50 dark:border-ocean-teal/20 shadow-xl max-w-[95vw] overflow-hidden flex flex-col px-0 py-0 min-h-0",
           showSuccess
             ? "md:max-w-md h-auto max-h-[min(90vh,90dvh)]"
-            : "md:max-w-lg lg:max-w-4xl h-[90vh] md:h-auto md:max-h-[85vh]"
+            : "md:max-w-lg lg:max-w-4xl h-[min(90vh,90dvh)] max-h-[min(90vh,90dvh)] md:h-[min(85vh,85dvh)] md:max-h-[min(85vh,85dvh)]"
         )}
       >
         {showSuccess ? (
@@ -921,8 +937,8 @@ const RepayModal = ({
             />
           </div>
         ) : (
-          <div className="flex flex-col h-full">
-            <div className="sticky top-0 z-20 bg-card dark:bg-slate-900 pt-6 px-6 md:px-8 lg:px-10 pb-4 border-b border-gray-200/50 dark:border-slate-700/50">
+          <div className="flex flex-col h-full min-h-0">
+            <div className="sticky top-0 z-20 shrink-0 bg-card dark:bg-slate-900 pt-6 px-6 md:px-8 lg:px-10 pb-4 border-b border-gray-200/50 dark:border-slate-700/50">
               <DialogHeader className="pb-0">
                 {availableAssets &&
                 availableAssets.length > 0 &&
@@ -989,10 +1005,7 @@ const RepayModal = ({
                     </div>
                     <span className="text-sm text-slate-500 dark:text-slate-400">
                       $
-                      {marketStats.tokenPrice.toLocaleString(undefined, {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 4,
-                      })}
+                      {formatUsdPerTokenDisplay(displayTokenPrice)}
                     </span>
                   </div>
                 ) : (
@@ -1008,10 +1021,7 @@ const RepayModal = ({
                       </DialogTitle>
                       <span className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">
                         $
-                        {marketStats.tokenPrice.toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 4,
-                        })}
+                        {formatUsdPerTokenDisplay(displayTokenPrice)}
                       </span>
                     </div>
                   </div>
@@ -1019,13 +1029,12 @@ const RepayModal = ({
               </DialogHeader>
             </div>
 
-            <div className="flex-1 overflow-y-auto overscroll-contain pt-2 px-6 md:px-8 lg:px-10 pb-6 md:pb-8 touch-pan-y">
+            <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pt-2 px-6 md:px-8 lg:px-10 pb-4 touch-pan-y">
               <div className="flex flex-col lg:flex-row lg:gap-8 space-y-6 lg:space-y-0">
                 {/* Left Column: Input Form */}
                 <div className="flex-1 space-y-6 min-w-0">
                   {workflowStep === "amount" ? (
-                    <>
-                      <div className="space-y-3">
+                    <div className="space-y-3">
                         <Label
                           htmlFor="amount"
                           className="text-sm font-medium text-slate-600 dark:text-slate-300"
@@ -1121,10 +1130,7 @@ const RepayModal = ({
                         {fiatValue > 0 && (
                           <p className="text-sm text-slate-500 dark:text-slate-400">
                             ≈ $
-                            {fiatValue.toLocaleString(undefined, {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2,
-                            })}
+                            {formatRepayUsd(fiatValue)}
                           </p>
                         )}
                         <div className="pt-2">
@@ -1139,10 +1145,12 @@ const RepayModal = ({
                                   {walletUnitSymbol}
                                   <span className="text-slate-500 dark:text-slate-400 ml-1">
                                     ($
-                                    {(
-                                      effectiveWalletBalance *
-                                      marketStats.tokenPrice
-                                    ).toLocaleString()}
+                                    {formatRepayUsd(
+                                      usdValueForHumanTokenAmount(
+                                        effectiveWalletBalance,
+                                        displayTokenPrice
+                                      )
+                                    )}
                                     )
                                   </span>
                                 </p>
@@ -1156,9 +1164,12 @@ const RepayModal = ({
                                   {tokenSymbol}
                                   <span className="text-slate-500 dark:text-slate-400 ml-1">
                                     ($
-                                    {(
-                                      currentBorrow * marketStats.tokenPrice
-                                    ).toLocaleString()}
+                                    {formatRepayUsd(
+                                      usdValueForHumanTokenAmount(
+                                        currentBorrow,
+                                        displayTokenPrice
+                                      )
+                                    )}
                                     )
                                   </span>
                                 </p>
@@ -1177,12 +1188,12 @@ const RepayModal = ({
                                   {tokenSymbol}
                                   <span className="text-amber-600 dark:text-amber-400 ml-1">
                                     ($
-                                    {(
-                                      accruedInterest * marketStats.tokenPrice
-                                    ).toLocaleString(undefined, {
-                                      minimumFractionDigits: 2,
-                                      maximumFractionDigits: 2,
-                                    })}
+                                    {formatRepayUsd(
+                                      usdValueForHumanTokenAmount(
+                                        accruedInterest,
+                                        displayTokenPrice
+                                      )
+                                    )}
                                     )
                                   </span>
                                 </p>
@@ -1229,22 +1240,9 @@ const RepayModal = ({
                             )}
                           </div>
                         </div>
-                      </div>
-
-                      <Button
-                        type="button"
-                        onClick={handleContinueToConfirm}
-                        disabled={
-                          !isValidAmount || isLoading || repayFolksBlockingSubmit
-                        }
-                        className="w-full font-semibold h-12 bg-whale-gold hover:bg-whale-gold/90 text-black disabled:opacity-50 disabled:cursor-not-allowed lg:mt-auto"
-                      >
-                        Continue
-                      </Button>
-                    </>
+                    </div>
                   ) : (
-                    <>
-                      <div className="space-y-3">
+                    <div className="space-y-3">
                         <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
                           Confirm repayment
                         </h3>
@@ -1268,13 +1266,12 @@ const RepayModal = ({
                               {tokenSymbol}
                               <span className="block text-[10px] text-slate-500 dark:text-slate-400 font-normal">
                                 ≈ $
-                                {(
-                                  principalBorrowExclInterest *
-                                  marketStats.tokenPrice
-                                ).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}
+                                {formatRepayUsd(
+                                  usdValueForHumanTokenAmount(
+                                    principalBorrowExclInterest,
+                                    displayTokenPrice
+                                  )
+                                )}
                               </span>
                             </span>
                           </div>
@@ -1290,12 +1287,12 @@ const RepayModal = ({
                               {tokenSymbol}
                               <span className="block text-[10px] text-amber-600/90 dark:text-amber-400/90 font-normal">
                                 ≈ $
-                                {(
-                                  accruedInterest * marketStats.tokenPrice
-                                ).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}
+                                {formatRepayUsd(
+                                  usdValueForHumanTokenAmount(
+                                    accruedInterest,
+                                    displayTokenPrice
+                                  )
+                                )}
                               </span>
                             </span>
                           </div>
@@ -1311,12 +1308,12 @@ const RepayModal = ({
                               {walletUnitSymbol}
                               <span className="block text-[10px] text-slate-500 dark:text-slate-400 font-normal">
                                 ≈ $
-                                {(
-                                  numAmount * marketStats.tokenPrice
-                                ).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}
+                                {formatRepayUsd(
+                                  usdValueForHumanTokenAmount(
+                                    numAmount,
+                                    displayTokenPrice
+                                  )
+                                )}
                               </span>
                             </span>
                           </div>
@@ -1335,39 +1332,17 @@ const RepayModal = ({
                               {tokenSymbol}
                               <span className="block text-[10px] text-slate-500 dark:text-slate-400 font-normal">
                                 ≈ $
-                                {(
-                                  estimatedRemainingBorrow *
-                                  marketStats.tokenPrice
-                                ).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}
+                                {formatRepayUsd(
+                                  usdValueForHumanTokenAmount(
+                                    estimatedRemainingBorrow,
+                                    displayTokenPrice
+                                  )
+                                )}
                               </span>
                             </span>
                           </div>
                         </div>
-                      </div>
-
-                      <div className="flex flex-col sm:flex-row gap-2 lg:mt-auto">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => setWorkflowStep("amount")}
-                          disabled={isLoading}
-                          className="w-full sm:flex-1 h-12 border-slate-300 dark:border-slate-600"
-                        >
-                          Back
-                        </Button>
-                        <Button
-                          type="button"
-                          onClick={handleConfirmRepay}
-                          disabled={isLoading}
-                          className="w-full sm:flex-1 h-12 font-semibold bg-whale-gold hover:bg-whale-gold/90 text-black disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {isLoading ? "Processing..." : "Confirm repayment"}
-                        </Button>
-                      </div>
-                    </>
+                    </div>
                   )}
                 </div>
 
@@ -1509,12 +1484,12 @@ const RepayModal = ({
                                 </p>
                                 <p className="text-slate-500 dark:text-slate-400">
                                   USD Value: $
-                                  {(
-                                    accruedInterest * marketStats.tokenPrice
-                                  ).toLocaleString(undefined, {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}
+                                  {formatRepayUsd(
+                                    usdValueForHumanTokenAmount(
+                                      accruedInterest,
+                                      displayTokenPrice
+                                    )
+                                  )}
                                 </p>
                                 {lastUpdateTime && (
                                   <p className="text-slate-500 dark:text-slate-400 mt-1 text-xs">
@@ -1816,6 +1791,41 @@ const RepayModal = ({
                   </Card>
                 </div>
               </div>
+            </div>
+
+            <div className="shrink-0 border-t border-gray-200/50 dark:border-slate-700/50 bg-card dark:bg-slate-900 px-6 md:px-8 lg:px-10 py-4">
+              {workflowStep === "amount" ? (
+                <Button
+                  type="button"
+                  onClick={handleContinueToConfirm}
+                  disabled={
+                    !isValidAmount || isLoading || repayFolksBlockingSubmit
+                  }
+                  className="w-full font-semibold h-12 bg-whale-gold hover:bg-whale-gold/90 text-black disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Continue
+                </Button>
+              ) : (
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setWorkflowStep("amount")}
+                    disabled={isLoading}
+                    className="w-full sm:flex-1 h-12 border-slate-300 dark:border-slate-600"
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={handleConfirmRepay}
+                    disabled={isLoading}
+                    className="w-full sm:flex-1 h-12 font-semibold bg-whale-gold hover:bg-whale-gold/90 text-black disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isLoading ? "Processing..." : "Confirm repayment"}
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/components/SupplyBorrowForm.tsx
+++ b/src/components/SupplyBorrowForm.tsx
@@ -460,7 +460,9 @@ const SupplyBorrowForm = ({
                       </span>
                     )}
                   </>
-                ) : userGlobalData
+                ) : isLoadingMaxBorrow
+                  ? "—"
+                  : userGlobalData
                   ? hasCapacityNoLiquidity
                     ? `Your capacity ≈ $${maxBorrowableUSD.toLocaleString(undefined, {
                         minimumFractionDigits: 2,
@@ -497,7 +499,12 @@ const SupplyBorrowForm = ({
       {!hideButton && (
         <Button
           onClick={onSubmit}
-          disabled={!isValidAmount || isLoading || disabled}
+          disabled={
+            !isValidAmount ||
+            isLoading ||
+            disabled ||
+            (mode === "borrow" && isLoadingMaxBorrow)
+          }
           className={`w-full font-semibold text-white h-12 transition-all hover:scale-105 ${mode === "deposit"
             ? "bg-teal-600 hover:bg-teal-700"
             : "bg-whale-gold hover:bg-whale-gold/90 text-black"

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -69,6 +69,7 @@ import { useTokenPrice } from "@/hooks/useTokenPrice";
 import { calculateMaxBorrowAmount } from "@/services/adminService";
 import dorkfiAPIService from "@/services/dorkfiAPIService";
 import { updateTransactionMetadata } from "@/utils/transactionUtils";
+import { warmBorrowModalMaxAndPool } from "@/utils/modalPrefetch";
 import type { PoolCollateralMarketRow } from "@/utils/poolCollateralMarketRows";
 import {
   buildLiquidationThresholdSummaryForDeposit,
@@ -299,6 +300,32 @@ export function supplyBorrowAssetRowKey(
   return `${a.asset}|${pool}|${net}|${mid}|${cfg}`;
 }
 
+/** Max wall time for building unsigned borrow/supply txns before surfacing a retryable error. */
+const BUILD_TRANSACTION_TIMEOUT_MS = 90_000;
+const BUILD_TIMEOUT_MARKER = "BUILD_TXN_TIMEOUT";
+
+function withBuildTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `${BUILD_TIMEOUT_MARKER}:${label}: We couldn’t build the transaction. Please try again.`
+        )
+      );
+    }, BUILD_TRANSACTION_TIMEOUT_MS);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
 /** Borrow amount field vs protocol: user may enter ALGO (underlying route) or f-asset; caps are in market-token human. */
 function borrowInputToMarketTokenHuman(
   amountStr: string,
@@ -425,7 +452,7 @@ const SupplyBorrowModal = ({
   poolCollateralMarkets,
   walletBalanceMarketToken,
   isLoadingWalletBalance = false,
-  isLoadingBorrowGlobalData = false,
+  isLoadingBorrowGlobalData: _isLoadingBorrowGlobalData = false,
   depositNotice,
   assetPairIcons,
 }: SupplyBorrowModalProps) => {
@@ -444,6 +471,8 @@ const SupplyBorrowModal = ({
   );
   const [isLoadingMaxBorrow, setIsLoadingMaxBorrow] = useState(false);
   const [maxBorrowError, setMaxBorrowError] = useState<string | null>(null);
+  /** Bumps on modal close / new build so stale in-flight builds do not update UI. */
+  const buildGenerationRef = useRef(0);
   /** Per-pool collateral/borrow (USD) for deposit health estimate; undefined = not loaded */
   const [poolGlobalUserData, setPoolGlobalUserData] = useState<
     | {
@@ -1503,16 +1532,16 @@ const SupplyBorrowModal = ({
 
   const borrowMaxLineLoading = useMemo(() => {
     if (mode !== "borrow") return false;
+    // Any in-flight max calc must hide/clear stale values from a prior asset.
+    const waitingOnMaxCalc = isLoadingMaxBorrow;
     return (
-      isLoadingBorrowGlobalData ||
-      isLoadingMaxBorrow ||
+      waitingOnMaxCalc ||
       (borrowInputReceiveBasis === "underlying" &&
         folksMintRatioStatus === "loading") ||
       (isXalgoConsensusBorrowAlgoRoute && xalgoBorrowConsensusState == null)
     );
   }, [
     mode,
-    isLoadingBorrowGlobalData,
     isLoadingMaxBorrow,
     borrowInputReceiveBasis,
     folksMintRatioStatus,
@@ -1652,8 +1681,10 @@ const SupplyBorrowModal = ({
       });
 
       setIsLoadingMaxBorrow(true);
+      setCalculatedMaxBorrow(null);
       setMaxBorrowError(null);
 
+      let keepLoadingForPoolData = false;
       try {
         const tokens = getAllTokensWithDisplayInfo(networkToUse as any);
         // If poolId is provided, find the token that matches both symbol and poolId
@@ -1805,20 +1836,25 @@ const SupplyBorrowModal = ({
           effectiveUserGlobalData.totalCollateralValue > 0
         ) {
           // Borrowing power must be based on collateral in this pool only (not aggregate across pools)
-          const poolData =
-            poolId != null && poolId !== ""
-              ? await fetchUserGlobalDataForPool(
-                activeAccount.address,
-                networkToUse as NetworkId,
-                Number(poolId)
-              )
-              : null;
-          console.log("SupplyBorrowModal: Pool data", { poolData, poolId });
+          if (
+            poolId != null &&
+            poolId !== "" &&
+            poolGlobalUserData === undefined
+          ) {
+            // Pool totals still loading (separate effect); keep spinner and re-run when ready
+            keepLoadingForPoolData = true;
+            return;
+          }
           const collateralForBorrow =
-            poolData != null
-              ? poolData.totalCollateralValue
+            poolGlobalUserData != null
+              ? poolGlobalUserData.totalCollateralValue
               : effectiveUserGlobalData.totalCollateralValue;
-          const maxBorrowUSD = collateralForBorrow * (assetData.collateralFactor / 100);
+          console.log("SupplyBorrowModal: Pool data", {
+            poolGlobalUserData,
+            poolId,
+          });
+          const maxBorrowUSD =
+            collateralForBorrow * (assetData.collateralFactor / 100);
           const calculatedMaxBorrow = capByBorrowCap(
             tokenPrice != null && tokenPrice > 0
               ? (maxBorrowUSD / tokenPrice) * Math.pow(10, 6) / Math.pow(10, decimals)
@@ -1844,7 +1880,9 @@ const SupplyBorrowModal = ({
         );
         setCalculatedMaxBorrow(null);
       } finally {
-        setIsLoadingMaxBorrow(false);
+        if (!keepLoadingForPoolData) {
+          setIsLoadingMaxBorrow(false);
+        }
       }
     };
 
@@ -1861,8 +1899,48 @@ const SupplyBorrowModal = ({
     tokenPrice,
     assetData.totalBorrow,
     assetData.maxTotalBorrows,
+    assetData.collateralFactor,
+    assetData.liquidationThreshold,
+    assetData.totalSupply,
     effectiveUserGlobalData?.totalCollateralValue,
+    poolGlobalUserData,
   ]);
+
+  // Warm RPC caches as soon as borrow modal opens (not only on row hover)
+  useEffect(() => {
+    if (
+      !isOpen ||
+      mode !== "borrow" ||
+      !activeAccount?.address ||
+      !asset
+    ) {
+      return;
+    }
+    warmBorrowModalMaxAndPool({
+      userAddress: activeAccount.address,
+      networkId: networkToUse as NetworkId,
+      asset,
+      poolId: poolId != null ? String(poolId) : undefined,
+      configSymbol,
+      marketId: marketId != null ? String(marketId) : undefined,
+    });
+  }, [
+    isOpen,
+    mode,
+    activeAccount?.address,
+    asset,
+    poolId,
+    configSymbol,
+    marketId,
+    networkToUse,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      buildGenerationRef.current += 1;
+      setIsLoading(false);
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     setPendingSign(null);
@@ -2487,6 +2565,12 @@ const SupplyBorrowModal = ({
       return;
     }
 
+    if (isLoading) {
+      return;
+    }
+
+    const buildGen = ++buildGenerationRef.current;
+
     // For deposits, check wallet balance (per selected deposit adapter basis).
     // xALGO consensus ALGO route: spendable ALGO loads async; until then effective balance is 0 — do not block.
     if (mode === "deposit") {
@@ -2708,8 +2792,8 @@ const SupplyBorrowModal = ({
             .integerValue(BigNumber.ROUND_FLOOR)
             .toFixed(0)
         );
-        const { txnsB64, borrowedXalgoAtomic } =
-          await buildXalgoConsensusBorrowAndBurnSingleGroup({
+        const { txnsB64, borrowedXalgoAtomic } = await withBuildTimeout(
+          buildXalgoConsensusBorrowAndBurnSingleGroup({
             userAddress: activeAccount.address,
             networkId: networkToUse as NetworkId,
             desiredMinAlgoMicros,
@@ -2718,7 +2802,10 @@ const SupplyBorrowModal = ({
             tokenStandard: String(
               resolvedBorrowTokenConfig.tokenStandard
             ) as TokenStandard,
-          });
+          }),
+          "borrow+burn"
+        );
+        if (buildGen !== buildGenerationRef.current) return;
         const dec = resolvedBorrowTokenConfig.decimals ?? 6;
         setPendingSign({
           txnsB64,
@@ -2740,11 +2827,16 @@ const SupplyBorrowModal = ({
           previewAmountHuman: formatXalgoAtomicAsHuman(borrowedXalgoAtomic, dec),
         });
       } catch (e) {
+        if (buildGen !== buildGenerationRef.current) return;
         setError(
-          e instanceof Error ? e.message : "Could not build borrow and burn."
+          e instanceof Error
+            ? e.message
+            : "We couldn’t build the transaction. Please try again."
         );
       } finally {
-        setIsLoading(false);
+        if (buildGen === buildGenerationRef.current) {
+          setIsLoading(false);
+        }
       }
       return;
     }
@@ -2997,16 +3089,19 @@ const SupplyBorrowModal = ({
           depositAdapterTrimmed !== TALGO_TINYMAN_DEPOSIT_ALGO_ROUTE_ID
             ? { depositAdapterId: depositAdapterTrimmed }
             : undefined;
-        result = await deposit(
-          token.poolId,
-          token.underlyingContractId,
-          originalTokenConfig.tokenStandard,
-          amountInAtomicUnits,
-          activeAccount.address,
-          actualNetwork as NetworkId,
-          useFolksTwoStep
-            ? { ...depositBaseOpts, folksTwoStep: "folks_mint_only" as const }
-            : depositBaseOpts
+        result = await withBuildTimeout(
+          deposit(
+            token.poolId,
+            token.underlyingContractId,
+            originalTokenConfig.tokenStandard,
+            amountInAtomicUnits,
+            activeAccount.address,
+            actualNetwork as NetworkId,
+            useFolksTwoStep
+              ? { ...depositBaseOpts, folksTwoStep: "folks_mint_only" as const }
+              : depositBaseOpts
+          ),
+          "deposit"
         );
       } else if (mode === "borrow") {
         // Call the lending service borrow method
@@ -3016,18 +3111,23 @@ const SupplyBorrowModal = ({
           borrowAdTrim !== XALGO_CONSENSUS_BORROW_ALGO_ROUTE_ID
             ? { borrowAdapterId: selectedBorrowAdapterId }
             : undefined;
-        result = await borrow(
-          token.poolId,
-          token.underlyingContractId,
-          originalTokenConfig.tokenStandard,
-          amountInAtomicUnits,
-          activeAccount.address,
-          actualNetwork as NetworkId,
-          borrowOpts
+        result = await withBuildTimeout(
+          borrow(
+            token.poolId,
+            token.underlyingContractId,
+            originalTokenConfig.tokenStandard,
+            amountInAtomicUnits,
+            activeAccount.address,
+            actualNetwork as NetworkId,
+            borrowOpts
+          ),
+          "borrow"
         );
       } else {
         throw new Error(`Unsupported mode: ${mode}`);
       }
+
+      if (buildGen !== buildGenerationRef.current) return;
 
       if (!result.success) {
         throw new Error(result.error || `${mode} failed`);
@@ -3146,57 +3246,64 @@ const SupplyBorrowModal = ({
         },
       });
     } catch (error) {
+      if (buildGen !== buildGenerationRef.current) return;
       console.error(`${mode} error:`, error);
 
       // Enhanced error handling with specific messages
       let errorMessage = `${mode} failed`;
 
       if (error instanceof Error) {
-        const message = error.message.toLowerCase();
+        const message = error.message;
+        const messageLower = message.toLowerCase();
 
-        if (message.includes("compatible wallet")) {
-          errorMessage = error.message;
-        } else if (message.includes("insufficient liquidity for withdraw")) {
+        if (message.startsWith(`${BUILD_TIMEOUT_MARKER}:`)) {
+          errorMessage =
+            "We couldn’t build the transaction. Please try again.";
+        } else if (messageLower.includes("compatible wallet")) {
+          errorMessage = message;
+        } else if (messageLower.includes("insufficient liquidity for withdraw")) {
           errorMessage =
             "Insufficient liquidity for withdraw. Please check your deposit and borrow balances, add collateral, or repay debt and try again.";
-        } else if (message.includes("insufficient collateral for borrow")) {
+        } else if (messageLower.includes("insufficient collateral for borrow")) {
           errorMessage =
             "Insufficient collateral for borrow. Please check your collateral balance, add collateral, or repay debt and try again.";
-        } else if (message.includes("tried to spend")) {
+        } else if (messageLower.includes("tried to spend")) {
           errorMessage = `Insufficient ${networkToUse === "algorand-mainnet" ? "Algorand" : "Voi"
             } Network balance for this transaction. Please check your wallet balance and try again.`;
-        } else if (message.includes("insufficient")) {
+        } else if (
+          messageLower.includes("insufficient liquidity") ||
+          messageLower.includes("insufficient collateral") ||
+          messageLower.includes("insufficient wallet")
+        ) {
           errorMessage =
             mode === "deposit"
               ? "Insufficient wallet balance for this transaction"
               : "Insufficient liquidity or collateral for this transaction";
         } else if (
-          message.includes("network") ||
-          message.includes("connection")
+          messageLower.includes("connection") ||
+          messageLower.includes("network request failed") ||
+          messageLower.includes("failed to fetch")
         ) {
           errorMessage =
             "Network connection issue. Please check your internet connection and try again.";
-        } else if (message.includes("gas") || message.includes("fee")) {
-          errorMessage =
-            "Transaction failed due to insufficient gas fees. Please ensure you have enough tokens for gas.";
-        } else if (message.includes("rejected") || message.includes("user")) {
-          errorMessage = "Transaction was rejected or cancelled by user.";
-        } else if (message.includes("timeout")) {
-          errorMessage = "Transaction timed out. Please try again.";
         } else if (
-          message.includes("invalid") ||
-          message.includes("malformed")
+          messageLower.includes("rejected by user") ||
+          messageLower.includes("user rejected") ||
+          messageLower.includes("user cancelled") ||
+          messageLower.includes("user canceled")
         ) {
-          errorMessage =
-            "Invalid transaction parameters. Please refresh and try again.";
+          errorMessage = "Transaction was rejected or cancelled by user.";
         } else {
-          errorMessage = error.message;
+          // Prefer the real simulate/RPC message so we can debug slow builds
+          errorMessage = message || `${mode} failed`;
         }
       }
 
       setError(errorMessage);
     } finally {
-      setIsLoading(false);
+      if (buildGen === buildGenerationRef.current) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -3697,6 +3804,7 @@ const SupplyBorrowModal = ({
                   (mode === "borrow" && borrowSubmitBlockedBelowHfTarget) ||
                   (mode === "borrow" && borrowNoCapacityAtHfTarget) ||
                   (mode === "borrow" && borrowFolksBlockingSubmit) ||
+                  (mode === "borrow" && borrowMaxLineLoading) ||
                   (mode === "borrow" &&
                     isXalgoConsensusBorrowAlgoRoute &&
                     amountBorrowMarketTokenHuman === null)
@@ -3956,6 +4064,7 @@ const SupplyBorrowModal = ({
                         (mode === "borrow" && borrowExceedsEffectiveCap) ||
                         (mode === "borrow" && borrowSubmitBlockedBelowHfTarget) ||
                         (mode === "borrow" && borrowFolksBlockingSubmit) ||
+                        (mode === "borrow" && borrowMaxLineLoading) ||
                         (mode === "borrow" &&
                           isXalgoConsensusBorrowAlgoRoute &&
                           amountBorrowMarketTokenHuman === null) ||

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -473,6 +473,8 @@ const SupplyBorrowModal = ({
   const [maxBorrowError, setMaxBorrowError] = useState<string | null>(null);
   /** Bumps on modal close / new build so stale in-flight builds do not update UI. */
   const buildGenerationRef = useRef(0);
+  /** Bumps when max-borrow deps change so stale in-flight calcs do not update UI. */
+  const maxBorrowGenRef = useRef(0);
   /** Per-pool collateral/borrow (USD) for deposit health estimate; undefined = not loaded */
   const [poolGlobalUserData, setPoolGlobalUserData] = useState<
     | {
@@ -1379,8 +1381,9 @@ const SupplyBorrowModal = ({
   /** Protocol + market liquidity cap in human tokens (always finite in borrow mode). */
   const borrowLiquidityOnlyTokens = useMemo(() => {
     if (mode !== "borrow") return null;
-    const raw =
-      calculatedMaxBorrow !== null ? calculatedMaxBorrow : assetData.liquidity;
+    // Do not fall back to assetData.liquidity when max is unknown/errored — market
+    // liquidity alone can look more permissive than collateral allows.
+    const raw = calculatedMaxBorrow !== null ? calculatedMaxBorrow : 0;
     const safeRaw =
       typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, raw) : 0;
     const borrowCap = assetData.maxTotalBorrows ?? 0;
@@ -1390,7 +1393,6 @@ const SupplyBorrowModal = ({
   }, [
     mode,
     calculatedMaxBorrow,
-    assetData.liquidity,
     assetData.maxTotalBorrows,
     assetData.totalBorrow,
   ]);
@@ -1666,6 +1668,7 @@ const SupplyBorrowModal = ({
     const fetchMaxBorrowAmount = async () => {
       // Only calculate for borrow mode
       if (mode !== "borrow" || !isOpen || !activeAccount?.address) {
+        maxBorrowGenRef.current += 1;
         setCalculatedMaxBorrow(null);
         setIsLoadingMaxBorrow(false);
         setMaxBorrowError(null);
@@ -1680,6 +1683,7 @@ const SupplyBorrowModal = ({
         currentNetwork,
       });
 
+      const gen = ++maxBorrowGenRef.current;
       setIsLoadingMaxBorrow(true);
       setCalculatedMaxBorrow(null);
       setMaxBorrowError(null);
@@ -1762,6 +1766,8 @@ const SupplyBorrowModal = ({
           storageAppId ? Number(storageAppId) : undefined
         );
 
+        if (gen !== maxBorrowGenRef.current) return;
+
         console.log("SupplyBorrowModal: maxBorrowBigInt result", {
           maxBorrowBigInt,
           isZero: maxBorrowBigInt === BigInt(0),
@@ -1824,6 +1830,7 @@ const SupplyBorrowModal = ({
             )
           );
 
+          if (gen !== maxBorrowGenRef.current) return;
           setCalculatedMaxBorrow(finalMaxBorrow);
           console.log("SupplyBorrowModal: Max borrow amount calculated:", {
             maxBorrowNumber,
@@ -1855,15 +1862,17 @@ const SupplyBorrowModal = ({
           });
           const maxBorrowUSD =
             collateralForBorrow * (assetData.collateralFactor / 100);
-          const calculatedMaxBorrow = capByBorrowCap(
+          const nextMaxBorrow = capByBorrowCap(
             tokenPrice != null && tokenPrice > 0
               ? (maxBorrowUSD / tokenPrice) * Math.pow(10, 6) / Math.pow(10, decimals)
               : 0
           );
-          setCalculatedMaxBorrow(calculatedMaxBorrow);
+          if (gen !== maxBorrowGenRef.current) return;
+          setCalculatedMaxBorrow(nextMaxBorrow);
         } else {
           // Even if maxBorrowBigInt is 0, we should still check deposits - borrowed, then cap by borrow cap
           const finalMaxBorrow = capByBorrowCap(Math.max(0, depositsMinusBorrowed));
+          if (gen !== maxBorrowGenRef.current) return;
           setCalculatedMaxBorrow(finalMaxBorrow);
           console.log(
             "SupplyBorrowModal: Max borrow amount (deposits - borrowed):",
@@ -1871,6 +1880,7 @@ const SupplyBorrowModal = ({
           );
         }
       } catch (error) {
+        if (gen !== maxBorrowGenRef.current) return;
         console.error(
           "SupplyBorrowModal: Error calculating max borrow amount:",
           error
@@ -1880,7 +1890,7 @@ const SupplyBorrowModal = ({
         );
         setCalculatedMaxBorrow(null);
       } finally {
-        if (!keepLoadingForPoolData) {
+        if (gen === maxBorrowGenRef.current && !keepLoadingForPoolData) {
           setIsLoadingMaxBorrow(false);
         }
       }
@@ -1938,6 +1948,7 @@ const SupplyBorrowModal = ({
   useEffect(() => {
     if (!isOpen) {
       buildGenerationRef.current += 1;
+      maxBorrowGenRef.current += 1;
       setIsLoading(false);
     }
   }, [isOpen]);

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -19,6 +19,7 @@ import {
   type TokenConfig,
   getAnyFolksAdapter,
 } from "@/config";
+import { runWithConcurrency } from "@/utils/runWithConcurrency";
 import {
   buildMarketInfoFromRawMarketData,
   fetchBulkApiMarketDataMap,
@@ -351,25 +352,6 @@ function writeMarketsSessionCache(
   } catch {
     // Ignore quota / private-mode failures.
   }
-}
-
-async function runWithConcurrency<T>(
-  items: T[],
-  concurrency: number,
-  worker: (item: T) => Promise<void>
-): Promise<void> {
-  if (items.length === 0) return;
-  let nextIndex = 0;
-  const runners = Array.from(
-    { length: Math.min(concurrency, items.length) },
-    async () => {
-      while (nextIndex < items.length) {
-        const index = nextIndex++;
-        await worker(items[index]);
-      }
-    }
-  );
-  await Promise.all(runners);
 }
 
 async function getCachedFolksMintedFAssetPerOneUnderlying(input: {

--- a/src/hooks/usePortfolioVisibleChainLive.ts
+++ b/src/hooks/usePortfolioVisibleChainLive.ts
@@ -19,6 +19,11 @@ import {
   estimateFolksDepositMintedFAssetAmount,
   folksFAssetHumanToUnderlyingHuman,
 } from "@/services/folksDepositAdapter";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import {
+  portfolioUsdCacheKey,
+  resolveWithLastGoodPortfolioUsd,
+} from "@/utils/portfolioUsdCache";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
 
 export type PortfolioChainLiveOverride = {
@@ -293,8 +298,8 @@ export function usePortfolioVisibleChainLive(opts: {
     enabled =
       import.meta.env.VITE_PORTFOLIO_CHAIN_POLL !== "false" &&
       import.meta.env.VITE_PORTFOLIO_CHAIN_POLL !== "0",
-    formatPriceFromContract,
   } = opts;
+  void opts.formatPriceFromContract;
 
   const useApiUserData =
     import.meta.env.VITE_PORTFOLIO_CHAIN_USE_API_USER_DATA !== "false" &&
@@ -360,13 +365,17 @@ export function usePortfolioVisibleChainLive(opts: {
         marketId: token.underlyingContractId,
         poolId: token.poolId,
         displaySymbol: token.symbol,
-      }) as { price?: string | number } | undefined;
-      const tp = mkt?.price
-        ? formatPriceFromContract(
-            mkt.price as string | number,
-            token.decimals
-          )
-        : 1;
+      });
+      const tp = resolveWithLastGoodPortfolioUsd(
+        usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
+          displaySymbol: token.symbol,
+        }),
+        portfolioUsdCacheKey(
+          String(networkId),
+          String(token.poolId),
+          String(token.underlyingContractId)
+        )
+      );
 
       try {
         if (kind === "deposit") {
@@ -415,7 +424,7 @@ export function usePortfolioVisibleChainLive(opts: {
     if (Object.keys(batch).length > 0) {
       setOverrides((prev) => ({ ...prev, ...batch }));
     }
-  }, [address, marketData, formatPriceFromContract]);
+  }, [address, marketData]);
 
   const fetchVisibleWithApiPost = useCallback(async () => {
     if (!address) return;
@@ -494,12 +503,21 @@ export function usePortfolioVisibleChainLive(opts: {
         );
       }
 
-      const tokenPrice = group.market?.price
-        ? formatPriceFromContract(
-            group.market.price as string | number,
-            group.tokenDecimals
-          )
-        : 1;
+      const tokenPrice = resolveWithLastGoodPortfolioUsd(
+        usdPerTokenFromPortfolioMarketRow(
+          group.market,
+          group.tokenDecimals,
+          {
+            displaySymbol:
+              (group.market as { symbol?: string } | null)?.symbol ?? undefined,
+          }
+        ),
+        portfolioUsdCacheKey(
+          String(group.network),
+          String(group.appId),
+          String(group.marketId)
+        )
+      );
 
       let groupDepositMinted: bigint | null = null;
       const firstKey = group.rows[0]?.portfolioKey;
@@ -594,13 +612,17 @@ export function usePortfolioVisibleChainLive(opts: {
           marketId: token.underlyingContractId,
           poolId: token.poolId,
           displaySymbol: token.symbol,
-        }) as { price?: string | number } | undefined;
-        const tp = mkt?.price
-          ? formatPriceFromContract(
-              mkt.price as string | number,
-              token.decimals
-            )
-          : 1;
+        });
+        const tp = resolveWithLastGoodPortfolioUsd(
+        usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
+          displaySymbol: token.symbol,
+        }),
+        portfolioUsdCacheKey(
+          String(networkId),
+          String(token.poolId),
+          String(token.underlyingContractId)
+        )
+      );
 
         try {
           if (row.kind === "deposit") {
@@ -652,7 +674,7 @@ export function usePortfolioVisibleChainLive(opts: {
         }
       }
     }
-  }, [address, marketData, formatPriceFromContract, useApiUserData]);
+  }, [address, marketData, useApiUserData]);
 
   const fetchVisible = useCallback(
     async (mode: FetchMode) => {

--- a/src/services/__tests__/borrowBuildProbes.test.ts
+++ b/src/services/__tests__/borrowBuildProbes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { orderBorrowBuildProbes } from "@/services/lendingService";
+
+describe("orderBorrowBuildProbes", () => {
+  it("skips balance-box variants when the token never needs a box", () => {
+    expect(orderBorrowBuildProbes(false, "unknown")).toEqual([
+      [0, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("prefers no-create path when the box is already present, with create fallbacks", () => {
+    expect(orderBorrowBuildProbes(true, "present")).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+    ]);
+  });
+
+  it("prefers create-box path when the box is missing, with no-box fallbacks", () => {
+    expect(orderBorrowBuildProbes(true, "missing")).toEqual([
+      [1, 0],
+      [1, 1],
+      [0, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("falls back to returning-user-first order when status is unknown", () => {
+    expect(orderBorrowBuildProbes(true, "unknown")).toEqual([
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ]);
+  });
+});

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -38,6 +38,7 @@ import {
 } from "@/config";
 import algorandService, { AlgorandNetwork } from "./algorandService";
 import { ARC200Service } from "./arc200Service";
+import { runWithConcurrency } from "@/utils/runWithConcurrency";
 import { abi, CONTRACT } from "ulujs";
 import {
   APP_SPEC as LendingPoolAppSpec,
@@ -51,7 +52,7 @@ import {
 } from "@/utils/assetDecimals";
 import algosdk from "algosdk";
 import BigNumber from "bignumber.js";
-import { withRpcReadCache } from "@/utils/rpcReadCache";
+import { withRpcReadCache, invalidateRpcReadCache } from "@/utils/rpcReadCache";
 import { calcDepositReturn } from "@folks-finance/algorand-sdk";
 import {
   calculateDepositAPY,
@@ -482,6 +483,9 @@ const ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS: Partial<
   "3333688282": ["3575837891"],
 };
 
+/** Symbols that can use the Pool A fWBTC oracle feed when their own entry is stale/missing. */
+const BTC_ORACLE_REFERENCE_SYMBOLS = new Set(["GOBTC", "WBTC", "BTC"]);
+
 async function readOracleUsdPerToken(
   networkId: NetworkId,
   oracleKey: string,
@@ -557,37 +561,44 @@ async function applyOraclePriceToMarketInfo(
     .map((k) => (k != null ? String(k).trim() : ""))
     .filter((k, i, arr) => k !== "" && arr.indexOf(k) === i);
 
-  const candidates: Array<{ usd: number; timestampSec: number }> = [];
+  const pickBest = (
+    candidates: Array<{ usd: number; timestampSec: number }>
+  ) =>
+    candidates.reduce((a, b) => {
+      if (b.timestampSec !== a.timestampSec) {
+        return b.timestampSec > a.timestampSec ? b : a;
+      }
+      return b.usd > a.usd ? b : a;
+    });
+
+  const collectFromKeys = async (keys: string[]) => {
+    if (keys.length === 0) return [] as Array<{ usd: number; timestampSec: number }>;
+    const oracleResults = await Promise.all(
+      keys.map((key) => readOracleUsdPerToken(networkId, key, tokenDecimals))
+    );
+    return oracleResults.filter(
+      (o): o is { usd: number; timestampSec: number } => o != null
+    );
+  };
+
+  // Primary keys first — avoid BTC-ref RPCs when the market's own feed is live.
+  let candidates = await collectFromKeys(oracleKeys);
 
   const sym = marketInfo.symbol.toUpperCase();
   const btcRefMarkets =
     ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS[marketInfo.poolId];
-  const allOracleKeys = [...oracleKeys];
-  if (btcRefMarkets && sym === "GOBTC") {
-    for (const refMarketId of btcRefMarkets) {
-      if (!allOracleKeys.includes(refMarketId)) {
-        allOracleKeys.push(refMarketId);
-      }
-    }
-  }
-
-  const oracleResults = await Promise.all(
-    allOracleKeys.map((key) =>
-      readOracleUsdPerToken(networkId, key, tokenDecimals)
-    )
-  );
-  for (const oracle of oracleResults) {
-    if (oracle) candidates.push(oracle);
+  if (
+    candidates.length === 0 &&
+    btcRefMarkets &&
+    BTC_ORACLE_REFERENCE_SYMBOLS.has(sym)
+  ) {
+    const refKeys = btcRefMarkets.filter((id) => !oracleKeys.includes(id));
+    candidates = await collectFromKeys(refKeys);
   }
 
   if (candidates.length === 0) return;
 
-  const best = candidates.reduce((a, b) => {
-    if (b.timestampSec !== a.timestampSec) {
-      return b.timestampSec > a.timestampSec ? b : a;
-    }
-    return b.usd > a.usd ? b : a;
-  });
+  const best = pickBest(candidates);
 
   marketInfo.oracleUsdPerToken = best.usd;
   marketInfo.oraclePriceTimestampSec = best.timestampSec;
@@ -1169,126 +1180,121 @@ export async function fetchFreshMarketInfo(
   }
 }
 
+/** Cap parallel per-market fetches to avoid Algod/API stampedes. */
+const FETCH_ALL_MARKETS_CONCURRENCY = 6;
+
+type FetchAllMarketsToken = {
+  symbol: string;
+  poolId?: string | null;
+  underlyingContractId?: string;
+};
+
+async function fetchMarketInfosForTokens(
+  networkId: NetworkId,
+  tokens: FetchAllMarketsToken[],
+  concurrency: number = FETCH_ALL_MARKETS_CONCURRENCY
+): Promise<MarketInfo[]> {
+  const markets: MarketInfo[] = [];
+  await runWithConcurrency(tokens, concurrency, async (token) => {
+    try {
+      const poolId = token.poolId;
+      if (!poolId) {
+        console.warn(
+          `No pool ID configured for token ${token.symbol}, skipping`
+        );
+        return;
+      }
+      const marketId = token.underlyingContractId || token.symbol;
+      const marketInfo = await fetchMarketInfo(poolId, marketId, networkId);
+      if (marketInfo) {
+        markets.push(marketInfo);
+      } else {
+        console.warn(`No market data found for ${token.symbol}, skipping`);
+      }
+    } catch (error) {
+      console.error(`Error fetching market data for ${token.symbol}:`, error);
+    }
+  });
+  return markets;
+}
+
 /**
- * Fetch all markets information
+ * Fetch market rows for specific pool/market keys (position-first Portfolio hydrate).
+ */
+export const fetchMarketsByKeys = async (
+  keys: UserPositionMarketKey[],
+  options?: { concurrency?: number }
+): Promise<MarketInfo[]> => {
+  if (!keys.length) return [];
+  const concurrency = options?.concurrency ?? FETCH_ALL_MARKETS_CONCURRENCY;
+  const markets: MarketInfo[] = [];
+  await runWithConcurrency(keys, concurrency, async (key) => {
+    try {
+      const marketInfo = await fetchMarketInfo(
+        key.poolId,
+        key.marketId,
+        key.networkId
+      );
+      if (marketInfo) markets.push(marketInfo);
+    } catch (error) {
+      console.error(
+        `[fetchMarketsByKeys] failed for ${key.networkId}/${key.poolId}/${key.marketId}:`,
+        error
+      );
+    }
+  });
+  return markets;
+};
+
+/**
+ * Fetch all markets information (capped parallel fetches).
  */
 export const fetchAllMarkets = async (
   networkId: NetworkId,
-  options?: { excludeMarketsTableHidden?: boolean }
+  options?: {
+    excludeMarketsTableHidden?: boolean;
+    concurrency?: number;
+  }
 ): Promise<MarketInfo[]> => {
   try {
-    const networkConfig = getNetworkConfig(networkId);
+    const concurrency = options?.concurrency ?? FETCH_ALL_MARKETS_CONCURRENCY;
 
     if (isAlgorandCompatibleNetwork(networkId)) {
-      // Get markets from config
       const tokens = options?.excludeMarketsTableHidden
         ? getMarketsTableVisibleTokensWithDisplayInfo(networkId)
         : getAllTokensWithDisplayInfo(networkId);
 
-      console.log("Fetching real market data for", tokens.length, "tokens");
+      console.log(
+        "Fetching real market data for",
+        tokens.length,
+        "tokens (concurrency",
+        concurrency,
+        ")"
+      );
 
-      // Fetch real market data for each token
-      const markets: MarketInfo[] = [];
-
-      for (const token of tokens) {
-        try {
-          // Use the token's own poolId from config, not the first lending pool
-          const poolId = token.poolId;
-
-          if (!poolId) {
-            console.warn(
-              `No pool ID configured for token ${token.symbol}, skipping`
-            );
-            continue;
-          }
-
-          const marketId = token.underlyingContractId || token.symbol;
-
-          console.log(
-            `Fetching market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
-          );
-
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId); // fetch from api
-
-          if (marketInfo) {
-            console.log(
-              `Successfully fetched market data for ${token.symbol}:`,
-              {
-                price: marketInfo.price,
-                totalDeposits: marketInfo.totalDeposits,
-                totalBorrows: marketInfo.totalBorrows,
-                utilizationRate: marketInfo.utilizationRate,
-              }
-            );
-            markets.push(marketInfo);
-          } else {
-            console.warn(`No market data found for ${token.symbol}, skipping`);
-          }
-        } catch (error) {
-          console.error(
-            `Error fetching market data for ${token.symbol}:`,
-            error
-          );
-          // Continue with other tokens even if one fails
-        }
-      }
-
+      const markets = await fetchMarketInfosForTokens(
+        networkId,
+        tokens,
+        concurrency
+      );
       console.log(`Successfully fetched ${markets.length} markets`);
       return markets;
     } else if (isEVMNetwork(networkId)) {
-      // For EVM networks, fetch real market data
       const tokens = getAllTokensWithDisplayInfo(networkId);
 
-      console.log("Fetching real EVM market data for", tokens.length, "tokens");
+      console.log(
+        "Fetching real EVM market data for",
+        tokens.length,
+        "tokens (concurrency",
+        concurrency,
+        ")"
+      );
 
-      // Fetch real market data for each token
-      const markets: MarketInfo[] = [];
-
-      for (const token of tokens) {
-        try {
-          // Use the token's own poolId from config, not the first lending pool
-          const poolId = token.poolId;
-
-          if (!poolId) {
-            console.warn(
-              `No pool ID configured for token ${token.symbol}, skipping`
-            );
-            continue;
-          }
-
-          const marketId = token.underlyingContractId || token.symbol;
-
-          console.log(
-            `Fetching EVM market data for ${token.symbol} (marketId: ${marketId}, poolId: ${poolId})`
-          );
-
-          const marketInfo = await fetchMarketInfo(poolId, marketId, networkId);
-
-          if (marketInfo) {
-            console.log(
-              `Successfully fetched EVM market data for ${token.symbol}:`,
-              {
-                price: marketInfo.price,
-                totalDeposits: marketInfo.totalDeposits,
-                totalBorrows: marketInfo.totalBorrows,
-                utilizationRate: marketInfo.utilizationRate,
-              }
-            );
-            markets.push(marketInfo);
-          } else {
-            console.warn(
-              `No EVM market data found for ${token.symbol}, skipping`
-            );
-          }
-        } catch (error) {
-          console.error(
-            `Error fetching EVM market data for ${token.symbol}:`,
-            error
-          );
-          // Continue with other tokens even if one fails
-        }
-      }
-
+      const markets = await fetchMarketInfosForTokens(
+        networkId,
+        tokens,
+        concurrency
+      );
       console.log(`Successfully fetched ${markets.length} EVM markets`);
       return markets;
     } else {
@@ -5640,6 +5646,142 @@ export const migrate = async (
 };
 
 /**
+ * Detect whether the user already has an nt200/ARC200 balance box on the token app.
+ * Used to avoid blind multi-simulate probe loops when building borrow groups.
+ */
+export async function detectNt200UserBalanceBox(
+  algod: any,
+  tokenAppId: number | string,
+  userAddress: string
+): Promise<"present" | "missing" | "unknown"> {
+  const appId = Number(tokenAppId);
+  if (!Number.isFinite(appId) || appId <= 0 || !userAddress) {
+    return "unknown";
+  }
+  return withRpcReadCache(
+    `nt200UserBox:${appId}:${userAddress}`,
+    async () => {
+      try {
+        const boxName = algosdk.decodeAddress(userAddress).publicKey;
+        await algod.getApplicationBoxByName(appId, boxName).do();
+        return "present" as const;
+      } catch (error: unknown) {
+        const err = error as {
+          response?: { status?: number };
+          status?: number;
+          message?: string;
+        };
+        const status = err?.response?.status ?? err?.status;
+        const msg = String(err?.message ?? error ?? "").toLowerCase();
+        if (
+          status === 404 ||
+          msg.includes("not found") ||
+          msg.includes("no box") ||
+          msg.includes("box does not exist")
+        ) {
+          // Prefer unknown over hard "missing" — wrong box-name schemes must not
+          // lock borrow into createBalanceBox-only probes.
+          try {
+            const ci = new CONTRACT(appId, algod, undefined, abi.nt200, {
+              addr: userAddress,
+              sk: new Uint8Array(),
+            });
+            const r = await ci.arc200_balanceOf(userAddress);
+            if (r.success) return "present" as const;
+            // balanceOf failed after box 404 → likely truly missing
+            return "missing" as const;
+          } catch {
+            return "unknown" as const;
+          }
+        }
+        // Fallback: readable balance implies box exists
+        try {
+          const ci = new CONTRACT(appId, algod, undefined, abi.nt200, {
+            addr: userAddress,
+            sk: new Uint8Array(),
+          });
+          const r = await ci.arc200_balanceOf(userAddress);
+          return r.success ? ("present" as const) : ("missing" as const);
+        } catch {
+          return "unknown" as const;
+        }
+      }
+    },
+    60_000
+  );
+}
+
+/** Order [balanceBox, highFee] probes so the first simulate usually succeeds.
+ * Always keep fallbacks — wrong box detection must not make borrow unusable.
+ */
+export function orderBorrowBuildProbes(
+  needsBalanceBoxProbe: boolean,
+  boxStatus: "present" | "missing" | "unknown"
+): Array<[number, number]> {
+  if (!needsBalanceBoxProbe) {
+    return [
+      [0, 0],
+      [0, 1],
+    ];
+  }
+  if (boxStatus === "present") {
+    // Prefer no createBalanceBox, but keep create variants as fallback
+    return [
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+    ];
+  }
+  if (boxStatus === "missing") {
+    // Prefer createBalanceBox first, but keep no-box variants as fallback
+    // (box-name detection can false-negative)
+    return [
+      [1, 0],
+      [1, 1],
+      [0, 0],
+      [0, 1],
+    ];
+  }
+  // Unknown: prefer returning-user path, then first-time box create
+  return [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ];
+}
+
+/** Only skip remaining probes on very clear simulate signals. */
+function borrowProbeSkipFromSimulateError(
+  errorText: string
+): { skipP1Zero?: boolean; skipP1One?: boolean; skipP2Zero?: boolean } {
+  const err = errorText.toLowerCase();
+  const out: {
+    skipP1Zero?: boolean;
+    skipP1One?: boolean;
+    skipP2Zero?: boolean;
+  } = {};
+  // Only skip when the node clearly says the box already exists
+  if (
+    err.includes("box already exist") ||
+    err.includes("err box exist") ||
+    err.includes("box exists")
+  ) {
+    out.skipP1One = true;
+  }
+  // Do not skip p1=0 on vague "box" / "assert" errors — those are common on other failures
+  // and caused usable paths to be discarded (FINITE borrow regressions).
+  if (
+    err.includes("overspend") ||
+    err.includes("fee too small")
+  ) {
+    out.skipP2Zero = true;
+  }
+  return out;
+}
+
+/**
  * Borrow tokens from a lending market
  */
 export const borrow = async (
@@ -5705,104 +5847,71 @@ export const borrow = async (
         throw new Error("Token not found");
       }
 
-      // Check if user is opted into the asset (for ASA and arc200-exchange tokens)
-      // Note: If not opted in, the transaction will include an opt-in automatically
-      let optIn = {};
-      if (
-        tokenStandardUsesAsaStyleNt200Txns(tokenStandard) ||
-        tokenStandard === "arc200-exchange"
-      ) {
-        if (token.underlyingAssetId) {
-          try {
-            const accountAssetInfo = await clients.algod
-              .accountAssetInformation(
-                userAddress,
-                Number(token.underlyingAssetId)
-              )
-              .do();
-            console.log(
-              `User is opted into asset ${token.underlyingAssetId} (${token.symbol})`
-            );
-          } catch (error: any) {
-            // If the error indicates the user is not opted in, log a warning
-            // The transaction will handle the opt-in automatically
-            if (
-              error?.response?.status === 404 ||
-              error?.response?.status === 400 ||
-              error?.message?.includes("not found") ||
-              error?.message?.includes("not opted") ||
-              error?.message?.includes("does not exist")
-            ) {
-              console.warn(
-                `User is not opted into asset ${token.underlyingAssetId} (${token.symbol}). Opt-in will be included in the transaction.`
+      // Opt-in check + market info in parallel (single market fetch; pause via marketInfo)
+      const needsAsaOptInCheck =
+        (tokenStandardUsesAsaStyleNt200Txns(tokenStandard) ||
+          tokenStandard === "arc200-exchange") &&
+        !!token.underlyingAssetId;
+
+      const optInCheckPromise = needsAsaOptInCheck
+        ? clients.algod
+            .accountAssetInformation(
+              userAddress,
+              Number(token.underlyingAssetId)
+            )
+            .do()
+            .then(() => {
+              console.log(
+                `User is opted into asset ${token.underlyingAssetId} (${token.symbol})`
               );
-              optIn = {
-                xaid: Number(token.underlyingAssetId),
-                snd: userAddress,
-                arcv: userAddress,
-              };
-            } else {
-              // Re-throw unexpected errors
+              return {} as Record<string, unknown>;
+            })
+            .catch((error: any) => {
+              if (
+                error?.response?.status === 404 ||
+                error?.response?.status === 400 ||
+                error?.message?.includes("not found") ||
+                error?.message?.includes("not opted") ||
+                error?.message?.includes("does not exist")
+              ) {
+                console.warn(
+                  `User is not opted into asset ${token.underlyingAssetId} (${token.symbol}). Opt-in will be included in the transaction.`
+                );
+                return {
+                  xaid: Number(token.underlyingAssetId),
+                  snd: userAddress,
+                  arcv: userAddress,
+                } as Record<string, unknown>;
+              }
               console.error("Error checking asset opt-in status:", error);
               throw error;
-            }
-          }
-        }
-      }
+            })
+        : Promise.resolve({} as Record<string, unknown>);
 
-      // Convert amount to proper units (considering decimals)
-      const bigAmount = BigInt(amount);
+      const [optIn, marketInfo, boxStatusEarly] = await Promise.all([
+        optInCheckPromise,
+        fetchMarketInfo(poolId, marketId, networkId),
+        tokenStandard == "network" ||
+        tokenStandardUsesAsaStyleNt200Txns(tokenStandard)
+          ? detectNt200UserBalanceBox(
+              clients.algod,
+              token.underlyingContractId,
+              userAddress
+            )
+          : Promise.resolve("unknown" as const),
+      ]);
 
-      // Check if market is paused
-      const marketPaused = await isMarketPaused(poolId, marketId, networkId);
-      if (marketPaused) {
-        throw new Error("Market is paused");
-      }
-
-      // Get market info and user global data to check borrowing capacity
-      console.log({
-        fetchMarketInfo: {
-          poolId,
-          marketId,
-          networkId,
-        },
-      });
-      const marketInfo = await fetchMarketInfo(poolId, marketId, networkId);
       if (!marketInfo) {
         throw new Error("Failed to fetch market info");
+      }
+      if (marketInfo.isPaused) {
+        throw new Error("Market is paused");
       }
 
       console.log("marketInfo", { marketInfo });
 
-      // Get user global data to check borrowing capacity
-      const userGlobalData = await fetchUserGlobalData(userAddress, networkId);
-      if (!userGlobalData) {
-        throw new Error("Failed to fetch user global data");
-      }
-
-      console.log("userGlobalData", { userGlobalData });
-
-      const borrowAmount = new BigNumber(amount);
-
-      // Check if borrow would exceed available liquidity in the market
-      const currentTotalDeposits = new BigNumber(marketInfo.totalDeposits);
-      const currentTotalBorrows = new BigNumber(marketInfo.totalBorrows);
-      const availableLiquidity =
-        currentTotalDeposits.minus(currentTotalBorrows);
-
-      if (borrowAmount.isGreaterThan(availableLiquidity)) {
-        //throw new Error("Insufficient liquidity available for borrowing");
-      }
-
-      // Check if borrow would exceed max total borrows for the market
-      const maxTotalBorrows = new BigNumber(marketInfo.maxTotalBorrows);
-      if (
-        currentTotalBorrows.plus(borrowAmount).isGreaterThan(maxTotalBorrows)
-      ) {
-        //throw new Error("Borrow would exceed maximum total borrows");
-      }
-
-      // Collateral-based validation removed
+      // Convert amount to proper units (considering decimals)
+      const bigAmount = BigInt(amount);
 
       const ci = new CONTRACT(
         Number(poolId),
@@ -5814,21 +5923,6 @@ export const borrow = async (
           sk: new Uint8Array(),
         }
       );
-      const ciLending = new CONTRACT(
-        Number(poolId),
-        clients.algod,
-        undefined,
-        { ...LendingPoolAppSpec.contract, events: [] },
-        { addr: userAddress, sk: new Uint8Array() }
-      );
-
-      ciLending.setFee(5000);
-      ciLending.setPaymentAmount(1e5);
-      const fetch_price_feedR = await ciLending.fetch_price_feed(
-        Number(marketId)
-      );
-      console.log("fetch_price_feedR", { fetch_price_feedR });
-      const doFetchPriceFeed = fetch_price_feedR.success;
 
       const builder = {
         lending: new CONTRACT(
@@ -5982,36 +6076,36 @@ export const borrow = async (
           folksMintTxnsToArccjsExtraTxns(burnUnsigned);
       }
 
-      ciLending.setFee(5000);
-
-      // const calculate_user_debt_interestR =
-      //   await ciLending.calculate_user_debt_interest(
-      //     userAddress,
-      //     Number(marketId)
-      //   );
-      // console.log("calculate_user_debt_interestR", {
-      //   calculate_user_debt_interestR,
-      // });
-      // const calculate_user_debt_interest =
-      //   calculate_user_debt_interestR.returnValue;
-      // console.log("calculate_user_debt_interest", {
-      //   calculate_user_debt_interest,
-      // });
-
-      // const sync_marketR = await ciLending.sync_market(Number(marketId));
-      // console.log("sync_marketR", { sync_marketR });
-
       let customTx: any;
 
-      // p1 - create balance box user
-      // p2 - payment to approve spending of token
-      for (const p of [
-        [0, 0], // no balance box, no approve
-        [1, 0], // balance box, no approve
-        [1, 1], // balance box, approve
-        [0, 1], // no balance box, approve
-      ]) {
+      // p1 - create balance box user; p2 - higher payment for inner-txn funding
+      const needsBalanceBoxProbe =
+        tokenStandard == "network" ||
+        tokenStandardUsesAsaStyleNt200Txns(tokenStandard);
+
+      const boxStatus = needsBalanceBoxProbe ? boxStatusEarly : "unknown";
+
+      const buildProbes = orderBorrowBuildProbes(
+        needsBalanceBoxProbe,
+        boxStatus
+      );
+
+      console.log("borrow build probes", {
+        needsBalanceBoxProbe,
+        boxStatus,
+        buildProbes,
+      });
+
+      let skipP1Zero = false;
+      let skipP1One = false;
+      let skipP2Zero = false;
+
+      for (const p of buildProbes) {
         const [p1, p2] = p;
+        if (p1 === 0 && skipP1Zero) continue;
+        if (p1 === 1 && skipP1One) continue;
+        if (p2 === 0 && skipP2Zero) continue;
+
         const buildN = [];
 
         // cond create balance box user if needed and network token
@@ -6092,7 +6186,7 @@ export const borrow = async (
           });
         }
 
-        console.log("buildN", { buildN });
+        console.log("buildN", { buildN, p1, p2 });
 
         // Create borrow transaction
         ci.setFee(20000);
@@ -6104,26 +6198,40 @@ export const borrow = async (
 
         customTx = await ci.custom();
 
-        console.log("customTx", { customTx });
+        console.log("customTx", { customTx, p1, p2 });
 
         if (customTx.success) {
           break;
         }
+
+        const errText = String(customTx?.error ?? "");
+        const skip = borrowProbeSkipFromSimulateError(errText);
+        if (skip.skipP1Zero) skipP1Zero = true;
+        if (skip.skipP1One) skipP1One = true;
+        if (skip.skipP2Zero) skipP2Zero = true;
       }
 
       console.log("customTx", { customTx });
 
-      if (!customTx.success) {
-        if (customTx.error.match(/tried to spend/)) {
-          throw new Error(customTx.error);
+      if (!customTx?.success) {
+        invalidateRpcReadCache(
+          `nt200UserBox:${Number(token.underlyingContractId)}:${userAddress}`
+        );
+        const errText = String(customTx?.error ?? "Borrow transaction failed");
+        if (/tried to spend/i.test(errText)) {
+          throw new Error(errText);
         } else if (
-          customTx.error.match(
-            /logic eval error: assert failed pc=.*opcodes=b[/]; b<=; assert/
+          /logic eval error: assert failed pc=.*opcodes=b[/]; b<=; assert/.test(
+            errText
           )
         ) {
           throw new Error("insufficient collateral for borrow");
         }
-        throw new Error("Borrow transaction failed");
+        throw new Error(
+          errText && errText !== "undefined"
+            ? errText
+            : "Borrow transaction failed"
+        );
       }
 
       return {

--- a/src/utils/__tests__/assetDecimals.test.ts
+++ b/src/utils/__tests__/assetDecimals.test.ts
@@ -12,6 +12,7 @@ import {
   usdPerTokenFromOracleContractRaw,
   marketInfoFormattedPriceFromUsdPerToken,
   resolveUsdPerTokenFromMarketInfo,
+  usdPerTokenFromPortfolioMarketRow,
   usdValueForHumanTokenAmount,
 } from "../assetDecimals";
 
@@ -179,6 +180,33 @@ describe("resolveUsdPerTokenFromMarketInfo", () => {
     expect(
       resolveUsdPerTokenFromMarketInfo({ price: "7120000" }, 6)
     ).toBe(7.12);
+  });
+});
+
+describe("usdPerTokenFromPortfolioMarketRow", () => {
+  it("returns 0 for missing market instead of inventing $1", () => {
+    expect(usdPerTokenFromPortfolioMarketRow(null, 8)).toBe(0);
+    expect(usdPerTokenFromPortfolioMarketRow(undefined, 8)).toBe(0);
+    expect(usdPerTokenFromPortfolioMarketRow({}, 8)).toBe(0);
+  });
+
+  it("uses oracleUsdPerToken when attached", () => {
+    expect(
+      usdPerTokenFromPortfolioMarketRow(
+        { price: "0", oracleUsdPerToken: 75440.41 },
+        8
+      )
+    ).toBeCloseTo(75440.41, 2);
+  });
+
+  it("normalizes WAD micro-USD (Markets-style)", () => {
+    expect(
+      usdPerTokenFromPortfolioMarketRow(
+        { price: "1000000", symbol: "WAD", oracleUsdPerToken: 1_000_000 },
+        6,
+        { displaySymbol: "WAD" }
+      )
+    ).toBeCloseTo(1, 5);
   });
 });
 

--- a/src/utils/__tests__/portfolioMarketHydrate.test.ts
+++ b/src/utils/__tests__/portfolioMarketHydrate.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  readPortfolioMarketsSessionCache,
+  writePortfolioMarketsSessionCache,
+  mergePortfolioMarketRows,
+} from "../portfolioMarketHydrate";
+import type { MarketInfo } from "@/services/lendingService";
+
+const sample = {
+  networkId: "algorand-mainnet",
+  poolId: "1",
+  marketId: "2",
+  symbol: "UNIT",
+  decimals: 8,
+  price: "100",
+} as MarketInfo;
+
+describe("portfolioMarketsSessionCache", () => {
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("round-trips MarketInfo rows", () => {
+    writePortfolioMarketsSessionCache("algorand-mainnet", [sample]);
+    const read = readPortfolioMarketsSessionCache("algorand-mainnet");
+    expect(read).toHaveLength(1);
+    expect(read?.[0]?.marketId).toBe("2");
+    expect(read?.[0]?.symbol).toBe("UNIT");
+  });
+
+  it("returns null when empty", () => {
+    expect(readPortfolioMarketsSessionCache("voi-mainnet")).toBeNull();
+  });
+});
+
+describe("mergePortfolioMarketRows", () => {
+  const baseKey = {
+    networkId: "algorand-mainnet",
+    poolId: "10",
+    marketId: "20",
+    symbol: "BTC",
+    decimals: 8,
+  } as const;
+
+  it("keeps oracle-refined row when Phase A bulk has USD but no oracle", () => {
+    const phaseB = {
+      ...baseKey,
+      price: "1000000",
+      oracleUsdPerToken: 95_000,
+    } as MarketInfo;
+    const phaseA = {
+      ...baseKey,
+      price: "800000",
+      // no oracleUsdPerToken — bulk decode only
+    } as MarketInfo;
+
+    const merged = mergePortfolioMarketRows([phaseB], [phaseA]) as MarketInfo[];
+    expect(merged).toHaveLength(1);
+    expect(merged[0].oracleUsdPerToken).toBe(95_000);
+  });
+
+  it("accepts Phase B oracle over a prior bulk-only row", () => {
+    const phaseA = {
+      ...baseKey,
+      price: "800000",
+    } as MarketInfo;
+    const phaseB = {
+      ...baseKey,
+      price: "1000000",
+      oracleUsdPerToken: 95_000,
+    } as MarketInfo;
+
+    const merged = mergePortfolioMarketRows([phaseA], [phaseB]) as MarketInfo[];
+    expect(merged[0].oracleUsdPerToken).toBe(95_000);
+  });
+
+  it("takes incoming when neither row has oracle and incoming has USD", () => {
+    const older = {
+      ...baseKey,
+      price: "0",
+    } as MarketInfo;
+    const newer = {
+      ...baseKey,
+      price: "1000000",
+    } as MarketInfo;
+
+    const merged = mergePortfolioMarketRows([older], [newer]) as MarketInfo[];
+    expect(merged[0].price).toBe("1000000");
+  });
+});

--- a/src/utils/__tests__/portfolioUsdCache.test.ts
+++ b/src/utils/__tests__/portfolioUsdCache.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  portfolioUsdCacheKey,
+  rememberPortfolioUsdPerToken,
+  resolveWithLastGoodPortfolioUsd,
+} from "../portfolioUsdCache";
+import { runWithConcurrency } from "../runWithConcurrency";
+
+describe("portfolioUsdCache", () => {
+  it("remembers and recalls last-good USD", () => {
+    const key = portfolioUsdCacheKey("algorand-mainnet", "1", "2");
+    rememberPortfolioUsdPerToken(key, 12.5);
+    expect(resolveWithLastGoodPortfolioUsd(0, key)).toBe(12.5);
+    expect(resolveWithLastGoodPortfolioUsd(13, key)).toBe(13);
+  });
+
+  it("does not invent a price without cache", () => {
+    const key = portfolioUsdCacheKey("algorand-mainnet", "9", "9");
+    expect(resolveWithLastGoodPortfolioUsd(0, key)).toBe(0);
+  });
+});
+
+describe("runWithConcurrency", () => {
+  it("runs all items with capped parallelism", async () => {
+    const seen: number[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await runWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      seen.push(n);
+      inFlight--;
+    });
+    expect(seen.sort()).toEqual([1, 2, 3, 4, 5]);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/utils/assetDecimals.ts
+++ b/src/utils/assetDecimals.ts
@@ -4,6 +4,7 @@
  */
 
 import BigNumber from "bignumber.js";
+import { normalizeWadUsdPerToken } from "@/lib/utils";
 
 /** Max fraction digits we show for asset amounts (e.g. goBTC has 8). */
 const MAX_DISPLAY_DECIMALS = 8;
@@ -116,6 +117,51 @@ export function resolveUsdPerTokenFromMarketInfo(
     return oracle;
   }
   return usdPerTokenFromMarketInfoPrice(marketInfo.price, tokenDecimals);
+}
+
+/**
+ * Portfolio / list-row helper: resolve USD per token from a marketData row.
+ * Returns 0 when price is missing or invalid — never invents $1.
+ * For WAD, applies {@link normalizeWadUsdPerToken} (micro-USD → $1) like MarketsTable.
+ */
+export function usdPerTokenFromPortfolioMarketRow(
+  market: unknown,
+  tokenDecimals: number,
+  options?: { displaySymbol?: string | null }
+): number {
+  if (!market || typeof market !== "object") return 0;
+  const m = market as {
+    price?: string | number | null;
+    oracleUsdPerToken?: number;
+    symbol?: string;
+  };
+  const priceStr =
+    m.price !== undefined && m.price !== null ? String(m.price) : "";
+  let usd = resolveUsdPerTokenFromMarketInfo(
+    {
+      price: priceStr,
+      oracleUsdPerToken:
+        typeof m.oracleUsdPerToken === "number"
+          ? m.oracleUsdPerToken
+          : undefined,
+    },
+    tokenDecimals
+  );
+
+  const sym = String(options?.displaySymbol ?? m.symbol ?? "").toUpperCase();
+  if (sym === "WAD") {
+    // Markets-style: treat decoded / oracle USD as possibly micro-USD, then normalize.
+    if (!(usd > 0) && priceStr !== "") {
+      const raw = Number.parseFloat(priceStr.replace(/,/g, ""));
+      if (Number.isFinite(raw) && raw > 0) {
+        usd = normalizeWadUsdPerToken(raw);
+      }
+    } else if (usd > 0) {
+      usd = normalizeWadUsdPerToken(usd);
+    }
+  }
+
+  return Number.isFinite(usd) && usd > 0 ? usd : 0;
 }
 
 export function usdPerTokenFromMarketInfoPrice(

--- a/src/utils/modalPrefetch.ts
+++ b/src/utils/modalPrefetch.ts
@@ -19,6 +19,7 @@ import {
   fetchUserGlobalDataForPool,
   fetchMarketInfoFromContract,
   getMaxWithdrawableForMarket,
+  detectNt200UserBalanceBox,
 } from "@/services/lendingService";
 import { estimateFolksDepositMintedFAssetAmount } from "@/services/folksDepositAdapter";
 import { fetchPoolCollateralMarketRowsForDeposit } from "@/utils/poolCollateralMarketRows";
@@ -136,6 +137,25 @@ export function warmBorrowModalMaxAndPool(params: MarketActionTokenParams): void
     token.underlyingContractId,
     storageAppId ? Number(storageAppId) : undefined
   ).catch(() => undefined);
+
+  // Warm nt200 balance-box detection so borrow() can pick a single simulate path
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (algodNet) {
+    void (async () => {
+      try {
+        const clients = algorandService.initializeClients(
+          algodNet as AlgorandNetwork
+        );
+        await detectNt200UserBalanceBox(
+          clients.algod,
+          token.underlyingContractId,
+          params.userAddress
+        );
+      } catch {
+        /* ignore */
+      }
+    })();
+  }
 }
 
 /** Repay modal: global user data + current borrow balance. */

--- a/src/utils/portfolioMarketHydrate.ts
+++ b/src/utils/portfolioMarketHydrate.ts
@@ -1,0 +1,303 @@
+/**
+ * Fast Portfolio market hydrate: bulk API Phase A (no oracle) → paint,
+ * then background Phase B oracle refine. Mirrors Markets `useOnDemandMarketData`
+ * so Value (USD) / APY appear in ~1 RTT instead of N×(GET+oracle).
+ */
+
+import {
+  getAllTokensWithDisplayInfo,
+  filterPortfolioVisibleMarketRows,
+  type NetworkId,
+} from "@/config";
+import {
+  buildMarketInfoFromRawMarketData,
+  fetchBulkApiMarketDataMap,
+  fetchMarketsByKeys,
+  marketDataLookupKey,
+  type MarketData,
+  type MarketInfo,
+  type UserPositionMarketKey,
+} from "@/services/lendingService";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import { runWithConcurrency } from "@/utils/runWithConcurrency";
+
+function marketDataRowKey(row: unknown): string {
+  const m = row as {
+    networkId?: string;
+    poolId?: string | number;
+    appId?: string | number;
+    marketId?: string | number;
+  };
+  return `${String(m.networkId ?? "")}|${String(m.poolId ?? m.appId ?? "")}|${String(m.marketId ?? "")}`;
+}
+
+function hasOracleUsd(row: unknown): boolean {
+  const o = (row as MarketInfo).oracleUsdPerToken;
+  return typeof o === "number" && Number.isFinite(o) && o > 0;
+}
+
+/**
+ * Merge market rows by network|pool|market key.
+ * Prefer oracle-refined rows over Phase A bulk (applyOracle: false) so a
+ * user-data refresh cannot clobber Phase B prices with cheaper bulk USD.
+ */
+export function mergePortfolioMarketRows(
+  prev: unknown[],
+  next: unknown[]
+): unknown[] {
+  const map = new Map<string, unknown>();
+  for (const row of prev) {
+    map.set(marketDataRowKey(row), row);
+  }
+  for (const row of next) {
+    const key = marketDataRowKey(row);
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, row);
+      continue;
+    }
+    // Keep Phase B / oracle-refined pricing when incoming is bulk-only.
+    if (hasOracleUsd(existing) && !hasOracleUsd(row)) {
+      continue;
+    }
+    const existingMi = existing as MarketInfo;
+    const incomingMi = row as MarketInfo;
+    const existingUsd = usdPerTokenFromPortfolioMarketRow(
+      existing,
+      existingMi.decimals ?? 6,
+      { displaySymbol: existingMi.symbol }
+    );
+    const incomingUsd = usdPerTokenFromPortfolioMarketRow(
+      row,
+      incomingMi.decimals ?? 6,
+      { displaySymbol: incomingMi.symbol }
+    );
+    // Prefer a row with a usable price; otherwise take the fresher incoming snapshot.
+    if (incomingUsd > 0 || existingUsd <= 0) {
+      map.set(key, row);
+    }
+  }
+  return [...map.values()];
+}
+
+const PORTFOLIO_MARKETS_SESSION_TTL_MS = 60_000;
+const MARKETS_TABLE_SESSION_TTL_MS = 60_000;
+const REFINE_CONCURRENCY = 6;
+
+function portfolioMarketsSessionKey(networkId: NetworkId): string {
+  return `dorkfi:portfolioMarkets:${networkId}`;
+}
+
+function marketsTableSessionKey(networkId: NetworkId): string {
+  return `dorkfi:marketsHydrate:${networkId}`;
+}
+
+/** Instant paint from last Portfolio Phase A/B snapshot. */
+export function readPortfolioMarketsSessionCache(
+  networkId: NetworkId
+): MarketInfo[] | null {
+  if (typeof sessionStorage === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(portfolioMarketsSessionKey(networkId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      savedAt?: number;
+      data?: MarketInfo[];
+    };
+    if (
+      !parsed?.savedAt ||
+      !Array.isArray(parsed.data) ||
+      Date.now() - parsed.savedAt > PORTFOLIO_MARKETS_SESSION_TTL_MS
+    ) {
+      return null;
+    }
+    return parsed.data;
+  } catch {
+    return null;
+  }
+}
+
+export function writePortfolioMarketsSessionCache(
+  networkId: NetworkId,
+  markets: MarketInfo[]
+): void {
+  if (typeof sessionStorage === "undefined" || markets.length === 0) return;
+  try {
+    sessionStorage.setItem(
+      portfolioMarketsSessionKey(networkId),
+      JSON.stringify({ savedAt: Date.now(), data: markets })
+    );
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}
+
+/**
+ * Reuse Markets table hydrate cache when the user visited Markets first.
+ * Extracts embedded `marketInfo` rows only.
+ */
+export function marketInfosFromMarketsTableSession(
+  networkId: NetworkId
+): MarketInfo[] {
+  if (typeof sessionStorage === "undefined") return [];
+  try {
+    const raw = sessionStorage.getItem(marketsTableSessionKey(networkId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as {
+      savedAt?: number;
+      data?: Record<string, { marketInfo?: MarketInfo; isLoaded?: boolean }>;
+    };
+    if (
+      !parsed?.savedAt ||
+      !parsed.data ||
+      Date.now() - parsed.savedAt > MARKETS_TABLE_SESSION_TTL_MS
+    ) {
+      return [];
+    }
+    const out: MarketInfo[] = [];
+    for (const row of Object.values(parsed.data)) {
+      if (row?.isLoaded && row.marketInfo?.marketId && row.marketInfo?.poolId) {
+        out.push(row.marketInfo);
+      }
+    }
+    return filterPortfolioVisibleMarketRows(networkId, out);
+  } catch {
+    return [];
+  }
+}
+
+export type PortfolioOracleRefineJob = {
+  networkId: NetworkId;
+  poolId: string;
+  marketId: string;
+  raw: MarketData;
+};
+
+export type PortfolioBulkHydrateResult = {
+  markets: MarketInfo[];
+  refineJobs: PortfolioOracleRefineJob[];
+  /** Position/token keys missing from bulk — gap-fill with per-market GET. */
+  missingKeys: UserPositionMarketKey[];
+};
+
+/**
+ * Phase A: one bulk GET + CPU build (no oracle RPC) → MarketInfo[] ready to paint.
+ */
+export async function hydratePortfolioNetworkMarketsPhaseA(
+  networkId: NetworkId
+): Promise<PortfolioBulkHydrateResult> {
+  const tokens = getAllTokensWithDisplayInfo(networkId);
+  let bulkMap: Map<string, MarketData> | null = null;
+  try {
+    bulkMap = await fetchBulkApiMarketDataMap(networkId);
+  } catch (e) {
+    console.warn(
+      `[portfolioMarketHydrate] bulk fetch failed for ${networkId}; gap-fill only`,
+      e
+    );
+  }
+
+  const markets: MarketInfo[] = [];
+  const refineJobs: PortfolioOracleRefineJob[] = [];
+  const missingKeys: UserPositionMarketKey[] = [];
+
+  for (const token of tokens) {
+    const poolId = token.poolId != null ? String(token.poolId) : "";
+    const marketId = String(
+      token.underlyingContractId ||
+        token.underlyingAssetId ||
+        token.originalContractId ||
+        ""
+    ).trim();
+    if (!poolId || !marketId) continue;
+
+    const raw = bulkMap?.get(marketDataLookupKey(poolId, marketId));
+    if (!raw) {
+      missingKeys.push({ networkId, poolId, marketId });
+      continue;
+    }
+
+    try {
+      const marketInfo = await buildMarketInfoFromRawMarketData(
+        raw,
+        poolId,
+        marketId,
+        networkId,
+        { applyOracle: false }
+      );
+      if (!marketInfo) {
+        missingKeys.push({ networkId, poolId, marketId });
+        continue;
+      }
+      markets.push(marketInfo);
+      refineJobs.push({ networkId, poolId, marketId, raw });
+    } catch (error) {
+      console.warn(
+        `[portfolioMarketHydrate] Phase A build failed ${networkId}/${poolId}/${marketId}`,
+        error
+      );
+      missingKeys.push({ networkId, poolId, marketId });
+    }
+  }
+
+  return {
+    markets: filterPortfolioVisibleMarketRows(networkId, markets),
+    refineJobs,
+    missingKeys,
+  };
+}
+
+/**
+ * Phase B: oracle refine in background (capped concurrency). Calls `onMarket`
+ * as each market completes so Portfolio can merge without waiting for all.
+ */
+export async function refinePortfolioMarketsPhaseB(
+  jobs: PortfolioOracleRefineJob[],
+  onMarket: (market: MarketInfo) => void,
+  isCancelled?: () => boolean
+): Promise<void> {
+  if (jobs.length === 0) return;
+  await runWithConcurrency(jobs, REFINE_CONCURRENCY, async (job) => {
+    if (isCancelled?.()) return;
+    try {
+      const marketInfo = await buildMarketInfoFromRawMarketData(
+        job.raw,
+        job.poolId,
+        job.marketId,
+        job.networkId,
+        { applyOracle: true }
+      );
+      if (isCancelled?.() || !marketInfo) return;
+      onMarket(marketInfo);
+    } catch (error) {
+      console.warn(
+        `[portfolioMarketHydrate] Phase B refine failed ${job.networkId}/${job.poolId}/${job.marketId}`,
+        error
+      );
+    }
+  });
+}
+
+/**
+ * Gap-fill keys missing from bulk (prefer position keys). Uses capped parallel GETs.
+ */
+export async function gapFillPortfolioMarkets(
+  keys: UserPositionMarketKey[],
+  options?: { concurrency?: number }
+): Promise<MarketInfo[]> {
+  if (keys.length === 0) return [];
+  const markets = await fetchMarketsByKeys(keys, {
+    concurrency: options?.concurrency ?? REFINE_CONCURRENCY,
+  });
+  const byNetwork = new Map<NetworkId, MarketInfo[]>();
+  for (const m of markets) {
+    const list = byNetwork.get(m.networkId) ?? [];
+    list.push(m);
+    byNetwork.set(m.networkId, list);
+  }
+  const visible: MarketInfo[] = [];
+  for (const [networkId, list] of byNetwork) {
+    visible.push(...filterPortfolioVisibleMarketRows(networkId, list));
+  }
+  return visible;
+}

--- a/src/utils/portfolioUsdCache.ts
+++ b/src/utils/portfolioUsdCache.ts
@@ -1,0 +1,43 @@
+/**
+ * Session-scoped last-known USD/token for Portfolio positions.
+ * Prevents Value (USD) from flashing $0 while market rows rehydrate.
+ */
+
+export function portfolioUsdCacheKey(
+  networkId: string,
+  poolId: string,
+  marketId: string
+): string {
+  return `${networkId}|${poolId}|${marketId}`;
+}
+
+const lastGoodPortfolioUsdPerToken = new Map<string, number>();
+
+export function rememberPortfolioUsdPerToken(
+  key: string,
+  usdPerToken: number
+): void {
+  if (usdPerToken > 0 && Number.isFinite(usdPerToken)) {
+    lastGoodPortfolioUsdPerToken.set(key, usdPerToken);
+  }
+}
+
+export function recallPortfolioUsdPerToken(key: string): number {
+  const stale = lastGoodPortfolioUsdPerToken.get(key);
+  return typeof stale === "number" && stale > 0 ? stale : 0;
+}
+
+export function resolveWithLastGoodPortfolioUsd(
+  usdPerToken: number,
+  key: string | null
+): number {
+  if (usdPerToken > 0 && Number.isFinite(usdPerToken)) {
+    if (key) rememberPortfolioUsdPerToken(key, usdPerToken);
+    return usdPerToken;
+  }
+  if (key) {
+    const stale = recallPortfolioUsdPerToken(key);
+    if (stale > 0) return stale;
+  }
+  return 0;
+}

--- a/src/utils/runWithConcurrency.ts
+++ b/src/utils/runWithConcurrency.ts
@@ -1,0 +1,20 @@
+/**
+ * Run async work over `items` with a fixed max in-flight count.
+ * Used for market/oracle hydrates to avoid serial waterfalls and RPC stampedes.
+ */
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>
+): Promise<void> {
+  if (items.length === 0) return;
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  let nextIndex = 0;
+  const runners = Array.from({ length: limit }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      await worker(items[index], index);
+    }
+  });
+  await Promise.all(runners);
+}


### PR DESCRIPTION
Speed up Portfolio Value (USD) / APY paint with bulk Phase A hydrate plus background Phase B oracle refine, session USD cache, and borrow-modal prefetch. Preserve oracle-refined prices when Phase A refreshes, and clear stale max-borrow while recalculating so asset switches cannot submit against the prior market’s limit.