### PR TITLE
perf(markets): shrink Markets critical path and cache position reads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { LocaleSettingsProvider } from "./contexts/LocaleSettingsContext";
 import Index from "./pages/Index";
 import { isFeatureEnabled } from "./config";
 import CountdownPage from "./pages/Countdown";
+import { LazyRouteFallback } from "@/components/LazySuspenseFallback";
 //const LAUNCH_TIMESTAMP = Date.UTC(2025, 10, 21, 2, 0, 0); // Nov 20, 2025 6:00 PM PST (Nov 21, 2025 2:00 AM UTC)
 const LAUNCH_TIMESTAMP = Date.now();
 
@@ -91,7 +92,7 @@ function App() {
               <Route
                 path="/admin"
                 element={
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<LazyRouteFallback />}>
                     <Admin />
                   </Suspense>
                 }
@@ -100,7 +101,7 @@ function App() {
                 <Route
                   path="/gas-station"
                   element={
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<LazyRouteFallback />}>
                       <GasStationPage />
                     </Suspense>
                   }
@@ -111,7 +112,7 @@ function App() {
                 <Route
                   path="/liquidation-markets"
                   element={
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<LazyRouteFallback />}>
                       <LiquidationMarketsPage
                         activeTab={activeTab}
                         onTabChange={setActiveTab}
@@ -123,7 +124,7 @@ function App() {
               <Route
                 path="/analytics"
                 element={
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<LazyRouteFallback />}>
                     <Analytics
                       activeTab={activeTab}
                       onTabChange={setActiveTab}
@@ -135,7 +136,7 @@ function App() {
                 <Route
                   path="/governance"
                   element={
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<LazyRouteFallback />}>
                       <Governance />
                     </Suspense>
                   }
@@ -145,7 +146,7 @@ function App() {
                 <Route
                   path="/pools"
                   element={
-                    <Suspense fallback={null}>
+                    <Suspense fallback={<LazyRouteFallback />}>
                       <PoolsPage
                         activeTab={activeTab}
                         onTabChange={setActiveTab}
@@ -157,7 +158,7 @@ function App() {
               <Route
                 path="/portfolio"
                 element={
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<LazyRouteFallback />}>
                     <PortfolioPage />
                   </Suspense>
                 }
@@ -165,7 +166,7 @@ function App() {
               <Route
                 path="/portfolio/:address"
                 element={
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<LazyRouteFallback />}>
                     <PortfolioPage />
                   </Suspense>
                 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,21 +5,19 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/theme-provider";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import Admin from "./pages/Admin";
-import Analytics from "./pages/Analytics";
-import Governance from "./pages/Governance";
 import { NetworkProvider } from "./contexts/NetworkContext";
 import { LocaleSettingsProvider } from "./contexts/LocaleSettingsContext";
 import Index from "./pages/Index";
 import { isFeatureEnabled } from "./config";
 import CountdownPage from "./pages/Countdown";
-import Dashboard from "./components/Dashboard";
-import Portfolio from "./components/Portfolio";
-import PoolsPage from "./pages/Pools";
-import PortfolioPage from "./pages/PortfolioPage";
 //const LAUNCH_TIMESTAMP = Date.UTC(2025, 10, 21, 2, 0, 0); // Nov 20, 2025 6:00 PM PST (Nov 21, 2025 2:00 AM UTC)
 const LAUNCH_TIMESTAMP = Date.now();
 
+const Admin = lazy(() => import("./pages/Admin"));
+const Analytics = lazy(() => import("./pages/Analytics"));
+const Governance = lazy(() => import("./pages/Governance"));
+const PoolsPage = lazy(() => import("./pages/Pools"));
+const PortfolioPage = lazy(() => import("./pages/PortfolioPage"));
 const GasStationPage = lazy(() => import("./pages/GasStation"));
 const LiquidationMarketsPage = lazy(() => import("./pages/LiquidationMarkets"));
 
@@ -90,7 +88,14 @@ function App() {
                   />
                 }
               />
-              <Route path="/admin" element={<Admin />} />
+              <Route
+                path="/admin"
+                element={
+                  <Suspense fallback={null}>
+                    <Admin />
+                  </Suspense>
+                }
+              />
               {isFeatureEnabled("enableGasStation") && (
                 <Route
                   path="/gas-station"
@@ -118,31 +123,53 @@ function App() {
               <Route
                 path="/analytics"
                 element={
-                  <Analytics
-                    activeTab={activeTab}
-                    onTabChange={setActiveTab}
-                  />
+                  <Suspense fallback={null}>
+                    <Analytics
+                      activeTab={activeTab}
+                      onTabChange={setActiveTab}
+                    />
+                  </Suspense>
                 }
               />
               {isFeatureEnabled("enableGovernance") && (
                 <Route
                   path="/governance"
-                  element={<Governance />}
+                  element={
+                    <Suspense fallback={null}>
+                      <Governance />
+                    </Suspense>
+                  }
                 />
               )}
               {isFeatureEnabled("enablePools") && (
                 <Route
                   path="/pools"
                   element={
-                    <PoolsPage
-                      activeTab={activeTab}
-                      onTabChange={setActiveTab}
-                    />
+                    <Suspense fallback={null}>
+                      <PoolsPage
+                        activeTab={activeTab}
+                        onTabChange={setActiveTab}
+                      />
+                    </Suspense>
                   }
                 />
               )}
-              <Route path="/portfolio" element={<PortfolioPage />} />
-              <Route path="/portfolio/:address" element={<PortfolioPage />} />
+              <Route
+                path="/portfolio"
+                element={
+                  <Suspense fallback={null}>
+                    <PortfolioPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/portfolio/:address"
+                element={
+                  <Suspense fallback={null}>
+                    <PortfolioPage />
+                  </Suspense>
+                }
+              />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </BrowserRouter>

--- a/src/components/LazySuspenseFallback.tsx
+++ b/src/components/LazySuspenseFallback.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/** Minimal Suspense fallback for lazy Index tabs / App routes. */
+export function LazyRouteFallback({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("w-full space-y-3 p-4", className)}
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <Skeleton className="h-8 w-48 max-w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-40 w-full" />
+    </div>
+  );
+}
+
+/** Minimal Suspense fallback while a lazy Markets action modal chunk loads. */
+export function LazyModalFallback() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      aria-busy="true"
+      aria-label="Loading modal"
+    >
+      <div className="w-full max-w-md space-y-3 rounded-lg border border-border bg-background p-6 shadow-lg">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/MarketDetailModal.tsx
+++ b/src/components/MarketDetailModal.tsx
@@ -19,9 +19,10 @@ import { useToast } from "@/hooks/use-toast";
 import { isAtBorrowCap as isAtBorrowCapUtil } from "@/constants/lendingCaps";
 import {
   createDebouncedPrefetch,
-  warmBorrowModalMaxAndPool,
+  prefetchSupplyBorrowModalChunk,
   type MarketActionTokenParams,
 } from "@/utils/modalPrefetch";
+import { warmBorrowModalMaxAndPool } from "@/utils/modalPrefetchHeavy";
 import type { NetworkId } from "@/config";
 import {
   borrowApyBadgeClassName,
@@ -107,6 +108,7 @@ const MarketDetailModal = ({ isOpen, onClose, asset, marketData }: MarketDetailM
       networkId: currentNetwork as NetworkId,
       asset,
     };
+    prefetchSupplyBorrowModalChunk();
     debouncedPrefetch(`borrowDetail:${currentNetwork}:${asset}`, () =>
       warmBorrowModalMaxAndPool(params)
     );

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -77,6 +77,11 @@ import {
   getCachedAsaHoldingAtomic,
   invalidateWalletBalanceRpc,
 } from "@/utils/walletBalanceRpc";
+import {
+  getRpcReadCache,
+  invalidateUserPositionRpcCache,
+} from "@/utils/rpcReadCache";
+import { LazyModalFallback } from "@/components/LazySuspenseFallback";
 import { useToast } from "@/hooks/use-toast";
 import { isAtDepositCap, isAtBorrowCap } from "@/constants/lendingCaps";
 import algosdk, { waitForConfirmation } from "algosdk";
@@ -114,7 +119,6 @@ import {
 import {
   createDebouncedPrefetch,
   warmMarketDetailUserPositionRpc,
-  warmBorrowModalMaxAndPool,
   poolIdFromMarketRow,
   marketRowKeyFromMarket,
   type MarketActionTokenParams,
@@ -1277,7 +1281,7 @@ const MarketsTable = () => {
     setWithdrawModal({ isOpen: true, asset });
   };
 
-  const handleBorrowClick = async (
+  const handleBorrowClick = (
     asset: string,
     poolId?: string,
     marketRowKey?: string
@@ -1299,6 +1303,40 @@ const MarketsTable = () => {
     }
 
     const configSymbol = configSymbolFromMarketRowKey(marketRowKey);
+    // Hover/warm owns the RPC waterfall. Seed from cache if hot; the open
+    // effect below refreshes (and hits cache) without a second warm kick.
+    if (activeAccount?.address) {
+      const cachedGlobal = getRpcReadCache<{
+        totalCollateralValue: number;
+        totalBorrowValue: number;
+        lastUpdateTime: number;
+        healthFactorIndex?: number;
+      } | null>(`userGlobal:${currentNetwork}:${activeAccount.address}`);
+      const token = resolveTokenForDisplayedAsset(asset, poolId, marketRowKey);
+      const cachedBorrow =
+        token?.poolId && token.underlyingContractId
+          ? getRpcReadCache<{ balance: number; interest: number } | null>(
+              `userBorrow:${currentNetwork}:${activeAccount.address}:${token.poolId}:${token.underlyingContractId}`
+            )
+          : undefined;
+      if (cachedGlobal !== undefined) {
+        setUserGlobalData(cachedGlobal);
+      }
+      if (cachedBorrow !== undefined) {
+        setUserBorrowBalance(cachedBorrow?.balance || 0);
+      }
+      setIsLoadingGlobalData(
+        cachedGlobal === undefined ||
+          (token?.poolId != null &&
+            token.underlyingContractId != null &&
+            cachedBorrow === undefined)
+      );
+    } else {
+      setUserGlobalData(null);
+      setUserBorrowBalance(0);
+      setIsLoadingGlobalData(false);
+    }
+
     setBorrowModal({
       isOpen: true,
       asset,
@@ -1306,68 +1344,6 @@ const MarketsTable = () => {
       marketRowKey,
       configSymbol,
     });
-
-    setIsLoadingGlobalData(true);
-    void (async () => {
-      try {
-        if (activeAccount?.address) {
-          warmBorrowModalMaxAndPool({
-            userAddress: activeAccount.address,
-            networkId: currentNetwork as NetworkId,
-            asset,
-            poolId,
-            configSymbol,
-            marketId: marketContractIdFromRowCacheKey(marketRowKey),
-            marketRowKey,
-          });
-
-          const token = resolveTokenForDisplayedAsset(
-            asset,
-            poolId,
-            marketRowKey
-          );
-
-          const [globalData, borrowData, poolCollateralRows] =
-            await Promise.all([
-              fetchUserGlobalData(activeAccount.address, currentNetwork),
-              token && token.poolId && token.underlyingContractId
-                ? fetchUserBorrowBalance(
-                    activeAccount.address,
-                    token.poolId,
-                    token.underlyingContractId,
-                    currentNetwork
-                  )
-                : Promise.resolve(null),
-              poolId != null && poolId !== ""
-                ? fetchPoolCollateralMarketRowsForDeposit(
-                    activeAccount.address,
-                    currentNetwork as NetworkId,
-                    poolId
-                  ).catch((e) => {
-                    console.error(
-                      "Error loading pool collateral markets for borrow:",
-                      e
-                    );
-                    return null;
-                  })
-                : Promise.resolve(null),
-            ]);
-
-          setUserGlobalData(globalData);
-          setUserBorrowBalance(borrowData?.balance || 0);
-          if (poolCollateralRows) {
-            setDepositPoolCollateralMarkets(poolCollateralRows);
-          }
-        } else {
-          setUserGlobalData(null);
-          setUserBorrowBalance(0);
-        }
-      } catch (error) {
-        console.error("Error fetching user data for borrow:", error);
-      } finally {
-        setIsLoadingGlobalData(false);
-      }
-    })();
   };
 
   const handleMintClick = async (
@@ -1599,62 +1575,74 @@ const MarketsTable = () => {
     }
   };
 
-  // Fetch user data when wallet connects while borrow modal is open (or when switching asset in-modal)
+  // Single owner for borrow-open position reads (wallet connect / asset switch).
+  // Hover warms rpcReadCache; click seeds from cache; this effect only fetches
+  // (cache hit is sync-fast via withRpcReadCache) — no second warmBorrow kick.
   useEffect(() => {
-    if (borrowModal.isOpen && borrowModal.asset && activeAccount?.address) {
-      const fetchData = async () => {
-        try {
-          const globalData = await fetchUserGlobalData(
-            activeAccount.address,
-            currentNetwork
-          );
-          setUserGlobalData(globalData);
+    if (!borrowModal.isOpen || !borrowModal.asset || !activeAccount?.address) {
+      return;
+    }
+    let cancelled = false;
+    const fetchData = async () => {
+      try {
+        const token = resolveTokenForDisplayedAsset(
+          borrowModal.asset,
+          borrowModal.poolId,
+          borrowModal.marketRowKey
+        );
+        const globalKey = `userGlobal:${currentNetwork}:${activeAccount.address}`;
+        const borrowKey =
+          token?.poolId && token.underlyingContractId
+            ? `userBorrow:${currentNetwork}:${activeAccount.address}:${token.poolId}:${token.underlyingContractId}`
+            : null;
+        const needsFetch =
+          getRpcReadCache(globalKey) === undefined ||
+          (borrowKey != null && getRpcReadCache(borrowKey) === undefined);
+        if (needsFetch) {
+          setIsLoadingGlobalData(true);
+        }
 
-          const token = resolveTokenForDisplayedAsset(
-            borrowModal.asset,
-            borrowModal.poolId,
-            borrowModal.marketRowKey
-          );
-
-          if (token && token.poolId && token.underlyingContractId) {
-            const borrowData = await fetchUserBorrowBalance(
-              activeAccount.address,
-              token.poolId,
-              token.underlyingContractId,
-              currentNetwork
-            );
-            setUserBorrowBalance(borrowData?.balance || 0);
-          } else {
-            setUserBorrowBalance(0);
-          }
-
-          let poolCollateralRows: PoolCollateralMarketRow[] = [];
-          if (
-            borrowModal.poolId != null &&
-            borrowModal.poolId !== ""
-          ) {
-            try {
-              poolCollateralRows =
-                await fetchPoolCollateralMarketRowsForDeposit(
-                  activeAccount.address,
-                  currentNetwork as NetworkId,
-                  borrowModal.poolId
+        const [globalData, borrowData, poolCollateralRows] = await Promise.all([
+          fetchUserGlobalData(activeAccount.address, currentNetwork),
+          token && token.poolId && token.underlyingContractId
+            ? fetchUserBorrowBalance(
+                activeAccount.address,
+                token.poolId,
+                token.underlyingContractId,
+                currentNetwork
+              )
+            : Promise.resolve(null),
+          borrowModal.poolId != null && borrowModal.poolId !== ""
+            ? fetchPoolCollateralMarketRowsForDeposit(
+                activeAccount.address,
+                currentNetwork as NetworkId,
+                borrowModal.poolId
+              ).catch((e) => {
+                console.error(
+                  "Error loading pool collateral markets for borrow:",
+                  e
                 );
-            } catch (e) {
-              console.error(
-                "Error loading pool collateral markets for borrow:",
-                e
-              );
-            }
-          }
-          setDepositPoolCollateralMarkets(poolCollateralRows);
-        } catch (error) {
+                return [] as PoolCollateralMarketRow[];
+              })
+            : Promise.resolve([] as PoolCollateralMarketRow[]),
+        ]);
+        if (cancelled) return;
+        setUserGlobalData(globalData);
+        setUserBorrowBalance(borrowData?.balance || 0);
+        setDepositPoolCollateralMarkets(poolCollateralRows);
+      } catch (error) {
+        if (!cancelled) {
           console.error("Error fetching user data:", error);
         }
-      };
+      } finally {
+        if (!cancelled) setIsLoadingGlobalData(false);
+      }
+    };
 
-      fetchData();
-    }
+    void fetchData();
+    return () => {
+      cancelled = true;
+    };
   }, [
     activeAccount?.address,
     borrowModal.isOpen,
@@ -4040,7 +4028,7 @@ const MarketsTable = () => {
         />
 
         {/* Lazy-loaded action modals — keep Markets chunk free of txn/signing stacks */}
-        <Suspense fallback={null}>
+        <Suspense fallback={<LazyModalFallback />}>
         {/* Market Detail Modal */}
         {detailModal.isOpen && detailModal.asset && detailModal.marketData && (
           <PremiumMarketModal
@@ -4143,6 +4131,12 @@ const MarketsTable = () => {
                   : undefined
               }
               onTransactionSuccess={async () => {
+                if (activeAccount?.address) {
+                  invalidateUserPositionRpcCache(
+                    currentNetwork,
+                    activeAccount.address
+                  );
+                }
                 // Refresh wallet balance immediately after successful transaction
                 if (depositModal.asset) {
                   void refreshWalletBalance(
@@ -4196,6 +4190,14 @@ const MarketsTable = () => {
                   totalBorrows: assetData.totalBorrow,
                   apyParameters: assetData.apyParameters,
                 }}
+                onTransactionSuccess={() => {
+                  if (activeAccount?.address) {
+                    invalidateUserPositionRpcCache(
+                      currentNetwork,
+                      activeAccount.address
+                    );
+                  }
+                }}
               />
             ) : null;
           })()}
@@ -4234,6 +4236,12 @@ const MarketsTable = () => {
               isLoadingBorrowGlobalData={isLoadingGlobalData}
               poolCollateralMarkets={depositPoolCollateralMarkets}
               onTransactionSuccess={() => {
+                if (activeAccount?.address) {
+                  invalidateUserPositionRpcCache(
+                    currentNetwork,
+                    activeAccount.address
+                  );
+                }
                 // Refresh market data after successful borrow
                 if (borrowModal.asset) {
                   loadMarketDataWithBypass(
@@ -4270,6 +4278,12 @@ const MarketsTable = () => {
               userGlobalData={userGlobalData}
               userBorrowBalance={userBorrowBalance}
               onTransactionSuccess={() => {
+                if (activeAccount?.address) {
+                  invalidateUserPositionRpcCache(
+                    currentNetwork,
+                    activeAccount.address
+                  );
+                }
                 // Refresh market data after successful mint
                 if (mintModal.asset) {
                   loadMarketDataWithBypass(

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,13 +41,18 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import MarketSearchFilters from "@/components/markets/MarketSearchFilters";
 import MarketsPageGuidance from "@/components/markets/MarketsPageGuidance";
 import MarketPagination from "@/components/markets/MarketPagination";
-import SupplyBorrowModal from "@/components/SupplyBorrowModal";
-import WithdrawModal from "@/components/WithdrawModal";
-import { PremiumMarketModal } from "@/components/market-modal/PremiumMarketModal";
-import MintModal from "@/components/MintModal";
 import MarketsHeroSection from "@/components/markets/MarketsHeroSection";
 import MarketsTableContent from "@/components/markets/MarketsTableContent";
-import TinymanSwapModal from "@/components/TinymanSwapModal";
+
+const SupplyBorrowModal = lazy(() => import("@/components/SupplyBorrowModal"));
+const WithdrawModal = lazy(() => import("@/components/WithdrawModal"));
+const PremiumMarketModal = lazy(() =>
+  import("@/components/market-modal/PremiumMarketModal").then((m) => ({
+    default: m.PremiumMarketModal,
+  }))
+);
+const MintModal = lazy(() => import("@/components/MintModal"));
+const TinymanSwapModal = lazy(() => import("@/components/TinymanSwapModal"));
 import {
   fetchUserGlobalData,
   fetchUserBorrowBalance,
@@ -4034,6 +4039,8 @@ const MarketsTable = () => {
           onPageChange={setCurrentPage}
         />
 
+        {/* Lazy-loaded action modals — keep Markets chunk free of txn/signing stacks */}
+        <Suspense fallback={null}>
         {/* Market Detail Modal */}
         {detailModal.isOpen && detailModal.asset && detailModal.marketData && (
           <PremiumMarketModal
@@ -4290,6 +4297,7 @@ const MarketsTable = () => {
             setMarketsToolbarAlgoRefreshNonce((n) => n + 1)
           }
         />
+        </Suspense>
 
         {/* Claim Rewards Modal */}
         {showClaimModal && (

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -105,10 +105,10 @@ import {
 } from "@/utils/portfolioUsdCache";
 import {
   createDebouncedPrefetch,
-  warmBorrowModalMaxAndPool,
   warmRepayModalRpc,
   type MarketActionTokenParams,
 } from "@/utils/modalPrefetch";
+import { warmBorrowModalMaxAndPool } from "@/utils/modalPrefetchHeavy";
 import {
   getCachedAccountInformation,
   getCachedAsaHoldingAtomic,

--- a/src/components/PortfolioModals.tsx
+++ b/src/components/PortfolioModals.tsx
@@ -70,7 +70,7 @@ import {
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
 import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
-import { warmWithdrawModalRpc } from "@/utils/modalPrefetch";
+import { warmWithdrawModalRpc } from "@/utils/modalPrefetchHeavy";
 import { withRainbowkitHostDialogDismissed } from "@/wallet/xchainSignUi";
 
 /**

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -69,7 +69,7 @@ import { useTokenPrice } from "@/hooks/useTokenPrice";
 import { calculateMaxBorrowAmount } from "@/services/adminService";
 import dorkfiAPIService from "@/services/dorkfiAPIService";
 import { updateTransactionMetadata } from "@/utils/transactionUtils";
-import { warmBorrowModalMaxAndPool } from "@/utils/modalPrefetch";
+import { warmBorrowModalMaxAndPool } from "@/utils/modalPrefetchHeavy";
 import type { PoolCollateralMarketRow } from "@/utils/poolCollateralMarketRows";
 import {
   buildLiquidationThresholdSummaryForDeposit,

--- a/src/components/SupplyBorrowModal.tsx
+++ b/src/components/SupplyBorrowModal.tsx
@@ -109,6 +109,13 @@ import {
 } from "@/services/tinymanTalgoAdapter";
 import { buildXalgoConsensusBorrowAndBurnSingleGroup } from "@/services/xalgoBorrowBurnSingleGroup";
 import type { ConsensusState } from "@folks-finance/algorand-sdk";
+import {
+  resolveSupplyBorrowToken,
+  supplyBorrowTokenConfigLookupKey,
+  type SupplyBorrowTokenRow,
+} from "@/utils/resolveSupplyBorrowToken";
+
+export { resolveSupplyBorrowToken } from "@/utils/resolveSupplyBorrowToken";
 
 /** Built transaction group ready for wallet signature (review step). */
 interface PendingSupplyBorrowSign {
@@ -147,33 +154,6 @@ interface PendingSupplyBorrowSign {
   fAssetIdForFolksStep2?: string;
 }
 
-type SupplyBorrowTokenRow = {
-  symbol: string;
-  poolId?: string;
-  configKey?: string;
-  originalSymbol?: string;
-  underlyingContractId?: string;
-  /** Config `contractId` when it differs from `underlyingContractId` (display ASA). */
-  originalContractId?: string;
-};
-
-/**
- * `getAllTokensWithDisplayInfo` sets `configKey` to the `tokens` map key (e.g. `USDC` for every
- * `tokens.USDC[]` row). Prefer `originalSymbol` (`fiUSDC`, `fUSDC`) so {@link getTokenConfig} hits
- * the correct row or standalone key.
- */
-function supplyBorrowTokenConfigLookupKey(
-  tok: SupplyBorrowTokenRow | null | undefined,
-  fallbackAsset: string
-): string {
-  if (!tok) return fallbackAsset;
-  const orig = String(tok.originalSymbol ?? "").trim();
-  if (orig !== "") return orig;
-  const ck = String(tok.configKey ?? "").trim();
-  if (ck !== "") return ck;
-  return fallbackAsset;
-}
-
 /** Pick one `TokenConfig` from `getTokenConfig` when the symbol maps to an array (e.g. several USDC pools). */
 function pickTokenConfigForSupplyBorrowRow(
   raw: TokenConfig | TokenConfig[] | undefined,
@@ -193,73 +173,6 @@ function pickTokenConfigForSupplyBorrowRow(
     if (byContract) return byContract;
   }
   return raw.find(poolOk) ?? raw[0] ?? null;
-}
-
-/** When display `asset` + `poolId` match multiple config rows (e.g. Algo vs fALGO), pass the tokens map key from the market row (`configSymbol`). */
-export function resolveSupplyBorrowToken<T extends SupplyBorrowTokenRow>(
-  tokens: T[],
-  asset: string,
-  poolId: string | undefined,
-  configSymbol: string | undefined,
-  marketId?: string | null
-): T | undefined {
-  const poolOk = (t: T) =>
-    poolId == null || poolId === "" || String(t.poolId) === String(poolId);
-
-  // Prefer market contract + pool first (e.g. legacy vs V2 wBTC share `wBTC` + pool id).
-  if (marketId != null && marketId !== "" && poolId != null && poolId !== "") {
-    const byContract = tokens.find(
-      (t) =>
-        String(t.underlyingContractId ?? "") === String(marketId) &&
-        String(t.poolId ?? "") === String(poolId)
-    );
-    if (byContract) return byContract;
-    const byOriginal = tokens.find(
-      (t) =>
-        String(t.originalContractId ?? "") === String(marketId) &&
-        String(t.poolId ?? "") === String(poolId)
-    );
-    if (byOriginal) return byOriginal;
-  }
-
-  if (configSymbol) {
-    const keyHits = tokens.filter(
-      (t) =>
-        poolOk(t) &&
-        (t.configKey === configSymbol ||
-          t.originalSymbol === configSymbol ||
-          t.symbol === configSymbol)
-    );
-    if (keyHits.length === 1) return keyHits[0];
-    if (keyHits.length > 1 && marketId != null && String(marketId) !== "") {
-      const mid = String(marketId);
-      const byMid = keyHits.find(
-        (t) =>
-          String(t.underlyingContractId ?? "") === mid ||
-          String(t.originalContractId ?? "") === mid
-      );
-      if (byMid) return byMid;
-    }
-    if (keyHits.length > 0) return keyHits[0];
-  }
-
-  if (poolId != null && poolId !== "") {
-    const poolHits = tokens.filter((t) => t.symbol === asset && poolOk(t));
-    if (poolHits.length <= 1) return poolHits[0];
-    if (marketId != null && String(marketId) !== "") {
-      const mid = String(marketId);
-      const byMid = poolHits.find(
-        (t) => String(t.underlyingContractId ?? "") === mid
-      );
-      if (byMid) return byMid;
-      const byOrig = poolHits.find(
-        (t) => String(t.originalContractId ?? "") === mid
-      );
-      if (byOrig) return byOrig;
-    }
-    return poolHits[0];
-  }
-  return tokens.find((t) => t.symbol === asset);
 }
 
 /** Row in the optional supply/borrow asset picker (same disambiguation idea as Withdraw modal). */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import SwapHeroSection from "@/components/SwapHeroSection";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { isFeatureEnabled } from "@/config";
 import { cn } from "@/lib/utils";
+import { LazyRouteFallback } from "@/components/LazySuspenseFallback";
 
 const MarketsTable = lazy(() => import("@/components/MarketsTable"));
 const Dashboard = lazy(() => import("@/components/Dashboard"));
@@ -67,38 +68,38 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
     switch (activeTab) {
       case "dashboard":
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <Dashboard onTabChange={onTabChange} />
           </Suspense>
         );
       case "markets":
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <MarketsTable />
           </Suspense>
         );
       case "portfolio":
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <Portfolio />
           </Suspense>
         );
       case "liquidations":
         if (isFeatureEnabled("enableLiquidations")) {
           return (
-            <Suspense fallback={null}>
+            <Suspense fallback={<LazyRouteFallback />}>
               <LiquidationMonitor accounts={[]} />
             </Suspense>
           );
         }
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <Dashboard onTabChange={onTabChange} />
           </Suspense>
         );
       case "swap":
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <SwapHeroSection />
             <div className="grid grid-cols-1 md:grid-cols-12 gap-3 sm:gap-4 lg:gap-6 w-full">
               <div className="md:col-span-7 order-1 md:order-none">
@@ -120,19 +121,19 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
       case "prefi":
         if (isFeatureEnabled("enablePreFi")) {
           return (
-            <Suspense fallback={null}>
+            <Suspense fallback={<LazyRouteFallback />}>
               <PreFi />
             </Suspense>
           );
         }
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <Dashboard onTabChange={onTabChange} />
           </Suspense>
         );
       default:
         return (
-          <Suspense fallback={null}>
+          <Suspense fallback={<LazyRouteFallback />}>
             <Dashboard onTabChange={onTabChange} />
           </Suspense>
         );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,18 +2,20 @@ import { useLocation } from "react-router-dom";
 import { lazy, Suspense, useState } from "react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import Dashboard from "@/components/Dashboard";
-import Portfolio from "@/components/Portfolio";
-import SwapWidget from "@/components/SwapWidget";
 import SwapHeroSection from "@/components/SwapHeroSection";
-import CandlestickChart from "@/components/CandlestickChart";
-import PreFi from "@/pages/PreFi";
 import { useIsMobile } from "@/hooks/use-mobile";
-import LiquidationMonitor from "@/components/liquidation/LiquidationMonitor";
 import { isFeatureEnabled } from "@/config";
 import { cn } from "@/lib/utils";
 
 const MarketsTable = lazy(() => import("@/components/MarketsTable"));
+const Dashboard = lazy(() => import("@/components/Dashboard"));
+const Portfolio = lazy(() => import("@/components/Portfolio"));
+const SwapWidget = lazy(() => import("@/components/SwapWidget"));
+const CandlestickChart = lazy(() => import("@/components/CandlestickChart"));
+const PreFi = lazy(() => import("@/pages/PreFi"));
+const LiquidationMonitor = lazy(
+  () => import("@/components/liquidation/LiquidationMonitor")
+);
 
 interface Token {
   symbol: string;
@@ -64,7 +66,11 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
     console.log("Rendering content for tab:", activeTab);
     switch (activeTab) {
       case "dashboard":
-        return <Dashboard onTabChange={onTabChange} />;
+        return (
+          <Suspense fallback={null}>
+            <Dashboard onTabChange={onTabChange} />
+          </Suspense>
+        );
       case "markets":
         return (
           <Suspense fallback={null}>
@@ -72,15 +78,27 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
           </Suspense>
         );
       case "portfolio":
-        return <Portfolio />;
+        return (
+          <Suspense fallback={null}>
+            <Portfolio />
+          </Suspense>
+        );
       case "liquidations":
         if (isFeatureEnabled("enableLiquidations")) {
-          return <LiquidationMonitor accounts={[]} />;
+          return (
+            <Suspense fallback={null}>
+              <LiquidationMonitor accounts={[]} />
+            </Suspense>
+          );
         }
-        return <Dashboard onTabChange={onTabChange} />;
+        return (
+          <Suspense fallback={null}>
+            <Dashboard onTabChange={onTabChange} />
+          </Suspense>
+        );
       case "swap":
         return (
-          <>
+          <Suspense fallback={null}>
             <SwapHeroSection />
             <div className="grid grid-cols-1 md:grid-cols-12 gap-3 sm:gap-4 lg:gap-6 w-full">
               <div className="md:col-span-7 order-1 md:order-none">
@@ -97,15 +115,27 @@ const Index = ({ activeTab, onTabChange }: IndexProps) => {
                 />
               </div>
             </div>
-          </>
+          </Suspense>
         );
       case "prefi":
         if (isFeatureEnabled("enablePreFi")) {
-          return <PreFi />;
+          return (
+            <Suspense fallback={null}>
+              <PreFi />
+            </Suspense>
+          );
         }
-        return <Dashboard onTabChange={onTabChange} />;
+        return (
+          <Suspense fallback={null}>
+            <Dashboard onTabChange={onTabChange} />
+          </Suspense>
+        );
       default:
-        return <Dashboard onTabChange={onTabChange} />;
+        return (
+          <Suspense fallback={null}>
+            <Dashboard onTabChange={onTabChange} />
+          </Suspense>
+        );
     }
   };
 

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -1854,6 +1854,25 @@ export const fetchUserBorrowBalance = async (
   marketId: string,
   networkId: NetworkId
 ): Promise<{ balance: number; interest: number } | null> => {
+  return withRpcReadCache(
+    `userBorrow:${networkId}:${userAddress}:${poolId}:${marketId}`,
+    () =>
+      fetchUserBorrowBalanceUncached(
+        userAddress,
+        poolId,
+        marketId,
+        networkId
+      ),
+    30_000
+  );
+};
+
+const fetchUserBorrowBalanceUncached = async (
+  userAddress: string,
+  poolId: string,
+  marketId: string,
+  networkId: NetworkId
+): Promise<{ balance: number; interest: number } | null> => {
   try {
     const networkConfig = getNetworkConfig(networkId);
 
@@ -2253,6 +2272,25 @@ export async function fetchBorrowPositionApiSnapshot(
  * This gets the user's scaled deposits from the lending pool contract
  */
 export const fetchUserDepositBalance = async (
+  userAddress: string,
+  poolId: string,
+  marketId: string,
+  networkId: NetworkId
+): Promise<number | null> => {
+  return withRpcReadCache(
+    `userDeposit:${networkId}:${userAddress}:${poolId}:${marketId}`,
+    () =>
+      fetchUserDepositBalanceUncached(
+        userAddress,
+        poolId,
+        marketId,
+        networkId
+      ),
+    30_000
+  );
+};
+
+const fetchUserDepositBalanceUncached = async (
   userAddress: string,
   poolId: string,
   marketId: string,

--- a/src/utils/modalHoverHandlers.ts
+++ b/src/utils/modalHoverHandlers.ts
@@ -3,7 +3,9 @@ import type { NetworkId } from "@/config";
 import {
   configSymbolFromMarketRowKey,
   createDebouncedPrefetch,
-  warmBorrowModalMaxAndPool,
+  prefetchMintModalChunk,
+  prefetchSupplyBorrowModalChunk,
+  prefetchWithdrawModalChunk,
   warmMintModalRpc,
   warmRepayModalRpc,
   type MarketActionTokenParams,
@@ -16,6 +18,19 @@ export type ModalHoverPrefetchBundle = {
   /** Portfolio / Markets: warm wallet balance via parent fetcher. */
   warmWalletBalance?: (params: MarketActionTokenParams) => void;
 };
+
+function warmBorrowHeavy(params: MarketActionTokenParams): void {
+  // Dynamic import keeps adminService / max-borrow simulate out of Markets chunk.
+  void import("@/utils/modalPrefetchHeavy").then((m) => {
+    m.warmBorrowModalMaxAndPool(params);
+  });
+}
+
+function warmWithdrawHeavy(params: MarketActionTokenParams): void {
+  void import("@/utils/modalPrefetchHeavy").then((m) => {
+    m.warmWithdrawModalRpc(params);
+  });
+}
 
 export function buildMarketHoverHandlers(
   bundle: ModalHoverPrefetchBundle,
@@ -51,6 +66,7 @@ export function buildMarketHoverHandlers(
     onDepositMouseEnter: bundle.userAddress
       ? (e: MouseEvent) => {
           stop(e);
+          prefetchSupplyBorrowModalChunk();
           // Warm immediately so a quick click still hits a hot cache.
           bundle.warmWalletBalance?.(params);
           bundle.debounced(`deposit:${keyBase}`, () => {
@@ -61,14 +77,16 @@ export function buildMarketHoverHandlers(
     onBorrowMouseEnter: bundle.userAddress
       ? (e: MouseEvent) => {
           stop(e);
+          prefetchSupplyBorrowModalChunk();
           bundle.debounced(`borrow:${keyBase}`, () => {
-            warmBorrowModalMaxAndPool(params);
+            warmBorrowHeavy(params);
           });
         }
       : undefined,
     onMintMouseEnter: bundle.userAddress
       ? (e: MouseEvent) => {
           stop(e);
+          prefetchMintModalChunk();
           bundle.debounced(`mint:${keyBase}`, () => {
             warmMintModalRpc(params);
           });
@@ -100,6 +118,7 @@ export function buildRepayHoverHandler(
   );
   return (e: MouseEvent) => {
     e.stopPropagation();
+    prefetchSupplyBorrowModalChunk();
     bundle.debounced(`repay:${keyBase}`, () => {
       warmRepayModalRpc(params);
       bundle.warmWalletBalance?.(params);
@@ -131,8 +150,13 @@ export function buildWithdrawHoverHandler(
   );
   return (e: MouseEvent) => {
     e.stopPropagation();
+    prefetchWithdrawModalChunk();
     bundle.debounced(`withdraw:${keyBase}`, () => {
-      onWithdrawWarm?.(params);
+      if (onWithdrawWarm) {
+        onWithdrawWarm(params);
+      } else {
+        warmWithdrawHeavy(params);
+      }
     });
   };
 }

--- a/src/utils/modalPrefetch.ts
+++ b/src/utils/modalPrefetch.ts
@@ -23,7 +23,7 @@ import {
 } from "@/services/lendingService";
 import { estimateFolksDepositMintedFAssetAmount } from "@/services/folksDepositAdapter";
 import { fetchPoolCollateralMarketRowsForDeposit } from "@/utils/poolCollateralMarketRows";
-import { resolveSupplyBorrowToken } from "@/components/SupplyBorrowModal";
+import { resolveSupplyBorrowToken } from "@/utils/resolveSupplyBorrowToken";
 import algorandService, { type AlgorandNetwork } from "@/services/algorandService";
 import { CONTRACT } from "ulujs";
 import {
@@ -76,42 +76,33 @@ export function createDebouncedPrefetch(cooldownMs = 2_500) {
   };
 }
 
-function prefetchKey(prefix: string, params: MarketActionTokenParams): string {
-  return [
-    prefix,
-    params.networkId,
-    params.userAddress,
-    params.asset,
-    params.poolId ?? "",
-    params.configSymbol ?? "",
-    params.marketId ?? "",
-  ].join(":");
-}
-
-/** Global user + per-asset borrow + pool collateral rows. */
+/** Global user + per-asset borrow + pool collateral rows (fully parallel). */
 export function warmBorrowModalRpc(params: MarketActionTokenParams): void {
   if (!params.userAddress) return;
-  const key = prefetchKey("borrow", params);
-  void Promise.all([
+  const token = resolveActionToken(params);
+  const tasks: Promise<unknown>[] = [
     fetchUserGlobalData(params.userAddress, params.networkId),
-    (async () => {
-      const token = resolveActionToken(params);
-      if (!token?.poolId || !token.underlyingContractId) return;
-      await fetchUserBorrowBalance(
+  ];
+  if (token?.poolId && token.underlyingContractId) {
+    tasks.push(
+      fetchUserBorrowBalance(
         params.userAddress,
         token.poolId,
         token.underlyingContractId,
         params.networkId
-      );
-      if (params.poolId) {
-        await fetchPoolCollateralMarketRowsForDeposit(
-          params.userAddress,
-          params.networkId,
-          params.poolId
-        );
-      }
-    })(),
-  ]).catch(() => undefined);
+      )
+    );
+  }
+  if (params.poolId) {
+    tasks.push(
+      fetchPoolCollateralMarketRowsForDeposit(
+        params.userAddress,
+        params.networkId,
+        params.poolId
+      )
+    );
+  }
+  void Promise.all(tasks).catch(() => undefined);
 }
 
 /** Same reads as borrow; used for sToken mint modal. */

--- a/src/utils/modalPrefetch.ts
+++ b/src/utils/modalPrefetch.ts
@@ -1,37 +1,18 @@
 /**
- * Debounced hover prefetch for supply / borrow / withdraw / repay modals.
- * Warms RPC read cache (see rpcReadCache) before the user clicks.
+ * Light hover/RPC warm helpers for the Markets critical path.
+ * Heavy warmers (admin max-borrow, withdraw ulujs/Folks) live in
+ * `modalPrefetchHeavy.ts` and should be dynamically imported from hover handlers.
  */
 
-import {
-  getAllTokensWithDisplayInfo,
-  getNetworkConfig,
-  getAlgorandNetworkFromNetworkId,
-  getFolksAdapterForPhase,
-  getTokenConfig,
-  type NetworkId,
-} from "@/config";
-import { calculateMaxBorrowAmount } from "@/services/adminService";
+import { getAllTokensWithDisplayInfo, type NetworkId } from "@/config";
 import {
   fetchUserBorrowBalance,
   fetchUserDepositBalance,
   fetchUserGlobalData,
-  fetchUserGlobalDataForPool,
-  fetchMarketInfoFromContract,
   getMaxWithdrawableForMarket,
-  detectNt200UserBalanceBox,
 } from "@/services/lendingService";
-import { estimateFolksDepositMintedFAssetAmount } from "@/services/folksDepositAdapter";
 import { fetchPoolCollateralMarketRowsForDeposit } from "@/utils/poolCollateralMarketRows";
 import { resolveSupplyBorrowToken } from "@/utils/resolveSupplyBorrowToken";
-import algorandService, { type AlgorandNetwork } from "@/services/algorandService";
-import { CONTRACT } from "ulujs";
-import {
-  APP_SPEC as LendingPoolAppSpec,
-  UserData,
-} from "@/clients/DorkFiLendingPoolClient";
-import algosdk from "algosdk";
-import BigNumber from "bignumber.js";
 
 export type MarketActionTokenParams = {
   userAddress: string;
@@ -44,7 +25,7 @@ export type MarketActionTokenParams = {
   marketRowKey?: string;
 };
 
-function resolveActionToken(params: MarketActionTokenParams) {
+export function resolveActionToken(params: MarketActionTokenParams) {
   const tokens = getAllTokensWithDisplayInfo(params.networkId);
   return resolveSupplyBorrowToken(
     tokens,
@@ -74,6 +55,19 @@ export function createDebouncedPrefetch(cooldownMs = 2_500) {
       }, delayMs)
     );
   };
+}
+
+/** Prefetch lazy modal JS chunks so first click does not wait on download/parse. */
+export function prefetchSupplyBorrowModalChunk(): void {
+  void import("@/components/SupplyBorrowModal");
+}
+
+export function prefetchWithdrawModalChunk(): void {
+  void import("@/components/WithdrawModal");
+}
+
+export function prefetchMintModalChunk(): void {
+  void import("@/components/MintModal");
 }
 
 /** Global user + per-asset borrow + pool collateral rows (fully parallel). */
@@ -108,47 +102,6 @@ export function warmBorrowModalRpc(params: MarketActionTokenParams): void {
 /** Same reads as borrow; used for sToken mint modal. */
 export const warmMintModalRpc = warmBorrowModalRpc;
 
-/** Per-pool global data + max borrow (SupplyBorrowModal mount). */
-export function warmBorrowModalMaxAndPool(params: MarketActionTokenParams): void {
-  warmBorrowModalRpc(params);
-  const token = resolveActionToken(params);
-  if (!token?.poolId || !token.underlyingContractId || !params.userAddress) {
-    return;
-  }
-  void fetchUserGlobalDataForPool(
-    params.userAddress,
-    params.networkId,
-    token.poolId
-  ).catch(() => undefined);
-  const storageAppId = getNetworkConfig(params.networkId)?.contracts
-    ?.appStorageId;
-  void calculateMaxBorrowAmount(
-    token.poolId,
-    params.userAddress,
-    token.underlyingContractId,
-    storageAppId ? Number(storageAppId) : undefined
-  ).catch(() => undefined);
-
-  // Warm nt200 balance-box detection so borrow() can pick a single simulate path
-  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
-  if (algodNet) {
-    void (async () => {
-      try {
-        const clients = algorandService.initializeClients(
-          algodNet as AlgorandNetwork
-        );
-        await detectNt200UserBalanceBox(
-          clients.algod,
-          token.underlyingContractId,
-          params.userAddress
-        );
-      } catch {
-        /* ignore */
-      }
-    })();
-  }
-}
-
 /** Repay modal: global user data + current borrow balance. */
 export function warmRepayModalRpc(params: MarketActionTokenParams): void {
   if (!params.userAddress) return;
@@ -163,102 +116,6 @@ export function warmRepayModalRpc(params: MarketActionTokenParams): void {
     token.underlyingContractId,
     params.networkId
   ).catch(() => undefined);
-}
-
-/** Withdraw indices (market + user deposit index). */
-export async function warmWithdrawIndicesRpc(
-  params: MarketActionTokenParams
-): Promise<void> {
-  if (!params.userAddress) return;
-  const token = resolveActionToken(params);
-  if (!token?.poolId || !token.underlyingContractId) return;
-
-  try {
-    await fetchMarketInfoFromContract(
-      token.poolId,
-      token.underlyingContractId,
-      params.networkId
-    );
-  } catch {
-    /* ignore */
-  }
-
-  const networkConfig = getNetworkConfig(params.networkId);
-  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
-  if (!algodNet) return;
-
-  try {
-    const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
-    const ci = new CONTRACT(
-      Number(token.poolId),
-      clients.algod,
-      undefined,
-      { ...LendingPoolAppSpec.contract, events: [] },
-      {
-        addr: algosdk.encodeAddress(
-          algosdk.getApplicationAddress(Number(token.poolId)).publicKey
-        ),
-        sk: new Uint8Array(),
-      }
-    );
-    ci.setFee(2000);
-    await ci.get_user(
-      params.userAddress,
-      Number(token.underlyingContractId)
-    );
-  } catch {
-    /* ignore */
-  }
-  void networkConfig;
-}
-
-/** Max withdraw + optional Folks mint ratio (RPC cache). */
-export function warmMaxWithdrawRpc(params: MarketActionTokenParams): void {
-  if (!params.userAddress) return;
-  const token = resolveActionToken(params);
-  if (!token?.poolId || !token.underlyingContractId) return;
-
-  void getMaxWithdrawableForMarket(
-    token.poolId,
-    token.underlyingContractId,
-    params.userAddress,
-    params.networkId,
-    token.decimals
-  ).catch(() => undefined);
-
-  const cfgSym = token.configKey ?? token.originalSymbol ?? token.symbol;
-  const rawTc = getTokenConfig(params.networkId, cfgSym);
-  const tc = Array.isArray(rawTc)
-    ? rawTc.find((c) => String(c.poolId) === String(token.poolId)) ?? rawTc[0]
-    : rawTc;
-  const folksSide = tc
-    ? getFolksAdapterForPhase(tc, "withdraw") ??
-      getFolksAdapterForPhase(tc, "deposit")
-    : undefined;
-  if (!folksSide || params.networkId !== "algorand-mainnet") return;
-
-  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
-  if (!algodNet) return;
-  void (async () => {
-    try {
-      const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
-      const oneUnderlyingAtomic = BigInt(
-        new BigNumber(1).shiftedBy(token.decimals).toFixed(0)
-      );
-      await estimateFolksDepositMintedFAssetAmount({
-        poolName: folksSide.folksParams.pool,
-        underlyingAmount: oneUnderlyingAtomic,
-        algod: clients.algod,
-      });
-    } catch {
-      /* ignore */
-    }
-  })();
-}
-
-export function warmWithdrawModalRpc(params: MarketActionTokenParams): void {
-  void warmWithdrawIndicesRpc(params);
-  warmMaxWithdrawRpc(params);
 }
 
 /** Markets detail sheet user position strip. */
@@ -287,7 +144,7 @@ export function warmMarketDetailUserPositionRpc(
       token.underlyingContractId,
       params.userAddress,
       params.networkId,
-      token.decimals
+      token.decimals ?? 6
     ),
   ]).catch(() => undefined);
 }

--- a/src/utils/modalPrefetchHeavy.ts
+++ b/src/utils/modalPrefetchHeavy.ts
@@ -1,0 +1,168 @@
+/**
+ * Heavy modal RPC warmers (admin max-borrow simulate, LendingPool/ulujs,
+ * Folks adapters). Import this module from already-heavy surfaces
+ * (SupplyBorrowModal, Portfolio) or via dynamic `import()` from Markets hover
+ * so the Markets critical chunk stays free of adminService / ulujs.
+ */
+
+import {
+  getNetworkConfig,
+  getAlgorandNetworkFromNetworkId,
+  getFolksAdapterForPhase,
+  getTokenConfig,
+} from "@/config";
+import { calculateMaxBorrowAmount } from "@/services/adminService";
+import {
+  fetchUserGlobalDataForPool,
+  fetchMarketInfoFromContract,
+  getMaxWithdrawableForMarket,
+  detectNt200UserBalanceBox,
+} from "@/services/lendingService";
+import { estimateFolksDepositMintedFAssetAmount } from "@/services/folksDepositAdapter";
+import algorandService, { type AlgorandNetwork } from "@/services/algorandService";
+import { CONTRACT } from "ulujs";
+import { APP_SPEC as LendingPoolAppSpec } from "@/clients/DorkFiLendingPoolClient";
+import algosdk from "algosdk";
+import BigNumber from "bignumber.js";
+import {
+  resolveActionToken,
+  warmBorrowModalRpc,
+  type MarketActionTokenParams,
+} from "@/utils/modalPrefetch";
+
+/** Per-pool global data + max borrow (SupplyBorrowModal mount / borrow hover). */
+export function warmBorrowModalMaxAndPool(params: MarketActionTokenParams): void {
+  warmBorrowModalRpc(params);
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId || !params.userAddress) {
+    return;
+  }
+  void fetchUserGlobalDataForPool(
+    params.userAddress,
+    params.networkId,
+    token.poolId
+  ).catch(() => undefined);
+  const storageAppId = getNetworkConfig(params.networkId)?.contracts
+    ?.appStorageId;
+  void calculateMaxBorrowAmount(
+    token.poolId,
+    params.userAddress,
+    token.underlyingContractId,
+    storageAppId ? Number(storageAppId) : undefined
+  ).catch(() => undefined);
+
+  // Warm nt200 balance-box detection so borrow() can pick a single simulate path
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (algodNet) {
+    void (async () => {
+      try {
+        const clients = algorandService.initializeClients(
+          algodNet as AlgorandNetwork
+        );
+        await detectNt200UserBalanceBox(
+          clients.algod,
+          token.underlyingContractId,
+          params.userAddress
+        );
+      } catch {
+        /* ignore */
+      }
+    })();
+  }
+}
+
+/** Withdraw indices (market + user deposit index). */
+export async function warmWithdrawIndicesRpc(
+  params: MarketActionTokenParams
+): Promise<void> {
+  if (!params.userAddress) return;
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+
+  try {
+    await fetchMarketInfoFromContract(
+      token.poolId,
+      token.underlyingContractId,
+      params.networkId
+    );
+  } catch {
+    /* ignore */
+  }
+
+  const networkConfig = getNetworkConfig(params.networkId);
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (!algodNet) return;
+
+  try {
+    const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
+    const ci = new CONTRACT(
+      Number(token.poolId),
+      clients.algod,
+      undefined,
+      { ...LendingPoolAppSpec.contract, events: [] },
+      {
+        addr: algosdk.encodeAddress(
+          algosdk.getApplicationAddress(Number(token.poolId)).publicKey
+        ),
+        sk: new Uint8Array(),
+      }
+    );
+    ci.setFee(2000);
+    await ci.get_user(
+      params.userAddress,
+      Number(token.underlyingContractId)
+    );
+  } catch {
+    /* ignore */
+  }
+  void networkConfig;
+}
+
+/** Max withdraw + optional Folks mint ratio (RPC cache). */
+export function warmMaxWithdrawRpc(params: MarketActionTokenParams): void {
+  if (!params.userAddress) return;
+  const token = resolveActionToken(params);
+  if (!token?.poolId || !token.underlyingContractId) return;
+
+  void getMaxWithdrawableForMarket(
+    token.poolId,
+    token.underlyingContractId,
+    params.userAddress,
+    params.networkId,
+    token.decimals ?? 6
+  ).catch(() => undefined);
+
+  const cfgSym = token.configKey ?? token.originalSymbol ?? token.symbol;
+  const rawTc = getTokenConfig(params.networkId, cfgSym);
+  const tc = Array.isArray(rawTc)
+    ? rawTc.find((c) => String(c.poolId) === String(token.poolId)) ?? rawTc[0]
+    : rawTc;
+  const folksSide = tc
+    ? getFolksAdapterForPhase(tc, "withdraw") ??
+      getFolksAdapterForPhase(tc, "deposit")
+    : undefined;
+  if (!folksSide || params.networkId !== "algorand-mainnet") return;
+
+  const algodNet = getAlgorandNetworkFromNetworkId(params.networkId);
+  if (!algodNet) return;
+  void (async () => {
+    try {
+      const clients = algorandService.initializeClients(algodNet as AlgorandNetwork);
+      const oneUnderlyingAtomic = BigInt(
+        new BigNumber(1).shiftedBy(token.decimals ?? 6).toFixed(0)
+      );
+      await estimateFolksDepositMintedFAssetAmount({
+        poolName: folksSide.folksParams.pool,
+        underlyingAmount: oneUnderlyingAtomic,
+        algod: clients.algod,
+      });
+    } catch {
+      /* ignore */
+    }
+  })();
+}
+
+export function warmWithdrawModalRpc(params: MarketActionTokenParams): void {
+  void warmWithdrawIndicesRpc(params);
+  warmMaxWithdrawRpc(params);
+}

--- a/src/utils/poolCollateralMarketRows.ts
+++ b/src/utils/poolCollateralMarketRows.ts
@@ -9,6 +9,7 @@ import {
   fetchUserDepositBalance,
 } from "@/services/lendingService";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
+import { runWithConcurrency } from "@/utils/runWithConcurrency";
 
 export type PoolCollateralMarketRow = {
   symbol: string;
@@ -134,16 +135,15 @@ export async function fetchPoolCollateralMarketRowsForDeposit(
 
     if (tokens.length === 0) return [];
 
-    const balances = await Promise.all(
-      tokens.map((t) =>
-        fetchUserDepositBalance(
-          userAddress,
-          t.poolId!,
-          t.underlyingContractId!,
-          networkId
-        )
-      )
-    );
+    const balances: Array<number | null> = new Array(tokens.length).fill(null);
+    await runWithConcurrency(tokens, 6, async (t, i) => {
+      balances[i] = await fetchUserDepositBalance(
+        userAddress,
+        t.poolId!,
+        t.underlyingContractId!,
+        networkId
+      );
+    });
 
     const supplied = tokens.filter((_, i) => (balances[i] ?? 0) > 0);
     if (supplied.length === 0) return [];

--- a/src/utils/resolveSupplyBorrowToken.test.ts
+++ b/src/utils/resolveSupplyBorrowToken.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveSupplyBorrowToken } from "./resolveSupplyBorrowToken";
+
+describe("resolveSupplyBorrowToken", () => {
+  const tokens = [
+    {
+      symbol: "UNIT",
+      poolId: "1",
+      underlyingContractId: "100",
+      configKey: "UNIT",
+      originalSymbol: "UNIT",
+    },
+    {
+      symbol: "UNIT",
+      poolId: "2",
+      underlyingContractId: "200",
+      configKey: "UNIT",
+      originalSymbol: "UNIT",
+    },
+  ];
+
+  it("prefers market contract + pool when provided", () => {
+    expect(
+      resolveSupplyBorrowToken(tokens, "UNIT", "2", "UNIT", "200")
+        ?.underlyingContractId
+    ).toBe("200");
+  });
+
+  it("falls back to config symbol + pool", () => {
+    expect(
+      resolveSupplyBorrowToken(tokens, "UNIT", "1", "UNIT")?.poolId
+    ).toBe("1");
+  });
+});

--- a/src/utils/resolveSupplyBorrowToken.test.ts
+++ b/src/utils/resolveSupplyBorrowToken.test.ts
@@ -17,6 +17,22 @@ describe("resolveSupplyBorrowToken", () => {
       configKey: "UNIT",
       originalSymbol: "UNIT",
     },
+    {
+      symbol: "USDC",
+      poolId: "1",
+      underlyingContractId: "301",
+      originalContractId: "300",
+      configKey: "USDC",
+      originalSymbol: "fiUSDC",
+    },
+    {
+      symbol: "USDC",
+      poolId: "1",
+      underlyingContractId: "401",
+      originalContractId: "400",
+      configKey: "USDC",
+      originalSymbol: "fUSDC",
+    },
   ];
 
   it("prefers market contract + pool when provided", () => {
@@ -30,5 +46,19 @@ describe("resolveSupplyBorrowToken", () => {
     expect(
       resolveSupplyBorrowToken(tokens, "UNIT", "1", "UNIT")?.poolId
     ).toBe("1");
+  });
+
+  it("matches originalContractId when market id is the display ASA", () => {
+    expect(
+      resolveSupplyBorrowToken(tokens, "USDC", "1", "USDC", "400")
+        ?.originalSymbol
+    ).toBe("fUSDC");
+  });
+
+  it("disambiguates multi-USDC rows via marketId among configKey hits", () => {
+    expect(
+      resolveSupplyBorrowToken(tokens, "USDC", "1", "USDC", "301")
+        ?.originalSymbol
+    ).toBe("fiUSDC");
   });
 });

--- a/src/utils/resolveSupplyBorrowToken.ts
+++ b/src/utils/resolveSupplyBorrowToken.ts
@@ -12,6 +12,7 @@ export type SupplyBorrowTokenRow = {
   underlyingContractId?: string;
   /** Config `contractId` when it differs from `underlyingContractId` (display ASA). */
   originalContractId?: string;
+  decimals?: number;
 };
 
 /**

--- a/src/utils/resolveSupplyBorrowToken.ts
+++ b/src/utils/resolveSupplyBorrowToken.ts
@@ -1,0 +1,99 @@
+/**
+ * Resolve a display token row for supply/borrow/withdraw/repay flows.
+ * Kept outside SupplyBorrowModal so hover prefetch and Markets can import it
+ * without pulling the full modal + signing stack into the critical path.
+ */
+
+export type SupplyBorrowTokenRow = {
+  symbol: string;
+  poolId?: string;
+  configKey?: string;
+  originalSymbol?: string;
+  underlyingContractId?: string;
+  /** Config `contractId` when it differs from `underlyingContractId` (display ASA). */
+  originalContractId?: string;
+};
+
+/**
+ * `getAllTokensWithDisplayInfo` sets `configKey` to the `tokens` map key (e.g. `USDC` for every
+ * `tokens.USDC[]` row). Prefer `originalSymbol` (`fiUSDC`, `fUSDC`) so getTokenConfig hits
+ * the correct row or standalone key.
+ */
+export function supplyBorrowTokenConfigLookupKey(
+  tok: SupplyBorrowTokenRow | null | undefined,
+  fallbackAsset: string
+): string {
+  if (!tok) return fallbackAsset;
+  const orig = String(tok.originalSymbol ?? "").trim();
+  if (orig !== "") return orig;
+  const ck = String(tok.configKey ?? "").trim();
+  if (ck !== "") return ck;
+  return fallbackAsset;
+}
+
+/** When display `asset` + `poolId` match multiple config rows (e.g. Algo vs fALGO), pass the tokens map key from the market row (`configSymbol`). */
+export function resolveSupplyBorrowToken<T extends SupplyBorrowTokenRow>(
+  tokens: T[],
+  asset: string,
+  poolId: string | undefined,
+  configSymbol: string | undefined,
+  marketId?: string | null
+): T | undefined {
+  const poolOk = (t: T) =>
+    poolId == null || poolId === "" || String(t.poolId) === String(poolId);
+
+  // Prefer market contract + pool first (e.g. legacy vs V2 wBTC share `wBTC` + pool id).
+  if (marketId != null && marketId !== "" && poolId != null && poolId !== "") {
+    const byContract = tokens.find(
+      (t) =>
+        String(t.underlyingContractId ?? "") === String(marketId) &&
+        String(t.poolId ?? "") === String(poolId)
+    );
+    if (byContract) return byContract;
+    const byOriginal = tokens.find(
+      (t) =>
+        String(t.originalContractId ?? "") === String(marketId) &&
+        String(t.poolId ?? "") === String(poolId)
+    );
+    if (byOriginal) return byOriginal;
+  }
+
+  if (configSymbol) {
+    const keyHits = tokens.filter(
+      (t) =>
+        poolOk(t) &&
+        (t.configKey === configSymbol ||
+          t.originalSymbol === configSymbol ||
+          t.symbol === configSymbol)
+    );
+    if (keyHits.length === 1) return keyHits[0];
+    if (keyHits.length > 1 && marketId != null && String(marketId) !== "") {
+      const mid = String(marketId);
+      const byMid = keyHits.find(
+        (t) =>
+          String(t.underlyingContractId ?? "") === mid ||
+          String(t.originalContractId ?? "") === mid
+      );
+      if (byMid) return byMid;
+    }
+    if (keyHits.length > 0) return keyHits[0];
+  }
+
+  if (poolId != null && poolId !== "") {
+    const poolHits = tokens.filter((t) => t.symbol === asset && poolOk(t));
+    if (poolHits.length <= 1) return poolHits[0];
+    if (marketId != null && String(marketId) !== "") {
+      const mid = String(marketId);
+      const byMid = poolHits.find(
+        (t) => String(t.underlyingContractId ?? "") === mid
+      );
+      if (byMid) return byMid;
+      const byOrig = poolHits.find(
+        (t) => String(t.originalContractId ?? "") === mid
+      );
+      if (byOrig) return byOrig;
+    }
+    return poolHits[0];
+  }
+  return tokens.find((t) => t.symbol === asset);
+}

--- a/src/utils/rpcReadCache.test.ts
+++ b/src/utils/rpcReadCache.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetRpcReadCacheForTests,
+  getRpcReadCache,
+  invalidateUserPositionRpcCache,
+  setRpcReadCache,
+  withRpcReadCache,
+} from "./rpcReadCache";
+
+describe("withRpcReadCache", () => {
+  afterEach(() => {
+    __resetRpcReadCacheForTests();
+  });
+
+  it("caches successful values including zero", async () => {
+    const fetcher = vi.fn().mockResolvedValue(0);
+    await expect(withRpcReadCache("userDeposit:t", fetcher)).resolves.toBe(0);
+    await expect(withRpcReadCache("userDeposit:t", fetcher)).resolves.toBe(0);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache null failures so retries re-fetch", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ balance: 1, interest: 0 });
+    await expect(withRpcReadCache("userBorrow:t", fetcher)).resolves.toBeNull();
+    expect(getRpcReadCache("userBorrow:t")).toBeUndefined();
+    await expect(withRpcReadCache("userBorrow:t", fetcher)).resolves.toEqual({
+      balance: 1,
+      interest: 0,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes concurrent in-flight requests", async () => {
+    let resolve!: (v: number) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<number>((r) => {
+          resolve = r;
+        })
+    );
+    const a = withRpcReadCache("inflight:t", fetcher);
+    const b = withRpcReadCache("inflight:t", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    resolve(42);
+    await expect(Promise.all([a, b])).resolves.toEqual([42, 42]);
+  });
+});
+
+describe("invalidateUserPositionRpcCache", () => {
+  afterEach(() => {
+    __resetRpcReadCacheForTests();
+  });
+
+  it("clears deposit, borrow, and global-user keys for the user", () => {
+    setRpcReadCache("userDeposit:net:addr:pool:mkt", 5);
+    setRpcReadCache("userBorrow:net:addr:pool:mkt", { balance: 1, interest: 0 });
+    setRpcReadCache("userGlobal:net:addr", { totalCollateralValue: 1 });
+    setRpcReadCache("userGlobalPool:net:pool:addr", { totalBorrowValue: 1 });
+    setRpcReadCache("userDeposit:net:other:pool:mkt", 9);
+
+    invalidateUserPositionRpcCache("net", "addr");
+
+    expect(getRpcReadCache("userDeposit:net:addr:pool:mkt")).toBeUndefined();
+    expect(getRpcReadCache("userBorrow:net:addr:pool:mkt")).toBeUndefined();
+    expect(getRpcReadCache("userGlobal:net:addr")).toBeUndefined();
+    expect(getRpcReadCache("userGlobalPool:net:pool:addr")).toBeUndefined();
+    expect(getRpcReadCache("userDeposit:net:other:pool:mkt")).toBe(9);
+  });
+});

--- a/src/utils/rpcReadCache.ts
+++ b/src/utils/rpcReadCache.ts
@@ -40,13 +40,51 @@ export function invalidateRpcReadCache(prefix?: string): void {
   }
 }
 
+/** Delete keys matching a predicate (for mid-key patterns like userGlobalPool). */
+export function invalidateRpcReadCacheWhere(
+  predicate: (key: string) => boolean
+): void {
+  for (const key of cache.keys()) {
+    if (predicate(key)) cache.delete(key);
+  }
+}
+
+/**
+ * Clear deposit/borrow/global-user position reads after a successful txn so
+ * the next modal open does not show stale 30s-cached balances.
+ */
+export function invalidateUserPositionRpcCache(
+  networkId: string,
+  userAddress: string
+): void {
+  if (!userAddress) return;
+  invalidateRpcReadCache(`userDeposit:${networkId}:${userAddress}:`);
+  invalidateRpcReadCache(`userBorrow:${networkId}:${userAddress}:`);
+  invalidateRpcReadCache(`userGlobal:${networkId}:${userAddress}`);
+  // Key shape: userGlobalPool:${networkId}:${poolId}:${userAddress}
+  invalidateRpcReadCacheWhere(
+    (key) =>
+      key.startsWith(`userGlobalPool:${networkId}:`) &&
+      key.endsWith(`:${userAddress}`)
+  );
+}
+
 /** Deduplicate concurrent in-flight requests for the same key. */
 const inflight = new Map<string, Promise<unknown>>();
+
+export type WithRpcReadCacheOptions<T> = {
+  /**
+   * Return false to skip caching (e.g. failed `null` reads).
+   * Defaults to caching everything except `null`.
+   */
+  shouldCache?: (value: T) => boolean;
+};
 
 export async function withRpcReadCache<T>(
   key: string,
   fetcher: () => Promise<T>,
-  ttlMs: number = DEFAULT_TTL_MS
+  ttlMs: number = DEFAULT_TTL_MS,
+  options?: WithRpcReadCacheOptions<T>
 ): Promise<T> {
   const cached = getRpcReadCache<T>(key);
   if (cached !== undefined) return cached;
@@ -54,9 +92,14 @@ export async function withRpcReadCache<T>(
   const pending = inflight.get(key) as Promise<T> | undefined;
   if (pending) return pending;
 
+  const shouldCache =
+    options?.shouldCache ?? ((value: T) => value !== null);
+
   const promise = fetcher()
     .then((value) => {
-      setRpcReadCache(key, value, ttlMs);
+      if (shouldCache(value)) {
+        setRpcReadCache(key, value, ttlMs);
+      }
       return value;
     })
     .finally(() => {
@@ -65,4 +108,10 @@ export async function withRpcReadCache<T>(
 
   inflight.set(key, promise);
   return promise;
+}
+
+/** Test helper — clear cache + inflight. */
+export function __resetRpcReadCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
 }


### PR DESCRIPTION
## Summary
Addresses [#583](https://github.com/DorkFi/dorkfi-app/issues/583) remaining load cost after #574/#580 hydrate work, plus review follow-ups on this PR:

- **Smaller critical JS on Markets** — `React.lazy` for Index tabs, App routes, and Markets action modals
- **Light hover prefetch** — `resolveSupplyBorrowToken` extracted; hover also prefetches lazy modal JS chunks (`import(...)`)
- **Split `modalPrefetch`** — light RPC warm stays on Markets path; admin max-borrow / ulujs / Folks warmers live in `modalPrefetchHeavy` (dynamic import from hover handlers)
- **Fewer duplicate algod reads** — cache deposit/borrow/global reads; **do not cache failed `null`**; invalidate `userDeposit:` / `userBorrow:` / `userGlobal*` after successful deposit/borrow/withdraw/mint
- **Deduped Borrow open** — hover/warm owns the waterfall; click seeds from cache; one open effect refreshes (hits cache) without a second `warmBorrowModalMaxAndPool` kick
- **Suspense UX** — minimal skeleton instead of `fallback={null}` for tabs/routes/modals

## Test plan
- [ ] Cold load `/` (Markets) — table paints without waiting on Portfolio/chart/modal chunks
- [ ] Hover Borrow then open — max borrow / health populate from warm cache without long spinner; network tab shows modal chunk prefetch on hover
- [ ] Open Supply / Borrow / Withdraw / Mint / market detail / Tinyman swap — modals still work after lazy load; Suspense shows a brief skeleton (not blank)
- [ ] After deposit/borrow/withdraw/mint success, reopen Borrow — balances/health are fresh (not stale 30s cache)
- [ ] Switch Index tabs (Portfolio, Swap, Dashboard) — each loads on demand with skeleton
- [ ] Visit `/governance`, `/pools`, `/portfolio`, `/analytics` — lazy routes render
- [ ] `npx vitest run src/utils/resolveSupplyBorrowToken.test.ts src/utils/rpcReadCache.test.ts`

Closes #583