### PR TITLE
fix(share): redirect share permalinks to app.dork.fi

### DIFF
--- a/docs/repay/REPAY_SHARE_API.md
+++ b/docs/repay/REPAY_SHARE_API.md
@@ -55,7 +55,7 @@ Flow:
 | Variable | Example |
 |----------|---------|
 | `NODE_ENV` | `production` |
-| `X_SHARE_FRONTEND_ORIGIN` | `https://beta.dork.fi` or comma-separated `https://beta.dork.fi,https://app.dork.fi` |
+| `X_SHARE_FRONTEND_ORIGIN` | `https://app.dork.fi` or comma-separated `https://app.dork.fi,https://beta.dork.fi` (redirects always prefer `app.dork.fi`) |
 | `X_SHARE_PUBLIC_BASE` | `https://share.dork.fi` (custom domain — see below) |
 
 ### Custom domain (required for X to render the card)

--- a/server/config.ts
+++ b/server/config.ts
@@ -16,6 +16,8 @@ function resolveSharePublicBase(): string {
   return DEFAULT_DEV_SHARE_PUBLIC_BASE;
 }
 
+const APP_FRONTEND_ORIGIN = "https://app.dork.fi";
+
 function resolveFrontendOrigins(): string[] {
   const explicit = process.env.X_SHARE_FRONTEND_ORIGIN?.trim();
   if (explicit) {
@@ -25,9 +27,24 @@ function resolveFrontendOrigins(): string[] {
       .filter(Boolean);
   }
   if (process.env.RAILWAY_PUBLIC_DOMAIN) {
-    return ["https://app.dork.fi", "https://beta.dork.fi"];
+    return [APP_FRONTEND_ORIGIN, "https://beta.dork.fi"];
   }
   return ["http://localhost:8080"];
+}
+
+/**
+ * Human redirects after opening a share permalink always land on app.dork.fi
+ * when that origin is allowed (or any dork.fi frontend is configured). CORS
+ * still uses the full `frontendOrigins` list so beta can create shares.
+ */
+function resolveFrontendOrigin(origins: string[]): string {
+  if (origins.includes(APP_FRONTEND_ORIGIN)) {
+    return APP_FRONTEND_ORIGIN;
+  }
+  if (origins.some((origin) => /\/\/(?:[\w-]+\.)*dork\.fi$/i.test(origin))) {
+    return APP_FRONTEND_ORIGIN;
+  }
+  return origins[0] ?? APP_FRONTEND_ORIGIN;
 }
 
 const frontendOrigins = resolveFrontendOrigins();
@@ -37,7 +54,7 @@ export const config = {
   /** Allowed browser origins for CORS (supports comma-separated env). */
   frontendOrigins,
   /** Primary origin for human redirects after opening a share permalink. */
-  frontendOrigin: frontendOrigins[0] ?? "https://app.dork.fi",
+  frontendOrigin: resolveFrontendOrigin(frontendOrigins),
   repayShareStorePath: optional(
     "X_REPAY_SHARE_STORE_PATH",
     ".data/repay-shares"


### PR DESCRIPTION
## Summary
- Prefer `https://app.dork.fi` for human redirects from repay/borrow/profile share permalinks, even when `X_SHARE_FRONTEND_ORIGIN` lists `beta.dork.fi` first.
- Keep both origins in the CORS allowlist so beta can still create share links.
- Update share API docs to document the redirect preference.

## Test plan
- [ ] Deploy/restart the Railway share service with this change
- [ ] Open an existing share permalink (e.g. `https://share.dork.fi/profile/<id>`) in a browser and confirm 302 → `https://app.dork.fi/`
- [ ] Confirm Twitterbot still receives OG HTML (no redirect for crawlers)
- [ ] Confirm beta can still POST new share links (CORS)


Made with [Cursor](https://cursor.com)