### PR TITLE
fix(haystack): fail hung quotes fast with proxy timeouts

### DIFF
--- a/docs/development/HAYSTACK_PROXY.md
+++ b/docs/development/HAYSTACK_PROXY.md
@@ -62,11 +62,27 @@ DEV defaults the UI on when the flag is unset. `beta.dork.fi` also auto-enables 
    npm run haystack-proxy
    ```
 
-2. Confirm `GET /health` → `{ "ok": true }`.
+2. Confirm `GET /health` → `{ "ok": true }` in under a second. If TCP hangs, the Railway service is down/misbound (not a SPA bug).
 
-3. **SPA build** — production uses committed `.env.production` (`VITE_ENABLE_CROSS_ASSET_REPAY=true`). Host CI can still override. Never set `HAYSTACK_API_KEY` on the SPA.
+3. **SPA build** — production uses committed `.env.production` (`VITE_ENABLE_CROSS_ASSET_REPAY=true`). Host CI can still override. Never set `HAYSTACK_API_KEY` on the SPA. Proxy URL defaults to the baked Railway origin (`DEFAULT_HAYSTACK_PROXY_URL`); override with `VITE_HAYSTACK_PROXY_URL` if the Railway hostname changes.
 
 4. Wallet QA on mainnet with a tiny repay (quote → swap → repay, cancel mid-flow, Folks debt if applicable).
+
+## Troubleshooting slow / hanging quotes
+
+Symptoms: repay UI shows “Fetching Haystack quote…” for a long time, then fails.
+
+1. **Proxy reachability** — from any machine:
+
+   ```bash
+   curl -sS --max-time 8 https://<proxy-host>/health
+   ```
+
+   Expect `{ "ok": true }` quickly. Connection timeout ⇒ redeploy/restart the Railway Haystack service (`railway.haystack.toml` / `Dockerfile.haystack`). Confirm `HAYSTACK_PROXY_HOST=0.0.0.0`, platform `PORT`, `HAYSTACK_API_KEY`, and `HAYSTACK_PROXY_CORS_ORIGINS` includes `https://app.dork.fi` and `https://beta.dork.fi`.
+
+2. **Upstream Haystack** — if `/health` is up but quotes 502/504, check logs for `fetchQuote failed` / upstream timeout (default 20s via `HAYSTACK_PROXY_UPSTREAM_TIMEOUT_MS`).
+
+3. **Client deadline** — the SPA aborts hung quote `fetch` calls after **12s** (`HAYSTACK_QUOTE_TIMEOUT_MS`) so a dead proxy fails visibly instead of waiting on the OS TCP timeout (~60–75s).
 
 ## Security notes
 

--- a/scripts/haystack-proxy.mjs
+++ b/scripts/haystack-proxy.mjs
@@ -23,6 +23,7 @@
  *   HAYSTACK_PROXY_HOST         (default 127.0.0.1; use 0.0.0.0 to bind publicly)
  *   HAYSTACK_PROXY_CORS_ORIGINS (comma-separated; required when host is not loopback)
  *   HAYSTACK_API_BASE           (default https://hayrouter.txnlab.dev)
+ *   HAYSTACK_PROXY_UPSTREAM_TIMEOUT_MS (default 20000 — cap hung hayrouter calls)
  */
 
 import http from "node:http";
@@ -36,6 +37,9 @@ const HOST = (process.env.HAYSTACK_PROXY_HOST || "127.0.0.1").trim();
 const UPSTREAM = (
   process.env.HAYSTACK_API_BASE || "https://hayrouter.txnlab.dev"
 ).replace(/\/$/, "");
+const UPSTREAM_TIMEOUT_MS = Number(
+  process.env.HAYSTACK_PROXY_UPSTREAM_TIMEOUT_MS || 20_000
+);
 
 const LOCAL_DEV_ORIGINS = [
   "http://127.0.0.1:8080",
@@ -111,6 +115,55 @@ async function readBody(req) {
   return Buffer.concat(chunks).toString("utf8");
 }
 
+function upstreamAbortSignal() {
+  if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+    return AbortSignal.timeout(UPSTREAM_TIMEOUT_MS);
+  }
+  const c = new AbortController();
+  setTimeout(() => c.abort(), UPSTREAM_TIMEOUT_MS);
+  return c.signal;
+}
+
+/**
+ * @param {string} label
+ * @param {string} url
+ * @param {RequestInit} [init]
+ */
+async function proxyUpstream(label, url, init) {
+  const started = Date.now();
+  try {
+    const r = await fetch(url, {
+      ...init,
+      signal: init?.signal ?? upstreamAbortSignal(),
+    });
+    const text = await r.text();
+    const ms = Date.now() - started;
+    console.log(
+      `[haystack-proxy] ${label} → ${r.status} ${ms}ms (${text.length}b)`
+    );
+    return { status: r.status, contentType: r.headers.get("content-type"), text };
+  } catch (e) {
+    const ms = Date.now() - started;
+    const timedOut =
+      e instanceof Error &&
+      (e.name === "TimeoutError" ||
+        e.name === "AbortError" ||
+        /aborted|timeout/i.test(e.message));
+    console.error(
+      `[haystack-proxy] ${label} failed after ${ms}ms:`,
+      e instanceof Error ? e.message : e
+    );
+    if (timedOut) {
+      const err = new Error(
+        `Upstream Haystack timed out after ${UPSTREAM_TIMEOUT_MS}ms`
+      );
+      err.code = "UPSTREAM_TIMEOUT";
+      throw err;
+    }
+    throw e;
+  }
+}
+
 const server = http.createServer(async (req, res) => {
   const hostHdr = req.headers.host || `${HOST}:${PORT}`;
   const url = new URL(req.url || "/", `http://${hostHdr}`);
@@ -118,7 +171,13 @@ const server = http.createServer(async (req, res) => {
   // Health is unauthenticated and CORS-open for load balancers.
   if (req.method === "GET" && url.pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+    res.end(
+      JSON.stringify({
+        ok: true,
+        upstream: UPSTREAM,
+        upstreamTimeoutMs: UPSTREAM_TIMEOUT_MS,
+      })
+    );
     return;
   }
 
@@ -139,12 +198,11 @@ const server = http.createServer(async (req, res) => {
       params.delete("apiKey");
       params.set("apiKey", API_KEY);
       const upstream = `${UPSTREAM}/api/fetchQuote?${params.toString()}`;
-      const r = await fetch(upstream);
-      const text = await r.text();
+      const r = await proxyUpstream("fetchQuote", upstream);
       res.writeHead(r.status, {
-        "Content-Type": r.headers.get("content-type") || "application/json",
+        "Content-Type": r.contentType || "application/json",
       });
-      res.end(text);
+      res.end(r.text);
       return;
     }
 
@@ -162,24 +220,29 @@ const server = http.createServer(async (req, res) => {
         delete body.apiKey;
         body.apiKey = API_KEY;
       }
-      const r = await fetch(`${UPSTREAM}/api/fetchExecuteSwapTxns`, {
+      const r = await proxyUpstream("fetchExecuteSwapTxns", `${UPSTREAM}/api/fetchExecuteSwapTxns`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      const text = await r.text();
       res.writeHead(r.status, {
-        "Content-Type": r.headers.get("content-type") || "application/json",
+        "Content-Type": r.contentType || "application/json",
       });
-      res.end(text);
+      res.end(r.text);
       return;
     }
 
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Not found" }));
   } catch (e) {
+    const timedOut =
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      e.code === "UPSTREAM_TIMEOUT";
+    const status = timedOut ? 504 : 502;
     console.error("[haystack-proxy]", e instanceof Error ? e.message : e);
-    res.writeHead(502, { "Content-Type": "application/json" });
+    res.writeHead(status, { "Content-Type": "application/json" });
     res.end(
       JSON.stringify({
         error: e instanceof Error ? e.message : "Proxy upstream error",
@@ -188,11 +251,15 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
+// Fail hung client connections instead of letting TCP sit forever.
+server.requestTimeout = Math.max(UPSTREAM_TIMEOUT_MS + 5_000, 30_000);
+server.headersTimeout = Math.max(UPSTREAM_TIMEOUT_MS + 5_000, 30_000);
+
 server.listen(PORT, HOST, () => {
   console.log(
     `[haystack-proxy] listening on http://${HOST}:${PORT} → ${UPSTREAM}`
   );
   console.log(
-    `[haystack-proxy] CORS allowlist: ${EFFECTIVE_CORS.join(", ") || "(none — Origin required for browser)"}`
+    `[haystack-proxy] upstream timeout ${UPSTREAM_TIMEOUT_MS}ms; CORS: ${EFFECTIVE_CORS.join(", ") || "(none — Origin required for browser)"}`
   );
 });

--- a/src/hooks/useHaystackRepayQuote.ts
+++ b/src/hooks/useHaystackRepayQuote.ts
@@ -89,6 +89,7 @@ export function useHaystackRepayQuote(
     }
 
     let cancelled = false;
+    const abort = new AbortController();
     const timer = window.setTimeout(() => {
       void (async () => {
         setIsLoading(true);
@@ -103,6 +104,7 @@ export function useHaystackRepayQuote(
             // Compact routes so SwapComposer can append repay in one atomic group.
             maxGroupSize: haystackRepayMaxGroupSize(),
             disabledProtocols: ["Humble"],
+            signal: abort.signal,
           });
           if (cancelled) return;
           if (!q.txnPayload) {
@@ -116,7 +118,15 @@ export function useHaystackRepayQuote(
           setPaymentAtomicNeeded(BigInt(Math.floor(Number(q.quote))));
           setLastUpdated(new Date());
         } catch (e) {
+          // Ignore only true cancellations (amount change / unmount), not quote timeouts.
           if (cancelled) return;
+          if (
+            e instanceof Error &&
+            e.name === "AbortError" &&
+            abort.signal.aborted
+          ) {
+            return;
+          }
           setQuote(null);
           setPaymentAtomicNeeded(null);
           setError(e instanceof Error ? e.message : "Quote failed");
@@ -128,6 +138,7 @@ export function useHaystackRepayQuote(
 
     return () => {
       cancelled = true;
+      abort.abort();
       window.clearTimeout(timer);
     };
   }, [

--- a/src/services/__tests__/haystackQuoteClient.test.ts
+++ b/src/services/__tests__/haystackQuoteClient.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHaystackDeadlineSignal,
+  fetchHaystackQuote,
+  formatHaystackFetchError,
+  HAYSTACK_QUOTE_TIMEOUT_MS,
+} from "@/services/haystackRouterService";
+
+describe("formatHaystackFetchError", () => {
+  it("maps TimeoutError to a proxy-unavailable message", () => {
+    const err = Object.assign(new Error("deadline"), { name: "TimeoutError" });
+    expect(formatHaystackFetchError(err, "quote").message).toMatch(
+      /timed out.*routing proxy/i
+    );
+  });
+
+  it("maps network TypeError to a unreachable-proxy message", () => {
+    const err = Object.assign(new Error("Failed to fetch"), {
+      name: "TypeError",
+    });
+    expect(formatHaystackFetchError(err, "quote").message).toMatch(
+      /could not reach the routing proxy/i
+    );
+  });
+
+  it("rethrows AbortError unchanged for cancel handling", () => {
+    const err = Object.assign(new Error("Aborted"), { name: "AbortError" });
+    expect(formatHaystackFetchError(err, "quote")).toBe(err);
+  });
+});
+
+describe("createHaystackDeadlineSignal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts with TimeoutError after the deadline", () => {
+    vi.useFakeTimers();
+    const { signal, cleanup } = createHaystackDeadlineSignal(1_000);
+    expect(signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1_000);
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toMatchObject({ name: "TimeoutError" });
+    cleanup();
+  });
+
+  it("aborts immediately when the external signal is already aborted", () => {
+    const external = new AbortController();
+    external.abort();
+    const { signal, cleanup } = createHaystackDeadlineSignal(5_000, external.signal);
+    expect(signal.aborted).toBe(true);
+    cleanup();
+  });
+});
+
+describe("fetchHaystackQuote", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("times out hung fetches instead of waiting indefinitely", async () => {
+    vi.stubEnv("VITE_HAYSTACK_PROXY_URL", "https://proxy.test");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) return;
+            if (signal.aborted) {
+              reject(
+                Object.assign(new Error("Aborted"), { name: "AbortError" })
+              );
+              return;
+            }
+            signal.addEventListener(
+              "abort",
+              () => {
+                reject(
+                  signal.reason instanceof Error
+                    ? signal.reason
+                    : Object.assign(new Error("Aborted"), {
+                        name: "TimeoutError",
+                      })
+                );
+              },
+              { once: true }
+            );
+          })
+      )
+    );
+
+    await expect(
+      fetchHaystackQuote({
+        amount: 1_000_000,
+        type: "fixed-output",
+        fromASAID: 0,
+        toASAID: 31566704,
+        timeoutMs: 50,
+      })
+    ).rejects.toThrow(/timed out.*routing proxy/i);
+  });
+
+  it("returns a successful quote payload", async () => {
+    vi.stubEnv("VITE_HAYSTACK_PROXY_URL", "https://proxy.test");
+    const body = {
+      quote: 42,
+      txnPayload: { iv: "a", data: "b" },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+
+    const q = await fetchHaystackQuote({
+      amount: 1,
+      type: "fixed-output",
+      fromASAID: 0,
+      toASAID: 1,
+    });
+    expect(q.quote).toBe(42);
+    expect(q.txnPayload).toEqual({ iv: "a", data: "b" });
+    expect(HAYSTACK_QUOTE_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+});

--- a/src/services/haystackRouterService.ts
+++ b/src/services/haystackRouterService.ts
@@ -48,6 +48,16 @@ export type HaystackExecuteResponse = {
 export const DEFAULT_HAYSTACK_PROXY_URL =
   "https://profound-bravery-production-418a.up.railway.app";
 
+/**
+ * Client-side deadline for a quote request (connect + proxy + upstream).
+ * Prevents the UI from spinning for the full browser TCP timeout when the
+ * Railway proxy is down or unreachable.
+ */
+export const HAYSTACK_QUOTE_TIMEOUT_MS = 12_000;
+
+/** Client-side deadline for building execute txns from a quote payload. */
+export const HAYSTACK_EXECUTE_TIMEOUT_MS = 20_000;
+
 /** Origins where cross-asset repay is on without `VITE_ENABLE_CROSS_ASSET_REPAY`. */
 export const CROSS_ASSET_REPAY_AUTO_ENABLE_ORIGINS = [
   "https://beta.dork.fi",
@@ -130,6 +140,110 @@ function executePath(proxyBase: string): string {
   return `${proxyBase}/api/fetchExecuteSwapTxns`;
 }
 
+/**
+ * Combine an optional external AbortSignal with a timeout. Timeout aborts set
+ * `name = "TimeoutError"` so callers can show a proxy-unavailable message;
+ * external abort keeps standard `AbortError` for ignore-on-unmount.
+ */
+export function createHaystackDeadlineSignal(
+  timeoutMs: number,
+  external?: AbortSignal
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+
+  if (external?.aborted) {
+    controller.abort(external.reason);
+    return { signal: controller.signal, cleanup: () => undefined };
+  }
+
+  const onTimeout = () => {
+    const reason =
+      typeof DOMException !== "undefined"
+        ? new DOMException(
+            `Haystack request exceeded ${timeoutMs}ms`,
+            "TimeoutError"
+          )
+        : Object.assign(new Error(`Haystack request exceeded ${timeoutMs}ms`), {
+            name: "TimeoutError",
+          });
+    controller.abort(reason);
+  };
+  const tid = setTimeout(onTimeout, timeoutMs);
+
+  const onExternal = () => {
+    clearTimeout(tid);
+    controller.abort(external!.reason);
+  };
+  external?.addEventListener("abort", onExternal, { once: true });
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(tid);
+      external?.removeEventListener("abort", onExternal);
+    },
+  };
+}
+
+export function formatHaystackFetchError(
+  err: unknown,
+  kind: "quote" | "execute"
+): Error {
+  if (err instanceof Error) {
+    // Caller cancelled (unmount / amount change) — rethrow unchanged.
+    if (err.name === "AbortError") {
+      return err;
+    }
+    if (
+      err.name === "TimeoutError" ||
+      /exceeded \d+ms/i.test(err.message) ||
+      /aborted due to timeout/i.test(err.message)
+    ) {
+      return new Error(
+        `Haystack ${kind} timed out. The routing proxy may be unavailable — retry shortly or check the Haystack proxy service.`
+      );
+    }
+    if (
+      err.name === "TypeError" ||
+      /failed to fetch|networkerror|load failed|network request failed/i.test(
+        err.message
+      )
+    ) {
+      return new Error(
+        `Haystack ${kind} could not reach the routing proxy. The proxy may be down — retry shortly.`
+      );
+    }
+    return err;
+  }
+  return new Error(`Haystack ${kind} failed`);
+}
+
+async function parseHaystackJsonResponse(
+  res: Response,
+  kind: "quote" | "execute"
+): Promise<unknown> {
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(
+      `Haystack ${kind} failed (${res.status}): ${text.slice(0, 200)}`
+    );
+  }
+  if (!res.ok) {
+    const msg =
+      typeof json === "object" &&
+      json &&
+      "error" in json &&
+      typeof (json as { error: unknown }).error === "string"
+        ? (json as { error: string }).error
+        : text.slice(0, 200) || res.statusText;
+    throw new Error(`Haystack ${kind} failed (${res.status}): ${msg}`);
+  }
+  return json;
+}
+
 export type FetchHaystackQuoteParams = {
   chain?: HaystackChain;
   amount: bigint | number | string;
@@ -144,6 +258,10 @@ export type FetchHaystackQuoteParams = {
   algodUri?: string;
   algodToken?: string;
   algodPort?: string | number;
+  /** Cancel in-flight quote (e.g. effect cleanup). Combined with quote timeout. */
+  signal?: AbortSignal;
+  /** Override default {@link HAYSTACK_QUOTE_TIMEOUT_MS}. */
+  timeoutMs?: number;
 };
 
 export async function fetchHaystackQuote(
@@ -185,27 +303,35 @@ export async function fetchHaystackQuote(
   }
 
   const url = `${quotePath(proxyBase)}?${search.toString()}`;
-  const res = await fetch(url);
-  const text = await res.text();
-  let json: unknown;
+  const timeoutMs = params.timeoutMs ?? HAYSTACK_QUOTE_TIMEOUT_MS;
+  const { signal, cleanup } = createHaystackDeadlineSignal(
+    timeoutMs,
+    params.signal
+  );
+
   try {
-    json = text ? JSON.parse(text) : {};
-  } catch {
-    throw new Error(
-      `Haystack quote failed (${res.status}): ${text.slice(0, 200)}`
-    );
+    const res = await fetch(url, { signal });
+    const json = await parseHaystackJsonResponse(res, "quote");
+    return json as HaystackQuoteResponse;
+  } catch (err) {
+    // External cancel (effect cleanup / user navigation) — leave as AbortError.
+    if (params.signal?.aborted) {
+      throw err instanceof Error
+        ? err
+        : Object.assign(new Error("Aborted"), { name: "AbortError" });
+    }
+    // fetch() surfaces signal.abort as AbortError; recover TimeoutError from our deadline.
+    const reason = signal.reason;
+    if (
+      reason instanceof Error &&
+      (reason.name === "TimeoutError" || /exceeded \d+ms/i.test(reason.message))
+    ) {
+      throw formatHaystackFetchError(reason, "quote");
+    }
+    throw formatHaystackFetchError(err, "quote");
+  } finally {
+    cleanup();
   }
-  if (!res.ok) {
-    const msg =
-      typeof json === "object" &&
-      json &&
-      "error" in json &&
-      typeof (json as { error: unknown }).error === "string"
-        ? (json as { error: string }).error
-        : text.slice(0, 200) || res.statusText;
-    throw new Error(`Haystack quote failed (${res.status}): ${msg}`);
-  }
-  return json as HaystackQuoteResponse;
 }
 
 export async function fetchHaystackExecuteTxns(args: {
@@ -213,35 +339,44 @@ export async function fetchHaystackExecuteTxns(args: {
   txnPayload: HaystackTxnPayload;
   /** Slippage percent, e.g. 1 = 1% */
   slippage: number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
 }): Promise<HaystackExecuteResponse> {
   const proxyBase = getHaystackProxyBaseUrl();
-  const res = await fetch(executePath(proxyBase), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      address: args.address,
-      txnPayloadJSON: args.txnPayload,
-      slippage: args.slippage,
-    }),
-  });
-  const text = await res.text();
-  let json: unknown;
+  const timeoutMs = args.timeoutMs ?? HAYSTACK_EXECUTE_TIMEOUT_MS;
+  const { signal, cleanup } = createHaystackDeadlineSignal(
+    timeoutMs,
+    args.signal
+  );
+
   try {
-    json = text ? JSON.parse(text) : {};
-  } catch {
-    throw new Error(
-      `Haystack execute failed (${res.status}): ${text.slice(0, 200)}`
-    );
+    const res = await fetch(executePath(proxyBase), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        address: args.address,
+        txnPayloadJSON: args.txnPayload,
+        slippage: args.slippage,
+      }),
+      signal,
+    });
+    const json = await parseHaystackJsonResponse(res, "execute");
+    return json as HaystackExecuteResponse;
+  } catch (err) {
+    if (args.signal?.aborted) {
+      throw err instanceof Error
+        ? err
+        : Object.assign(new Error("Aborted"), { name: "AbortError" });
+    }
+    const reason = signal.reason;
+    if (
+      reason instanceof Error &&
+      (reason.name === "TimeoutError" || /exceeded \d+ms/i.test(reason.message))
+    ) {
+      throw formatHaystackFetchError(reason, "execute");
+    }
+    throw formatHaystackFetchError(err, "execute");
+  } finally {
+    cleanup();
   }
-  if (!res.ok) {
-    const msg =
-      typeof json === "object" &&
-      json &&
-      "error" in json &&
-      typeof (json as { error: unknown }).error === "string"
-        ? (json as { error: string }).error
-        : text.slice(0, 200) || res.statusText;
-    throw new Error(`Haystack execute failed (${res.status}): ${msg}`);
-  }
-  return json as HaystackExecuteResponse;
 }

--- a/vite/haystackProxyPlugin.ts
+++ b/vite/haystackProxyPlugin.ts
@@ -2,6 +2,8 @@ import type { Plugin, Connect } from "vite";
 import type { IncomingMessage } from "node:http";
 
 const UPSTREAM_DEFAULT = "https://hayrouter.txnlab.dev";
+/** Cap hung hayrouter calls in local Vite middleware (ms). */
+const UPSTREAM_TIMEOUT_MS = 20_000;
 
 async function readBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -9,6 +11,15 @@ async function readBody(req: IncomingMessage): Promise<string> {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return Buffer.concat(chunks).toString("utf8");
+}
+
+function upstreamSignal(): AbortSignal {
+  if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+    return AbortSignal.timeout(UPSTREAM_TIMEOUT_MS);
+  }
+  const c = new AbortController();
+  setTimeout(() => c.abort(), UPSTREAM_TIMEOUT_MS);
+  return c.signal;
 }
 
 function createHaystackMiddleware(apiKey: string, upstreamBase: string) {
@@ -39,7 +50,7 @@ function createHaystackMiddleware(apiKey: string, upstreamBase: string) {
         params.delete("apiKey");
         params.set("apiKey", apiKey);
         const target = `${upstream}/api/fetchQuote?${params.toString()}`;
-        const r = await fetch(target);
+        const r = await fetch(target, { signal: upstreamSignal() });
         const text = await r.text();
         res.statusCode = r.status;
         res.setHeader(
@@ -70,6 +81,7 @@ function createHaystackMiddleware(apiKey: string, upstreamBase: string) {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
+          signal: upstreamSignal(),
         });
         const text = await r.text();
         res.statusCode = r.status;
@@ -86,11 +98,20 @@ function createHaystackMiddleware(apiKey: string, upstreamBase: string) {
       res.end(JSON.stringify({ error: "Not found" }));
     } catch (e) {
       console.error("[haystack-proxy]", e);
-      res.statusCode = 502;
+      const timedOut =
+        e instanceof Error &&
+        (e.name === "TimeoutError" ||
+          e.name === "AbortError" ||
+          /aborted|timeout/i.test(e.message));
+      res.statusCode = timedOut ? 504 : 502;
       res.setHeader("Content-Type", "application/json");
       res.end(
         JSON.stringify({
-          error: e instanceof Error ? e.message : "Proxy upstream error",
+          error: timedOut
+            ? `Upstream Haystack timed out after ${UPSTREAM_TIMEOUT_MS}ms`
+            : e instanceof Error
+              ? e.message
+              : "Proxy upstream error",
         })
       );
     }


### PR DESCRIPTION
## Summary
- Abort Haystack quote/execute fetches after a client deadline (12s quote / 20s execute) so a slow or unreachable Railway proxy fails with a clear message instead of hanging on OS TCP timeouts.
- Cap upstream `hayrouter` calls in the standalone proxy and Vite middleware (default 20s) with request logging and 504s; repay quote hook cancels in-flight requests on amount/asset change.
- Document proxy health-check troubleshooting for production.

## Test plan
- [ ] `npm test -- src/services/__tests__/haystackQuoteClient.test.ts src/services/__tests__/haystackFeatureFlag.test.ts`
- [ ] Local: open cross-asset repay, change amount quickly — loading state resets without stale errors
- [ ] With proxy healthy: quote still returns within a few seconds
- [ ] Simulated hang / bad host: UI shows timeout/proxy-unavailable message within ~12s (not 60s+)
- [ ] Redeploy Railway `profound-bravery` with this proxy script when ready; confirm `/health` and a sample `fetchQuote` in Network tab


Made with [Cursor](https://cursor.com)