### PR TITLE
Enable cross-asset repay for production builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,10 @@ HAYSTACK_API_KEY=
 # Client (VITE_*) — safe for the browser bundle; no API secrets here
 # =============================================================================
 
-# Cross-asset repay UI. Defaults ON in Vite DEV only; OFF in production builds
-# unless explicitly set. Safe beta ship: leave unset (feature dark) until proxy is live.
-# VITE_ENABLE_CROSS_ASSET_REPAY=true
+# Cross-asset repay UI. Local: set true below. Production builds use
+# `.env.production` (VITE_ENABLE_CROSS_ASSET_REPAY=true). Kill-switch: false.
+# DEV defaults on when unset. beta.dork.fi also auto-enables when unset.
+VITE_ENABLE_CROSS_ASSET_REPAY=true
 
 # Absolute origin of the deployed Haystack key proxy (no trailing slash).
 # Dev default is /api/haystack (Vite middleware injects HAYSTACK_API_KEY).

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,6 @@
+# Production SPA build defaults (committed — no secrets).
+# Vite loads this in `mode === "production"` so CI/host builds pick it up without
+# dashboard env vars. Override by setting VITE_* in the host CI if needed.
+# Kill-switch: VITE_ENABLE_CROSS_ASSET_REPAY=false
+
+VITE_ENABLE_CROSS_ASSET_REPAY=true

--- a/docs/development/HAYSTACK_PROXY.md
+++ b/docs/development/HAYSTACK_PROXY.md
@@ -22,17 +22,17 @@ The browser must **never** receive `HAYSTACK_API_KEY`. Quotes and execute calls 
 
 Static SPA hosts (`vite build`) do **not** include the Vite Haystack middleware.
 
-### Option A — Ship code dark (safest first merge)
+### Feature flag (SPA)
 
 | Build env (SPA) | Value |
 |-----------------|-------|
-| `VITE_ENABLE_CROSS_ASSET_REPAY` | **omit** (or `false`) |
-| `VITE_HAYSTACK_PROXY_URL` | omit |
+| `VITE_ENABLE_CROSS_ASSET_REPAY` | **true** in committed `.env.production` (production builds on by default). Override with `false` to kill-switch. |
+| `VITE_HAYSTACK_PROXY_URL` | omit (SPA falls back to baked Railway proxy) or set absolute proxy origin |
 | `HAYSTACK_API_KEY` | **do not set** on the SPA host |
 
-On hosts other than `https://beta.dork.fi`, the feature stays hidden when the flag is unset. `beta.dork.fi` auto-enables the UI; set `VITE_ENABLE_CROSS_ASSET_REPAY=false` to force it off.
+DEV defaults the UI on when the flag is unset. `beta.dork.fi` also auto-enables when unset. Explicit `false`/`0` always forces the UI off.
 
-### Option B — Enable cross-asset repay on beta
+### Deploy the Haystack proxy
 
 1. **Deploy** `scripts/haystack-proxy.mjs` as its own service (Railway, Fly, etc.):
 
@@ -64,13 +64,7 @@ On hosts other than `https://beta.dork.fi`, the feature stays hidden when the fl
 
 2. Confirm `GET /health` → `{ "ok": true }`.
 
-3. **SPA build** env (frontend CI / host):
-
-   | Build env | Value |
-   |-----------|-------|
-   | `VITE_ENABLE_CROSS_ASSET_REPAY` | omit on beta (auto-on for `beta.dork.fi`); `true` elsewhere |
-   | `VITE_HAYSTACK_PROXY_URL` | omit (SPA falls back to `https://profound-bravery-production-418a.up.railway.app`) or override |
-   | `HAYSTACK_API_KEY` | **must not** be present |
+3. **SPA build** — production uses committed `.env.production` (`VITE_ENABLE_CROSS_ASSET_REPAY=true`). Host CI can still override. Never set `HAYSTACK_API_KEY` on the SPA.
 
 4. Wallet QA on mainnet with a tiny repay (quote → swap → repay, cancel mid-flow, Folks debt if applicable).
 


### PR DESCRIPTION
## Summary
- Add committed `.env.production` with `VITE_ENABLE_CROSS_ASSET_REPAY=true` so production Vite builds bake the feature on without host dashboard env vars.
- Document the flag + Haystack proxy checklist now that the Railway proxy is the runtime dependency.
- Align `.env.example` so local setup matches the enabled default.

## Notes
- Explicit `VITE_ENABLE_CROSS_ASSET_REPAY=false` still forces the UI off.
- Do not set `HAYSTACK_API_KEY` on the SPA host; only on the Haystack Railway proxy.
- Local `.env` already has the flag on (gitignored — not in this PR).

## Test plan
- [ ] Confirm production build embeds the flag (`vite build` then grep dist bundle or UI on deploy pred)
- [ ] On beta/app: open Repay → cross-asset pay-with appears
- [ ] Kill-switch: host `VITE_ENABLE_CROSS_ASSET_REPAY=false` rebuild hides UI
- [ ] Haystack `GET /health` → `{ "ok": true }` and CORS covers SPA origins
- [ ] Tiny mainnet quote → swap → repay smoke


Made with [Cursor](https://cursor.com)