### PR TITLE
perf(analytics): cache series to speed Analytics historical loads (#599)

### DIFF
--- a/src/components/analytics/ActivityFlowsChart.tsx
+++ b/src/components/analytics/ActivityFlowsChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   CartesianGrid,
   Legend,
@@ -12,23 +12,14 @@ import {
 } from "recharts";
 import ChartCard from "./ChartCard";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { dorkfiAPIService } from "@/services/dorkfiAPIService";
-import { fetchAnalyticsMarketUsdLookup } from "@/services/analyticsProtocolTvl";
 import {
-  activityRowToUsd,
-  analyticsValueToUsd,
-  pickWithdrawValueUsd,
-} from "@/utils/analyticsActivityUsd";
-import {
-  aggregateEventsByDay,
-  mergeDailyFlows,
-  symmetricYDomain,
-  type FlowDataPoint,
-} from "@/utils/analyticsActivityFlows";
+  useFlowSeries,
+} from "@/hooks/useCachedAnalyticsSeries";
+import { symmetricYDomain } from "@/utils/analyticsActivityFlows";
 import { formatCurrency, formatChartDate } from "@/utils/analyticsUtils";
+import { type AnalyticsTimePeriod } from "@/utils/analyticsTimePeriod";
 import { useTheme } from "next-themes";
 
-type TimePeriod = "7d" | "30d" | "90d";
 type FlowMode = "liquidity" | "loans";
 
 interface ActivityFlowsChartProps {
@@ -77,101 +68,8 @@ function formatAxisValue(value: number): string {
 const ActivityFlowsChart = ({ mode }: ActivityFlowsChartProps) => {
   const { theme } = useTheme();
   const config = FLOW_CONFIG[mode];
-  const [flowData, setFlowData] = useState<FlowDataPoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>("90d");
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchFlowData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days =
-          timePeriod === "7d" ? 7 : timePeriod === "30d" ? 30 : 90;
-        const startTime = now - days * 24 * 60 * 60 * 1000;
-
-        if (mode === "liquidity") {
-          const [depositsResponse, withdrawalsResponse, marketUsdLookup] =
-            await Promise.all([
-              dorkfiAPIService.getDeposits(startTime, now, 10000),
-              dorkfiAPIService.getWithdrawals(startTime, now, 10000),
-              fetchAnalyticsMarketUsdLookup().catch((error) => {
-                console.warn("Flow chart market USD lookup failed", error);
-                return new Map();
-              }),
-            ]);
-
-          if (cancelled) return;
-
-          const deposits =
-            depositsResponse.success && depositsResponse.data?.deposits
-              ? depositsResponse.data.deposits
-              : [];
-          const withdrawals =
-            withdrawalsResponse.success &&
-            withdrawalsResponse.data?.withdrawals
-              ? withdrawalsResponse.data.withdrawals
-              : [];
-
-          const inflowByDay = aggregateEventsByDay(deposits, (deposit) =>
-            analyticsValueToUsd(deposit.depositValueUSD, deposit.amount)
-          );
-          const outflowByDay = aggregateEventsByDay(withdrawals, (withdrawal) =>
-            activityRowToUsd(
-              {
-                amount: withdrawal.amount,
-                valueUsd: pickWithdrawValueUsd(withdrawal),
-                network: withdrawal.network,
-                marketId: withdrawal.marketId,
-              },
-              marketUsdLookup
-            )
-          );
-
-          setFlowData(mergeDailyFlows(inflowByDay, outflowByDay));
-          return;
-        }
-
-        const [borrowsResponse, repaysResponse] = await Promise.all([
-          dorkfiAPIService.getBorrows(startTime, now, 10000),
-          dorkfiAPIService.getRepays(startTime, now, 10000),
-        ]);
-
-        if (cancelled) return;
-
-        const borrows =
-          borrowsResponse.success && borrowsResponse.data?.borrows
-            ? borrowsResponse.data.borrows
-            : [];
-        const repays =
-          repaysResponse.success && repaysResponse.data?.repays
-            ? repaysResponse.data.repays
-            : [];
-
-        const inflowByDay = aggregateEventsByDay(borrows, (borrow) =>
-          analyticsValueToUsd(borrow.borrowValueUSD, borrow.amount)
-        );
-        const outflowByDay = aggregateEventsByDay(repays, (repay) =>
-          analyticsValueToUsd(repay.repayValueUSD, repay.amount)
-        );
-
-        setFlowData(mergeDailyFlows(inflowByDay, outflowByDay));
-      } catch (error) {
-        console.error(`Error fetching ${mode} flow data:`, error);
-        if (!cancelled) setFlowData([]);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    fetchFlowData();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [mode, timePeriod]);
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>("90d");
+  const { series: flowData, loading } = useFlowSeries(mode, timePeriod);
 
   const chartData = useMemo(
     () =>
@@ -215,7 +113,9 @@ const ActivityFlowsChart = ({ mode }: ActivityFlowsChartProps) => {
         <ToggleGroup
           type="single"
           value={timePeriod}
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) =>
+            value && setTimePeriod(value as AnalyticsTimePeriod)
+          }
           variant="outline"
           size="sm"
         >

--- a/src/components/analytics/BorrowsChart.tsx
+++ b/src/components/analytics/BorrowsChart.tsx
@@ -1,97 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
-import {
-  analyticsSummaryToUsd,
-  analyticsValueToUsd,
-} from '@/utils/analyticsActivityUsd';
+import { useActivityDailySeries } from '@/hooks/useCachedAnalyticsSeries';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface BorrowsDataPoint {
-  date: string;
-  amount: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const BorrowsChart = () => {
   const { theme } = useTheme();
-  const [borrowsData, setBorrowsData] = useState<BorrowsDataPoint[]>([]);
-  const [totalBorrows, setTotalBorrows] = useState<number>(0);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
-
-  useEffect(() => {
-    const fetchBorrowsData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        // Always use total (no network filter)
-        const networkFilter = undefined;
-        const response = await dorkfiAPIService.getBorrows(
-          startTime,
-          now,
-          10000,
-          networkFilter
-        );
-
-        if (response.success && response.data?.borrows) {
-          const borrows = response.data.borrows;
-          if (borrows.length > 0) {
-            // Group by date and sum amounts (matching demo page approach)
-            const dailyBorrows: { [key: string]: number } = {};
-            
-            borrows.forEach((borrow) => {
-              const date = new Date(borrow.timestamp).toISOString().split('T')[0];
-              const value = analyticsValueToUsd(
-                borrow.borrowValueUSD,
-                borrow.amount
-              );
-              dailyBorrows[date] = (dailyBorrows[date] || 0) + value;
-            });
-
-            const transformed = Object.entries(dailyBorrows)
-              .map(([date, amount]) => ({ date, amount }))
-              .sort((a, b) => a.date.localeCompare(b.date));
-            
-            setBorrowsData(transformed);
-            
-            // Calculate total from summary if available, otherwise sum the daily amounts
-            const totalFromSummary = response.data.summary?.totalBorrowValueUSD
-              ? analyticsSummaryToUsd(
-                  response.data.summary.totalBorrowValueUSD,
-                  borrows.map((b) => ({
-                    valueUsd: b.borrowValueUSD,
-                    amount: b.amount,
-                  }))
-                )
-              : transformed.reduce((sum, d) => sum + d.amount, 0);
-            setTotalBorrows(totalFromSummary);
-          } else {
-            setBorrowsData([]);
-            setTotalBorrows(0);
-          }
-        } else {
-          console.warn('Borrows API returned unsuccessful response');
-          setBorrowsData([]);
-          setTotalBorrows(0);
-        }
-      } catch (error) {
-        console.error('Error fetching borrows data:', error);
-        setBorrowsData([]);
-        setTotalBorrows(0);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchBorrowsData();
-  }, [timePeriod]);
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: borrowsData, loading, total: totalBorrows } =
+    useActivityDailySeries('borrows', timePeriod);
 
   const formattedTotal = totalBorrows >= 1_000_000 
     ? `$${(totalBorrows / 1_000_000).toFixed(1)}M`
@@ -101,14 +20,13 @@ const BorrowsChart = () => {
 
   const chartData = borrowsData.map(d => ({
     date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    amount: d.amount, // Use raw dollar amounts
+    amount: d.amount,
   }));
 
-  // Calculate max value and set Y-axis domain to 1.1x max
   const maxValue = chartData.length > 0 
     ? Math.max(...chartData.map(d => d.amount))
     : 0;
-  const yAxisDomain = [0, maxValue * 1.1 || 5000]; // Default to 5000 if no data
+  const yAxisDomain = [0, maxValue * 1.1 || 5000];
 
   if (loading) {
     return (
@@ -133,7 +51,7 @@ const BorrowsChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -204,4 +122,3 @@ const BorrowsChart = () => {
 };
 
 export default BorrowsChart;
-

--- a/src/components/analytics/DepositsChart.tsx
+++ b/src/components/analytics/DepositsChart.tsx
@@ -1,97 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
-import {
-  analyticsSummaryToUsd,
-  analyticsValueToUsd,
-} from '@/utils/analyticsActivityUsd';
+import { useActivityDailySeries } from '@/hooks/useCachedAnalyticsSeries';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface DepositsDataPoint {
-  date: string;
-  amount: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const DepositsChart = () => {
   const { theme } = useTheme();
-  const [depositsData, setDepositsData] = useState<DepositsDataPoint[]>([]);
-  const [totalDeposits, setTotalDeposits] = useState<number>(0);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
-
-  useEffect(() => {
-    const fetchDepositsData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        // Always use total (no network filter)
-        const networkFilter = undefined;
-        const response = await dorkfiAPIService.getDeposits(
-          startTime,
-          now,
-          10000,
-          networkFilter
-        );
-
-        if (response.success && response.data?.deposits) {
-          const deposits = response.data.deposits;
-          if (deposits.length > 0) {
-            // Group by date and sum amounts (matching demo page approach)
-            const dailyDeposits: { [key: string]: number } = {};
-            
-            deposits.forEach((deposit) => {
-              const date = new Date(deposit.timestamp).toISOString().split('T')[0];
-              const value = analyticsValueToUsd(
-                deposit.depositValueUSD,
-                deposit.amount
-              );
-              dailyDeposits[date] = (dailyDeposits[date] || 0) + value;
-            });
-
-            const transformed = Object.entries(dailyDeposits)
-              .map(([date, amount]) => ({ date, amount }))
-              .sort((a, b) => a.date.localeCompare(b.date));
-            
-            setDepositsData(transformed);
-            
-            // Calculate total from summary if available, otherwise sum the daily amounts
-            const totalFromSummary = response.data.summary?.totalDepositValueUSD
-              ? analyticsSummaryToUsd(
-                  response.data.summary.totalDepositValueUSD,
-                  deposits.map((d) => ({
-                    valueUsd: d.depositValueUSD,
-                    amount: d.amount,
-                  }))
-                )
-              : transformed.reduce((sum, d) => sum + d.amount, 0);
-            setTotalDeposits(totalFromSummary);
-          } else {
-            setDepositsData([]);
-            setTotalDeposits(0);
-          }
-        } else {
-          console.warn('Deposits API returned unsuccessful response');
-          setDepositsData([]);
-          setTotalDeposits(0);
-        }
-      } catch (error) {
-        console.error('Error fetching deposits data:', error);
-        setDepositsData([]);
-        setTotalDeposits(0);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchDepositsData();
-  }, [timePeriod]);
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: depositsData, loading, total: totalDeposits } =
+    useActivityDailySeries('deposits', timePeriod);
 
   const formattedTotal = totalDeposits >= 1_000_000 
     ? `$${(totalDeposits / 1_000_000).toFixed(1)}M`
@@ -101,14 +20,13 @@ const DepositsChart = () => {
 
   const chartData = depositsData.map(d => ({
     date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    amount: d.amount, // Use raw dollar amounts
+    amount: d.amount,
   }));
 
-  // Calculate max value and set Y-axis domain to 1.1x max
   const maxValue = chartData.length > 0 
     ? Math.max(...chartData.map(d => d.amount))
     : 0;
-  const yAxisDomain = [0, maxValue * 1.1 || 5000]; // Default to 5000 if no data
+  const yAxisDomain = [0, maxValue * 1.1 || 5000];
 
   if (loading) {
     return (
@@ -133,7 +51,7 @@ const DepositsChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -204,4 +122,3 @@ const DepositsChart = () => {
 };
 
 export default DepositsChart;
-

--- a/src/components/analytics/RepaysChart.tsx
+++ b/src/components/analytics/RepaysChart.tsx
@@ -1,97 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
-import {
-  analyticsSummaryToUsd,
-  analyticsValueToUsd,
-} from '@/utils/analyticsActivityUsd';
+import { useActivityDailySeries } from '@/hooks/useCachedAnalyticsSeries';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface RepaysDataPoint {
-  date: string;
-  amount: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const RepaysChart = () => {
   const { theme } = useTheme();
-  const [repaysData, setRepaysData] = useState<RepaysDataPoint[]>([]);
-  const [totalRepays, setTotalRepays] = useState<number>(0);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
-
-  useEffect(() => {
-    const fetchRepaysData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        // Always use total (no network filter)
-        const networkFilter = undefined;
-        const response = await dorkfiAPIService.getRepays(
-          startTime,
-          now,
-          10000,
-          networkFilter
-        );
-
-        if (response.success && response.data?.repays) {
-          const repays = response.data.repays;
-          if (repays.length > 0) {
-            // Group by date and sum amounts (matching demo page approach)
-            const dailyRepays: { [key: string]: number } = {};
-            
-            repays.forEach((repay) => {
-              const date = new Date(repay.timestamp).toISOString().split('T')[0];
-              const value = analyticsValueToUsd(
-                repay.repayValueUSD,
-                repay.amount
-              );
-              dailyRepays[date] = (dailyRepays[date] || 0) + value;
-            });
-
-            const transformed = Object.entries(dailyRepays)
-              .map(([date, amount]) => ({ date, amount }))
-              .sort((a, b) => a.date.localeCompare(b.date));
-            
-            setRepaysData(transformed);
-            
-            // Calculate total from summary if available, otherwise sum the daily amounts
-            const totalFromSummary = response.data.summary?.totalRepayValueUSD
-              ? analyticsSummaryToUsd(
-                  response.data.summary.totalRepayValueUSD,
-                  repays.map((r) => ({
-                    valueUsd: r.repayValueUSD,
-                    amount: r.amount,
-                  }))
-                )
-              : transformed.reduce((sum, d) => sum + d.amount, 0);
-            setTotalRepays(totalFromSummary);
-          } else {
-            setRepaysData([]);
-            setTotalRepays(0);
-          }
-        } else {
-          console.warn('Repays API returned unsuccessful response');
-          setRepaysData([]);
-          setTotalRepays(0);
-        }
-      } catch (error) {
-        console.error('Error fetching repays data:', error);
-        setRepaysData([]);
-        setTotalRepays(0);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchRepaysData();
-  }, [timePeriod]);
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: repaysData, loading, total: totalRepays } =
+    useActivityDailySeries('repays', timePeriod);
 
   const formattedTotal = totalRepays >= 1_000_000 
     ? `$${(totalRepays / 1_000_000).toFixed(1)}M`
@@ -101,14 +20,13 @@ const RepaysChart = () => {
 
   const chartData = repaysData.map(d => ({
     date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    amount: d.amount, // Use raw dollar amounts
+    amount: d.amount,
   }));
 
-  // Calculate max value and set Y-axis domain to 1.1x max
   const maxValue = chartData.length > 0 
     ? Math.max(...chartData.map(d => d.amount))
     : 0;
-  const yAxisDomain = [0, maxValue * 1.1 || 5000]; // Default to 5000 if no data
+  const yAxisDomain = [0, maxValue * 1.1 || 5000];
 
   if (loading) {
     return (
@@ -133,7 +51,7 @@ const RepaysChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -204,4 +122,3 @@ const RepaysChart = () => {
 };
 
 export default RepaysChart;
-

--- a/src/components/analytics/TVLChart.tsx
+++ b/src/components/analytics/TVLChart.tsx
@@ -1,107 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
-import { fetchOracleBasedProtocolTotals, peekCachedOracleProtocolTotals } from '@/services/analyticsProtocolTvl';
+import { useTvlGrowthSeries } from '@/hooks/useCachedAnalyticsSeries';
 import { formatCurrency, formatChartDate } from '@/utils/analyticsUtils';
-import {
-  overlayLiveTvlOnSeries,
-  tvlFromGrowthDataPoint,
-} from '@/utils/analyticsProtocolTvl';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface TVLDataPoint {
-  date: string;
-  total: number;
-  weth: number;
-  usdc: number;
-  usdt: number;
-  wbtc: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const TVLChart = () => {
   const { theme } = useTheme();
-  const [tvlData, setTvlData] = useState<TVLDataPoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: tvlData, loading } = useTvlGrowthSeries(timePeriod);
 
-  useEffect(() => {
-    const fetchTVLData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        const networkFilter = undefined;
-        const cachedOracle = peekCachedOracleProtocolTotals();
-        const response = await dorkfiAPIService.getTVLGrowth(
-          startTime,
-          now,
-          'day',
-          networkFilter
-        );
-
-        if (response.success && response.data?.dataPoints) {
-          const dataPoints = response.data.dataPoints;
-          if (dataPoints.length > 0) {
-            const transformed: TVLDataPoint[] = dataPoints
-              .map((point: { tvl?: number; value?: number; timestamp: number }) => {
-                const tvlValue = tvlFromGrowthDataPoint(point);
-                
-                return {
-                  date: new Date(point.timestamp).toISOString().split('T')[0],
-                  total: tvlValue,
-                  weth: tvlValue * 0.35,
-                  usdc: tvlValue * 0.28,
-                  usdt: tvlValue * 0.22,
-                  wbtc: tvlValue * 0.15,
-                };
-              })
-              .filter((point) => point.total >= 0);
-            
-            setTvlData(
-              cachedOracle?.tvl
-                ? overlayLiveTvlOnSeries(transformed, cachedOracle.tvl)
-                : transformed
-            );
-          } else {
-            setTvlData([]);
-          }
-        } else {
-          console.warn('TVL growth API returned unsuccessful response');
-          setTvlData([]);
-        }
-
-        if (!cachedOracle) {
-          fetchOracleBasedProtocolTotals()
-            .then((oracleTotals) => {
-              if (!oracleTotals?.tvl) return;
-              setTvlData((prev) =>
-                prev.length > 0
-                  ? overlayLiveTvlOnSeries(prev, oracleTotals.tvl)
-                  : prev
-              );
-            })
-            .catch((error) => {
-              console.warn('[TVLChart] oracle overlay failed', error);
-            });
-        }
-      } catch (error) {
-        console.error('Error fetching TVL growth data:', error);
-        setTvlData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchTVLData();
-  }, [timePeriod]);
-
-  // Calculate min and max values from the data
   const yAxisDomain = React.useMemo(() => {
     if (tvlData.length === 0) return ['auto', 'auto'];
     
@@ -109,7 +19,6 @@ const TVLChart = () => {
     const min = Math.min(...values);
     const max = Math.max(...values);
     
-    // Set y-axis to 0.95 * min and 1.05 * max for better visualization
     return [min * 0.95, max * 1.05];
   }, [tvlData]);
 
@@ -147,7 +56,7 @@ const TVLChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -192,4 +101,3 @@ const TVLChart = () => {
 };
 
 export default TVLChart;
-

--- a/src/components/analytics/WADCirculationChart.tsx
+++ b/src/components/analytics/WADCirculationChart.tsx
@@ -1,79 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
+import { useWadGrowthSeries } from '@/hooks/useCachedAnalyticsSeries';
 import { formatCurrency, formatChartDate } from '@/utils/analyticsUtils';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface WADDataPoint {
-  date: string;
-  supply: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const WADCirculationChart = () => {
   const { theme } = useTheme();
-  const [wadData, setWadData] = useState<WADDataPoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: wadData, loading } = useWadGrowthSeries(timePeriod);
 
-  useEffect(() => {
-    const fetchWADData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        // Always use total (no network filter)
-        const networkFilter = undefined;
-        const response = await dorkfiAPIService.getWADSupplyGrowth(
-          startTime,
-          now,
-          'day',
-          networkFilter
-        );
-
-        if (response.success && response.data?.dataPoints) {
-          const dataPoints = response.data.dataPoints;
-          if (dataPoints.length > 0) {
-            // Extract WAD supply values for total, matching demo page logic
-            const transformed: WADDataPoint[] = dataPoints
-              .map((point: any) => {
-                // When showing total, use the 'supply' field from dataPoint
-                // Normalize WAD by dividing by 10^6 (1e6)
-                const rawValue = parseFloat(point.supply || point.value || '0');
-                const supplyValue = rawValue / 1e6;
-                
-                return {
-                  date: new Date(point.timestamp).toISOString().split('T')[0],
-                  supply: supplyValue,
-                };
-              })
-              .filter((point) => point.supply >= 0); // Allow 0 values but filter out negative
-            
-            setWadData(transformed);
-          } else {
-            setWadData([]);
-          }
-        } else {
-          console.warn('WAD supply growth API returned unsuccessful response');
-          setWadData([]);
-        }
-      } catch (error) {
-        console.error('Error fetching WAD supply growth data:', error);
-        setWadData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchWADData();
-  }, [timePeriod]);
-
-  // Calculate min and max values from the data
   const yAxisDomain = React.useMemo(() => {
     if (wadData.length === 0) return ['auto', 'auto'];
     
@@ -81,7 +19,6 @@ const WADCirculationChart = () => {
     const min = Math.min(...values);
     const max = Math.max(...values);
     
-    // Set y-axis to 0.95 * min and 1.05 * max for better visualization
     return [min * 0.95, max * 1.05];
   }, [wadData]);
 
@@ -118,7 +55,7 @@ const WADCirculationChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -163,4 +100,3 @@ const WADCirculationChart = () => {
 };
 
 export default WADCirculationChart;
-

--- a/src/components/analytics/WithdrawalsChart.tsx
+++ b/src/components/analytics/WithdrawalsChart.tsx
@@ -1,102 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
 import ChartCard from './ChartCard';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
-import { fetchAnalyticsMarketUsdLookup } from '@/services/analyticsProtocolTvl';
-import {
-  activityRowToUsd,
-  pickWithdrawValueUsd,
-} from '@/utils/analyticsActivityUsd';
+import { useActivityDailySeries } from '@/hooks/useCachedAnalyticsSeries';
+import { type AnalyticsTimePeriod } from '@/utils/analyticsTimePeriod';
 import { useTheme } from 'next-themes';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-interface WithdrawalsDataPoint {
-  date: string;
-  amount: number;
-}
-
-type TimePeriod = '7d' | '30d' | '90d';
-
 const WithdrawalsChart = () => {
   const { theme } = useTheme();
-  const [withdrawalsData, setWithdrawalsData] = useState<WithdrawalsDataPoint[]>([]);
-  const [totalWithdrawals, setTotalWithdrawals] = useState<number>(0);
-  const [loading, setLoading] = useState(true);
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>('90d');
-
-  useEffect(() => {
-    const fetchWithdrawalsData = async () => {
-      setLoading(true);
-      try {
-        const now = Date.now();
-        const days = timePeriod === '7d' ? 7 : timePeriod === '30d' ? 30 : 90;
-        const startTime = now - (days * 24 * 60 * 60 * 1000);
-        
-        // Always use total (no network filter)
-        const networkFilter = undefined;
-        const [response, marketUsdLookup] = await Promise.all([
-          dorkfiAPIService.getWithdrawals(
-            startTime,
-            now,
-            10000,
-            networkFilter
-          ),
-          fetchAnalyticsMarketUsdLookup().catch((error) => {
-            console.warn('Withdrawals market USD lookup failed', error);
-            return new Map();
-          }),
-        ]);
-
-        if (response.success && response.data?.withdrawals) {
-          const withdrawals = response.data.withdrawals;
-          if (withdrawals.length > 0) {
-            // Group by date and sum amounts (matching demo page approach)
-            const dailyWithdrawals: { [key: string]: number } = {};
-            
-            withdrawals.forEach((withdrawal) => {
-              const date = new Date(withdrawal.timestamp).toISOString().split('T')[0];
-              const value = activityRowToUsd(
-                {
-                  amount: withdrawal.amount,
-                  valueUsd: pickWithdrawValueUsd(withdrawal),
-                  network: withdrawal.network,
-                  marketId: withdrawal.marketId,
-                },
-                marketUsdLookup
-              );
-              dailyWithdrawals[date] = (dailyWithdrawals[date] || 0) + value;
-            });
-
-            const transformed = Object.entries(dailyWithdrawals)
-              .map(([date, amount]) => ({ date, amount }))
-              .sort((a, b) => a.date.localeCompare(b.date));
-            
-            setWithdrawalsData(transformed);
-            
-            // Sum normalized rows. Withdrawal summaries are still mixed-scale vs deposits.
-            setTotalWithdrawals(
-              transformed.reduce((sum, d) => sum + d.amount, 0)
-            );
-          } else {
-            setWithdrawalsData([]);
-            setTotalWithdrawals(0);
-          }
-        } else {
-          console.warn('Withdrawals API returned unsuccessful response');
-          setWithdrawalsData([]);
-          setTotalWithdrawals(0);
-        }
-      } catch (error) {
-        console.error('Error fetching withdrawals data:', error);
-        setWithdrawalsData([]);
-        setTotalWithdrawals(0);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchWithdrawalsData();
-  }, [timePeriod]);
+  const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>('90d');
+  const { series: withdrawalsData, loading, total: totalWithdrawals } =
+    useActivityDailySeries('withdrawals', timePeriod);
 
   const formattedTotal = totalWithdrawals >= 1_000_000 
     ? `$${(totalWithdrawals / 1_000_000).toFixed(1)}M`
@@ -106,14 +20,13 @@ const WithdrawalsChart = () => {
 
   const chartData = withdrawalsData.map(d => ({
     date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    amount: d.amount, // Use raw dollar amounts
+    amount: d.amount,
   }));
 
-  // Calculate max value and set Y-axis domain to 1.1x max
   const maxValue = chartData.length > 0 
     ? Math.max(...chartData.map(d => d.amount))
     : 0;
-  const yAxisDomain = [0, maxValue * 1.1 || 5000]; // Default to 5000 if no data
+  const yAxisDomain = [0, maxValue * 1.1 || 5000];
 
   if (loading) {
     return (
@@ -138,7 +51,7 @@ const WithdrawalsChart = () => {
         <ToggleGroup 
           type="single" 
           value={timePeriod} 
-          onValueChange={(value) => value && setTimePeriod(value as TimePeriod)}
+          onValueChange={(value) => value && setTimePeriod(value as AnalyticsTimePeriod)}
           variant="outline"
           size="sm"
         >
@@ -209,4 +122,3 @@ const WithdrawalsChart = () => {
 };
 
 export default WithdrawalsChart;
-

--- a/src/hooks/useAnalyticsData.ts
+++ b/src/hooks/useAnalyticsData.ts
@@ -1,22 +1,19 @@
-import { useState, useEffect, useRef } from 'react';
-import { dorkfiAPIService } from '@/services/dorkfiAPIService';
+import { useState, useEffect, useRef } from "react";
+import { dorkfiAPIService } from "@/services/dorkfiAPIService";
 import {
-  fetchAnalyticsMarketUsdLookup,
+  fetchLiveProtocolSnapshot,
+  peekLiveProtocolSnapshot,
+} from "@/services/analyticsLiveSnapshot";
+import {
   fetchOracleBasedProtocolTotals,
   peekCachedOracleProtocolTotals,
-} from '@/services/analyticsProtocolTvl';
-import { buildHealthFactorDistribution } from '@/utils/analyticsHealthFactorDistribution';
+} from "@/services/analyticsProtocolTvl";
 import {
   growthPercentFromSeries,
   overlayLiveTvlOnSeries,
   pickFirstFiniteNumber,
   tvlFromGrowthDataPoint,
-} from '@/utils/analyticsProtocolTvl';
-import {
-  activityRowToUsd,
-  analyticsValueToUsd,
-  pickWithdrawValueUsd,
-} from '@/utils/analyticsActivityUsd';
+} from "@/utils/analyticsProtocolTvl";
 
 export interface KPIData {
   tvl: number;
@@ -30,342 +27,127 @@ export interface KPIData {
   walletsGrowth7d?: number;
 }
 
-export interface TVLData {
+interface TvlSeriesPoint {
   date: string;
   total: number;
-  weth: number;
-  usdc: number;
-  usdt: number;
-  wbtc: number;
 }
 
-export interface UtilizationData {
-  asset: string;
-  supplied: number;
-  borrowed: number;
-  utilization: number;
-}
-
-export interface RevenueData {
-  month: string;
-  interest: number;
-  liquidations: number;
-  flashLoans: number;
-}
-
-export interface TreasuryData {
-  holdings: Array<{
-    name: string;
-    value: number;
-    color: string;
-  }>;
-  growthData: Array<{
-    date: string;
-    value: number;
-  }>;
-}
-
-export interface WADData {
-  supplyData: Array<{
-    date: string;
-    supply: number;
-  }>;
-  collateralizationRatio: number;
-  pegStability: Array<{
-    date: string;
-    price: number;
-  }>;
-}
-
-export interface MAUData {
-  month: string;
-  lenders: number;
-  borrowers: number;
-  stakers: number;
-}
-
-export interface LoanData {
-  volume: Array<{
-    date: string;
-    loans: number;
-    repayments: number;
-  }>;
-  avgLoanSize: number;
-}
-
-export interface AssetDistribution {
-  deposits: Array<{
-    name: string;
-    value: number;
-    color: string;
-  }>;
-  borrows: Array<{
-    name: string;
-    value: number;
-    color: string;
-  }>;
-}
-
-export interface InterestRateData {
-  date: string;
-  wethSupply: number;
-  wethBorrow: number;
-  usdcSupply: number;
-  usdcBorrow: number;
-}
-
-export interface HealthFactorData {
-  range: string;
-  count: number;
-  color: string;
-}
-
-export interface LiquidationData {
-  events: Array<{
-    date: string;
-    volume: number;
-    count: number;
-  }>;
-  recovery: Array<{
-    month: string;
-    collateralRecovered: number;
-    liquidatorBonuses: number;
-  }>;
-}
-
-export interface DepositsData {
-  date: string;
-  amount: number;
-}
-
-export interface WithdrawalsData {
-  date: string;
-  amount: number;
-}
-
-const generateMockUtilizationData = (): UtilizationData[] => [
-  { asset: 'WETH', supplied: 125_000_000, borrowed: 87_500_000, utilization: 70 },
-  { asset: 'USDC', supplied: 68_000_000, borrowed: 40_800_000, utilization: 60 },
-  { asset: 'USDT', supplied: 54_000_000, borrowed: 32_400_000, utilization: 60 },
-  { asset: 'WBTC', supplied: 32_000_000, borrowed: 19_200_000, utilization: 60 },
-];
-
-const generateMockRevenueData = (): RevenueData[] => [
-  { month: 'Oct', interest: 850_000, liquidations: 120_000, flashLoans: 45_000 },
-  { month: 'Nov', interest: 920_000, liquidations: 156_000, flashLoans: 52_000 },
-  { month: 'Dec', interest: 1_100_000, liquidations: 89_000, flashLoans: 61_000 },
-  { month: 'Jan', interest: 1_350_000, liquidations: 234_000, flashLoans: 78_000 },
-  { month: 'Feb', interest: 1_180_000, liquidations: 167_000, flashLoans: 69_000 },
-  { month: 'Mar', interest: 1_450_000, liquidations: 198_000, flashLoans: 85_000 },
-];
-
-const generateMockTreasuryData = (): TreasuryData => ({
-  holdings: [
-    { name: 'WETH', value: 12_500_000, color: 'hsl(var(--ocean-teal))' },
-    { name: 'USDC', value: 8_900_000, color: 'hsl(var(--whale-gold))' },
-    { name: 'Protocol Tokens', value: 6_200_000, color: 'hsl(var(--highlight-aqua))' },
-    { name: 'Other', value: 2_800_000, color: 'hsl(var(--muted))' },
-  ],
-  growthData: Array.from({ length: 90 }, (_, i) => ({
-    date: new Date(Date.now() - (89 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    value: 25_000_000 + i * 150_000 + Math.random() * 1_000_000,
-  })),
-});
-
-const generateMockWADData = (): WADData => ({
-  supplyData: Array.from({ length: 30 }, (_, i) => ({
-    date: new Date(Date.now() - (29 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    supply: 80_000_000 + i * 300_000 + Math.random() * 500_000,
-  })),
-  collateralizationRatio: 135.4,
-  pegStability: Array.from({ length: 30 }, (_, i) => ({
-    date: new Date(Date.now() - (29 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    price: 1.0 + (Math.random() - 0.5) * 0.02,
-  })),
-});
-
-const generateMockMAUData = (): MAUData[] => [
-  { month: 'Oct', lenders: 15_200, borrowers: 8_900, stakers: 12_300 },
-  { month: 'Nov', lenders: 16_800, borrowers: 9_650, stakers: 13_100 },
-  { month: 'Dec', lenders: 18_200, borrowers: 10_400, stakers: 14_200 },
-  { month: 'Jan', lenders: 19_500, borrowers: 11_200, stakers: 15_800 },
-  { month: 'Feb', lenders: 18_900, borrowers: 10_800, stakers: 15_200 },
-  { month: 'Mar', lenders: 21_300, borrowers: 12_100, stakers: 16_900 },
-];
-
-const generateMockLoanData = (days: number = 30): LoanData => ({
-  volume: Array.from({ length: days }, (_, i) => ({
-    date: new Date(Date.now() - (days - 1 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    loans: 2_500_000 + Math.random() * 1_000_000,
-    repayments: 2_200_000 + Math.random() * 800_000,
-  })),
-  avgLoanSize: 45_680,
-});
-
-const generateMockAssetDistribution = (): AssetDistribution => ({
-  deposits: [
-    { name: 'WETH', value: 125_000_000, color: 'hsl(var(--ocean-teal))' },
-    { name: 'USDC', value: 68_000_000, color: 'hsl(var(--whale-gold))' },
-    { name: 'USDT', value: 54_000_000, color: 'hsl(var(--highlight-aqua))' },
-    { name: 'WBTC', value: 32_000_000, color: 'hsl(var(--accent))' },
-  ],
-  borrows: [
-    { name: 'WETH', value: 87_500_000, color: 'hsl(var(--ocean-teal))' },
-    { name: 'USDC', value: 40_800_000, color: 'hsl(var(--whale-gold))' },
-    { name: 'USDT', value: 32_400_000, color: 'hsl(var(--highlight-aqua))' },
-    { name: 'WBTC', value: 19_200_000, color: 'hsl(var(--accent))' },
-  ],
-});
-
-const generateMockInterestRateData = (days: number = 30): InterestRateData[] => {
-  return Array.from({ length: days }, (_, i) => ({
-    date: new Date(Date.now() - (days - 1 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    wethSupply: 3.2 + Math.random() * 0.8,
-    wethBorrow: 5.5 + Math.random() * 1.2,
-    usdcSupply: 2.1 + Math.random() * 0.6,
-    usdcBorrow: 4.2 + Math.random() * 0.9,
-  }));
-};
-
-const generateMockLiquidationData = (days: number = 30): LiquidationData => ({
-  events: Array.from({ length: days }, (_, i) => ({
-    date: new Date(Date.now() - (days - 1 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    volume: Math.random() * 2_000_000,
-    count: Math.floor(Math.random() * 50) + 5,
-  })),
-  recovery: [
-    { month: 'Oct', collateralRecovered: 8_900_000, liquidatorBonuses: 890_000 },
-    { month: 'Nov', collateralRecovered: 12_300_000, liquidatorBonuses: 1_230_000 },
-    { month: 'Dec', collateralRecovered: 6_700_000, liquidatorBonuses: 670_000 },
-    { month: 'Jan', collateralRecovered: 15_600_000, liquidatorBonuses: 1_560_000 },
-    { month: 'Feb', collateralRecovered: 11_200_000, liquidatorBonuses: 1_120_000 },
-    { month: 'Mar', collateralRecovered: 13_800_000, liquidatorBonuses: 1_380_000 },
-  ],
-});
-
-const generateMockDepositsData = (days: number = 30): DepositsData[] => {
-  return Array.from({ length: days }, (_, i) => ({
-    date: new Date(Date.now() - (days - 1 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    amount: 7_000_000 + Math.random() * 5_000_000 + Math.sin(i * 0.5) * 2_000_000,
-  }));
-};
-
-const generateMockWithdrawalsData = (days: number = 30): WithdrawalsData[] => {
-  return Array.from({ length: days }, (_, i) => ({
-    date: new Date(Date.now() - (days - 1 - i) * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-    amount: 5_000_000 + Math.random() * 5_000_000 + Math.cos(i * 0.5) * 2_000_000,
-  }));
-};
-
+/**
+ * Paint TVL/borrowed ASAP from session oracle cache or analytics API, then
+ * refine to Markets-accurate oracle totals without blocking first paint.
+ */
 export const useAnalyticsData = () => {
-  const [kpiData, setKpiData] = useState<KPIData | null>(null);
-  const [tvlData, setTvlData] = useState<TVLData[]>([]);
-  const [utilizationData, setUtilizationData] = useState<UtilizationData[]>([]);
-  const [revenueData, setRevenueData] = useState<RevenueData[]>([]);
-  const [treasuryData, setTreasuryData] = useState<TreasuryData | null>(null);
-  const [wadData, setWadData] = useState<WADData | null>(null);
-  const [mauData, setMauData] = useState<MAUData[]>([]);
-  const [loanData, setLoanData] = useState<LoanData | null>(null);
-  const [assetDistribution, setAssetDistribution] = useState<AssetDistribution | null>(null);
-  const [interestRateData, setInterestRateData] = useState<InterestRateData[]>([]);
-  const [healthFactorData, setHealthFactorData] = useState<HealthFactorData[]>([]);
-  const [liquidationData, setLiquidationData] = useState<LiquidationData | null>(null);
-  const [depositsData, setDepositsData] = useState<DepositsData[]>([]);
-  const [withdrawalsData, setWithdrawalsData] = useState<WithdrawalsData[]>([]);
-  const [kpiLoading, setKpiLoading] = useState(true);
+  const cachedOracle = peekCachedOracleProtocolTotals();
+  const cachedLive = peekLiveProtocolSnapshot();
+  const initial =
+    cachedOracle ??
+    (cachedLive
+      ? {
+          tvl: cachedLive.tvl,
+          borrowed: cachedLive.borrowed,
+          marketCount: 0,
+          fetchedAt: cachedLive.fetchedAt,
+        }
+      : null);
+
+  const [kpiData, setKpiData] = useState<KPIData | null>(() => {
+    if (!initial) return null;
+    return {
+      tvl: initial.tvl,
+      totalBorrowed: initial.borrowed,
+      wadCirculation: 0,
+      protocolRevenue: 0,
+      activeWallets: 0,
+    };
+  });
+  const [kpiLoading, setKpiLoading] = useState(() => !initial);
   const [oracleRefining, setOracleRefining] = useState(false);
-  const tvlSeriesRef = useRef<TVLData[]>([]);
+  const tvlSeriesRef = useRef<TvlSeriesPoint[]>([]);
 
   useEffect(() => {
     let cancelled = false;
 
+    const applyOracleTotals = (totals: {
+      tvl: number;
+      borrowed: number;
+    }) => {
+      const series = tvlSeriesRef.current;
+      const overlaid = overlayLiveTvlOnSeries(series, totals.tvl);
+      tvlSeriesRef.current = overlaid;
+
+      setKpiData((prev) => {
+        if (!prev) {
+          return {
+            tvl: totals.tvl,
+            totalBorrowed: totals.borrowed,
+            wadCirculation: 0,
+            protocolRevenue: 0,
+            activeWallets: 0,
+            tvlGrowth7d: growthPercentFromSeries(overlaid, totals.tvl, 7),
+          };
+        }
+        return {
+          ...prev,
+          tvl: totals.tvl,
+          totalBorrowed: totals.borrowed,
+          tvlGrowth7d: pickFirstFiniteNumber(
+            growthPercentFromSeries(overlaid, totals.tvl, 7),
+            prev.tvlGrowth7d
+          ),
+        };
+      });
+    };
+
     const loadFastKpis = async () => {
-      setKpiLoading(true);
-      
+      const hadCache = Boolean(peekCachedOracleProtocolTotals() || peekLiveProtocolSnapshot());
+      if (!hadCache) setKpiLoading(true);
+
       try {
+        // Prefer warm oracle session cache; otherwise paint analytics API quickly.
+        const warmOracle = peekCachedOracleProtocolTotals();
+        if (warmOracle) {
+          applyOracleTotals(warmOracle);
+          setKpiLoading(false);
+        } else {
+          const live = await fetchLiveProtocolSnapshot();
+          if (cancelled) return;
+          setKpiData((prev) => ({
+            tvl: live?.tvl ?? prev?.tvl ?? 0,
+            totalBorrowed: live?.borrowed ?? prev?.totalBorrowed ?? 0,
+            wadCirculation: prev?.wadCirculation ?? 0,
+            protocolRevenue: 0,
+            activeWallets: prev?.activeWallets ?? 0,
+            tvlGrowth7d: prev?.tvlGrowth7d,
+            borrowedGrowth7d: prev?.borrowedGrowth7d,
+            wadGrowth7d: prev?.wadGrowth7d,
+            walletsGrowth7d: prev?.walletsGrowth7d,
+          }));
+          setKpiLoading(false);
+        }
+
         const now = Date.now();
-        const days30 = 30 * 24 * 60 * 60 * 1000;
-        const startTime30d = now - days30;
-        const cachedOracle = peekCachedOracleProtocolTotals();
+        const startTime30d = now - 30 * 24 * 60 * 60 * 1000;
 
         const [
-          tvlResponse,
           tvlGrowthResponse,
-          borrowedResponse,
           borrowedGrowthResponse,
           wadResponse,
           wadGrowthResponse,
           walletsResponse,
           walletsGrowthResponse,
         ] = await Promise.allSettled([
-          dorkfiAPIService.getTVL(),
-          dorkfiAPIService.getTVLGrowth(startTime30d, now, 'day'),
-          dorkfiAPIService.getTotalBorrowed(),
+          dorkfiAPIService.getTVLGrowth(startTime30d, now, "day"),
           dorkfiAPIService.getBorrowedGrowth(),
           dorkfiAPIService.getWADCirculation(),
-          dorkfiAPIService.getWADSupplyGrowth(startTime30d, now, 'day'),
+          dorkfiAPIService.getWADSupplyGrowth(startTime30d, now, "day"),
           dorkfiAPIService.getActiveWallets(),
           dorkfiAPIService.getActiveWalletsGrowth(),
         ]);
-
         if (cancelled) return;
 
-        const apiTvl =
-          tvlResponse.status === 'fulfilled' && tvlResponse.value.success
-            ? tvlResponse.value.data?.totalTVL || 0
-            : 0;
-        const apiBorrowed =
-          borrowedResponse.status === 'fulfilled' && borrowedResponse.value.success
-            ? borrowedResponse.value.data?.totalBorrowed || 0
-            : 0;
-
-        const wadCirculation =
-          wadResponse.status === 'fulfilled' && wadResponse.value.success
-            ? parseFloat(wadResponse.value.data?.totalWadCirculation || '0') / 1e6
-            : 0;
-
-        const activeWallets =
-          walletsResponse.status === 'fulfilled' && walletsResponse.value.success
-            ? walletsResponse.value.data?.totalActiveWallets || 0
-            : 0;
-
-        const apiTvlGrowth7d =
-          tvlGrowthResponse.status === 'fulfilled' && tvlGrowthResponse.value.success
-            ? pickFirstFiniteNumber(
-                tvlGrowthResponse.value.data?.growth7d,
-                tvlGrowthResponse.value.data?.growth24h
-              )
-            : undefined;
-
-        const borrowedGrowth7d =
-          borrowedGrowthResponse.status === 'fulfilled' &&
-          borrowedGrowthResponse.value.success
-            ? pickFirstFiniteNumber(
-                borrowedGrowthResponse.value.data?.growth7d,
-                borrowedGrowthResponse.value.data?.growth24h
-              )
-            : undefined;
-
-        const wadGrowth7d =
-          wadGrowthResponse.status === 'fulfilled' && wadGrowthResponse.value.success
-            ? pickFirstFiniteNumber(
-                wadGrowthResponse.value.data?.growth7d,
-                wadGrowthResponse.value.data?.growth24h
-              )
-            : undefined;
-
-        const walletsGrowth7d =
-          walletsGrowthResponse.status === 'fulfilled' &&
-          walletsGrowthResponse.value.success
-            ? pickFirstFiniteNumber(
-                walletsGrowthResponse.value.data?.growth7d,
-                walletsGrowthResponse.value.data?.growth24h
-              )
-            : undefined;
-
-        let transformedTvlSeries: TVLData[] = [];
+        let transformedTvlSeries: TvlSeriesPoint[] = [];
         if (
-          tvlGrowthResponse.status === 'fulfilled' &&
+          tvlGrowthResponse.status === "fulfilled" &&
           tvlGrowthResponse.value.success
         ) {
           const dataPoints = tvlGrowthResponse.value.data?.dataPoints || [];
@@ -374,83 +156,110 @@ export const useAnalyticsData = () => {
               point as { tvl?: number; value?: number }
             );
             return {
-              date: new Date(point.timestamp).toISOString().split('T')[0],
+              date: new Date(point.timestamp).toISOString().split("T")[0],
               total: tvlValue,
-              weth: tvlValue * 0.35,
-              usdc: tvlValue * 0.28,
-              usdt: tvlValue * 0.22,
-              wbtc: tvlValue * 0.15,
             };
           });
         }
 
-        const initialTvl = cachedOracle?.tvl ?? apiTvl;
-        const initialBorrowed = cachedOracle?.borrowed ?? apiBorrowed;
-
-        if (cachedOracle?.tvl) {
+        const seedTvl =
+          peekCachedOracleProtocolTotals()?.tvl ??
+          peekLiveProtocolSnapshot()?.tvl;
+        if (seedTvl) {
           transformedTvlSeries = overlayLiveTvlOnSeries(
             transformedTvlSeries,
-            cachedOracle.tvl
+            seedTvl
           );
         }
-
         tvlSeriesRef.current = transformedTvlSeries;
-        setTvlData(transformedTvlSeries);
 
-        const tvlGrowth7d = cachedOracle?.tvl
+        const apiTvlGrowth7d =
+          tvlGrowthResponse.status === "fulfilled" &&
+          tvlGrowthResponse.value.success
+            ? pickFirstFiniteNumber(
+                tvlGrowthResponse.value.data?.growth7d,
+                tvlGrowthResponse.value.data?.growth24h
+              )
+            : undefined;
+
+        const tvlGrowth7d = seedTvl
           ? pickFirstFiniteNumber(
-              growthPercentFromSeries(transformedTvlSeries, cachedOracle.tvl, 7),
+              growthPercentFromSeries(transformedTvlSeries, seedTvl, 7),
               apiTvlGrowth7d
             )
           : apiTvlGrowth7d;
 
-        setKpiData({
-          tvl: initialTvl,
-          totalBorrowed: initialBorrowed,
-          wadCirculation,
-          protocolRevenue: 0,
-          activeWallets,
-          tvlGrowth7d,
-          borrowedGrowth7d,
-          wadGrowth7d,
-          walletsGrowth7d,
-        });
-        setKpiLoading(false);
+        const wadCirculation =
+          wadResponse.status === "fulfilled" && wadResponse.value.success
+            ? parseFloat(wadResponse.value.data?.totalWadCirculation || "0") /
+              1e6
+            : 0;
+        const activeWallets =
+          walletsResponse.status === "fulfilled" &&
+          walletsResponse.value.success
+            ? walletsResponse.value.data?.totalActiveWallets || 0
+            : 0;
 
-        if (cachedOracle) return;
+        const borrowedGrowth7d =
+          borrowedGrowthResponse.status === "fulfilled" &&
+          borrowedGrowthResponse.value.success
+            ? pickFirstFiniteNumber(
+                borrowedGrowthResponse.value.data?.growth7d,
+                borrowedGrowthResponse.value.data?.growth24h
+              )
+            : undefined;
+        const wadGrowth7d =
+          wadGrowthResponse.status === "fulfilled" &&
+          wadGrowthResponse.value.success
+            ? pickFirstFiniteNumber(
+                wadGrowthResponse.value.data?.growth7d,
+                wadGrowthResponse.value.data?.growth24h
+              )
+            : undefined;
+        const walletsGrowth7d =
+          walletsGrowthResponse.status === "fulfilled" &&
+          walletsGrowthResponse.value.success
+            ? pickFirstFiniteNumber(
+                walletsGrowthResponse.value.data?.growth7d,
+                walletsGrowthResponse.value.data?.growth24h
+              )
+            : undefined;
+
+        setKpiData((prev) =>
+          prev
+            ? {
+                ...prev,
+                wadCirculation,
+                activeWallets,
+                tvlGrowth7d,
+                borrowedGrowth7d,
+                wadGrowth7d,
+                walletsGrowth7d,
+              }
+            : prev
+        );
+
+        // Markets-accurate oracle refine (amounts × live oracle USD).
+        const freshOracle = peekCachedOracleProtocolTotals();
+        if (freshOracle && Date.now() - freshOracle.fetchedAt < 5_000) {
+          applyOracleTotals(freshOracle);
+          return;
+        }
 
         setOracleRefining(true);
         fetchOracleBasedProtocolTotals()
           .then((oracleTotals) => {
             if (cancelled || !oracleTotals) return;
-
-            const series = tvlSeriesRef.current;
-            const overlaid = overlayLiveTvlOnSeries(series, oracleTotals.tvl);
-            tvlSeriesRef.current = overlaid;
-            setTvlData(overlaid);
-
-            setKpiData((prev) =>
-              prev
-                ? {
-                    ...prev,
-                    tvl: oracleTotals.tvl,
-                    totalBorrowed: oracleTotals.borrowed,
-                    tvlGrowth7d: pickFirstFiniteNumber(
-                      growthPercentFromSeries(overlaid, oracleTotals.tvl, 7),
-                      prev.tvlGrowth7d
-                    ),
-                  }
-                : prev
-            );
+            applyOracleTotals(oracleTotals);
           })
           .catch((error) => {
-            console.warn('[useAnalyticsData] oracle TVL refine failed', error);
+            console.warn("[useAnalyticsData] oracle TVL refine failed", error);
           })
           .finally(() => {
             if (!cancelled) setOracleRefining(false);
           });
       } catch (error) {
-        console.error('Error loading analytics KPIs:', error);
+        console.error("Error loading analytics KPIs:", error);
         if (!cancelled) {
           setKpiData({
             tvl: 0,
@@ -465,157 +274,7 @@ export const useAnalyticsData = () => {
       }
     };
 
-    const loadSecondaryData = async () => {
-      try {
-        const now = Date.now();
-        const days30 = 30 * 24 * 60 * 60 * 1000;
-        const startTime30d = now - days30;
-
-        const [
-          wadGrowthResponse,
-          depositsResponse,
-          withdrawalsResponse,
-          healthFactorResponse,
-          marketUsdLookupResult,
-        ] = await Promise.allSettled([
-          dorkfiAPIService.getWADSupplyGrowth(startTime30d, now, 'day'),
-          dorkfiAPIService.getDeposits(startTime30d, now, 10000),
-          dorkfiAPIService.getWithdrawals(startTime30d, now, 10000),
-          dorkfiAPIService.getAllUserHealth(),
-          fetchAnalyticsMarketUsdLookup(),
-        ]);
-
-        if (cancelled) return;
-
-        if (
-          wadGrowthResponse.status === 'fulfilled' &&
-          wadGrowthResponse.value.success
-        ) {
-          const dataPoints = wadGrowthResponse.value.data?.dataPoints || [];
-          if (dataPoints.length > 0) {
-            const supplyData = dataPoints.map((point) => ({
-              date: new Date(point.timestamp).toISOString().split('T')[0],
-              supply: point.value / 1e6,
-            }));
-
-            setWadData({
-              supplyData,
-              collateralizationRatio: 135.4,
-              pegStability: supplyData.map((d) => ({
-                date: d.date,
-                price: 1.0,
-              })),
-            });
-          } else {
-            setWadData(generateMockWADData());
-          }
-        } else {
-          setWadData(generateMockWADData());
-        }
-
-        if (
-          depositsResponse.status === 'fulfilled' &&
-          depositsResponse.value.success
-        ) {
-          const deposits = depositsResponse.value.data?.deposits || [];
-          if (deposits.length > 0) {
-            const dailyDeposits: { [key: string]: number } = {};
-            deposits.forEach((deposit) => {
-              const date = new Date(deposit.timestamp).toISOString().split('T')[0];
-              const value = analyticsValueToUsd(
-                deposit.depositValueUSD,
-                deposit.amount
-              );
-              dailyDeposits[date] = (dailyDeposits[date] || 0) + value;
-            });
-            setDepositsData(
-              Object.entries(dailyDeposits)
-                .map(([date, amount]) => ({ date, amount }))
-                .sort((a, b) => a.date.localeCompare(b.date))
-            );
-          } else {
-            setDepositsData(generateMockDepositsData());
-          }
-        } else {
-          setDepositsData(generateMockDepositsData());
-        }
-
-        if (
-          withdrawalsResponse.status === 'fulfilled' &&
-          withdrawalsResponse.value.success
-        ) {
-          const withdrawals = withdrawalsResponse.value.data?.withdrawals || [];
-          if (withdrawals.length > 0) {
-            const marketUsdLookup =
-              marketUsdLookupResult.status === 'fulfilled'
-                ? marketUsdLookupResult.value
-                : new Map();
-            const dailyWithdrawals: { [key: string]: number } = {};
-            withdrawals.forEach((withdrawal) => {
-              const date = new Date(withdrawal.timestamp).toISOString().split('T')[0];
-              const value = activityRowToUsd(
-                {
-                  amount: withdrawal.amount,
-                  valueUsd: pickWithdrawValueUsd(withdrawal),
-                  network: withdrawal.network,
-                  marketId: withdrawal.marketId,
-                },
-                marketUsdLookup
-              );
-              dailyWithdrawals[date] = (dailyWithdrawals[date] || 0) + value;
-            });
-            setWithdrawalsData(
-              Object.entries(dailyWithdrawals)
-                .map(([date, amount]) => ({ date, amount }))
-                .sort((a, b) => a.date.localeCompare(b.date))
-            );
-          } else {
-            setWithdrawalsData(generateMockWithdrawalsData());
-          }
-        } else {
-          setWithdrawalsData(generateMockWithdrawalsData());
-        }
-
-        if (
-          healthFactorResponse.status === 'fulfilled' &&
-          healthFactorResponse.value.success
-        ) {
-          const colors = [
-            'hsl(var(--destructive))',
-            'hsl(var(--warning-orange))',
-            'hsl(var(--whale-gold))',
-            'hsl(var(--highlight-aqua))',
-            'hsl(var(--ocean-teal))',
-          ];
-          const distribution = buildHealthFactorDistribution(
-            healthFactorResponse.value.data || []
-          );
-          setHealthFactorData(
-            distribution.map((item, index) => ({
-              range: item.range,
-              count: item.count,
-              color: colors[index % colors.length],
-            }))
-          );
-        } else {
-          setHealthFactorData([]);
-        }
-
-        setUtilizationData(generateMockUtilizationData());
-        setRevenueData(generateMockRevenueData());
-        setTreasuryData(generateMockTreasuryData());
-        setMauData(generateMockMAUData());
-        setLoanData(generateMockLoanData());
-        setAssetDistribution(generateMockAssetDistribution());
-        setInterestRateData(generateMockInterestRateData());
-        setLiquidationData(generateMockLiquidationData());
-      } catch (error) {
-        console.error('Error loading secondary analytics data:', error);
-      }
-    };
-
     loadFastKpis();
-    loadSecondaryData();
 
     return () => {
       cancelled = true;
@@ -624,22 +283,8 @@ export const useAnalyticsData = () => {
 
   return {
     kpiData,
-    tvlData,
-    utilizationData,
-    revenueData,
-    treasuryData,
-    wadData,
-    mauData,
-    loanData,
-    assetDistribution,
-    interestRateData,
-    healthFactorData,
-    liquidationData,
-    depositsData,
-    withdrawalsData,
     loading: kpiLoading,
     kpiLoading,
     oracleRefining,
   };
 };
-

--- a/src/hooks/useCachedAnalyticsSeries.ts
+++ b/src/hooks/useCachedAnalyticsSeries.ts
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  fetchActivitySeriesForPeriod,
+  fetchLiquidityFlowSeries,
+  fetchLoansFlowSeries,
+  type AnalyticsActivityKind,
+  type DailyUsdPoint,
+} from "@/services/analyticsActivityCache";
+import {
+  fetchTvlGrowthForPeriod,
+  fetchWadGrowthForPeriod,
+  overlayCachedTvlGrowth,
+  type TvlGrowthPoint,
+  type WadGrowthPoint,
+} from "@/services/analyticsGrowthCache";
+import {
+  fetchOracleBasedProtocolTotals,
+  peekCachedOracleProtocolTotals,
+} from "@/services/analyticsProtocolTvl";
+import {
+  sliceDailySeriesByPeriod,
+  sumDailyAmounts,
+  type AnalyticsTimePeriod,
+} from "@/utils/analyticsTimePeriod";
+import type { FlowDataPoint } from "@/utils/analyticsActivityFlows";
+
+/**
+ * Shared activity daily series. Shows loading only on the first unresolved fetch;
+ * period switches reuse the cached 90d window without blanking the chart.
+ */
+export function useActivityDailySeries(
+  kind: AnalyticsActivityKind,
+  period: AnalyticsTimePeriod
+) {
+  const [series, setSeries] = useState<DailyUsdPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const hasDataRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!hasDataRef.current) setLoading(true);
+
+    fetchActivitySeriesForPeriod(kind, period)
+      .then((points) => {
+        if (cancelled) return;
+        hasDataRef.current = true;
+        setSeries(points);
+      })
+      .catch((error) => {
+        console.error(`[useActivityDailySeries] ${kind} failed`, error);
+        if (!cancelled) setSeries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, period]);
+
+  return {
+    series,
+    loading,
+    total: sumDailyAmounts(series),
+  };
+}
+
+export function useFlowSeries(
+  mode: "liquidity" | "loans",
+  period: AnalyticsTimePeriod
+) {
+  const [series, setSeries] = useState<FlowDataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const hasDataRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasDataRef.current) setLoading(true);
+
+    const fetchSeries =
+      mode === "liquidity" ? fetchLiquidityFlowSeries : fetchLoansFlowSeries;
+
+    fetchSeries(period)
+      .then((points) => {
+        if (cancelled) return;
+        hasDataRef.current = true;
+        setSeries(points);
+      })
+      .catch((error) => {
+        console.error(`[useFlowSeries] ${mode} failed`, error);
+        if (!cancelled) setSeries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, period]);
+
+  return { series, loading };
+}
+
+export function useLiquidityFlowSeries(period: AnalyticsTimePeriod) {
+  return useFlowSeries("liquidity", period);
+}
+
+export function useLoansFlowSeries(period: AnalyticsTimePeriod) {
+  return useFlowSeries("loans", period);
+}
+
+export function useTvlGrowthSeries(period: AnalyticsTimePeriod) {
+  const [series, setSeries] = useState<TvlGrowthPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const hasDataRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasDataRef.current) setLoading(true);
+
+    fetchTvlGrowthForPeriod(period)
+      .then(async (points) => {
+        if (cancelled) return;
+        hasDataRef.current = true;
+        setSeries(points);
+
+        try {
+          const cached = peekCachedOracleProtocolTotals();
+          if (cached?.tvl) {
+            const overlaid = overlayCachedTvlGrowth(cached.tvl);
+            if (overlaid && !cancelled) {
+              setSeries(sliceDailySeriesByPeriod(overlaid, period));
+            }
+            return;
+          }
+
+          const oracleTotals = await fetchOracleBasedProtocolTotals();
+          if (cancelled || !oracleTotals?.tvl) return;
+          const overlaid = overlayCachedTvlGrowth(oracleTotals.tvl);
+          if (overlaid) {
+            setSeries(sliceDailySeriesByPeriod(overlaid, period));
+          }
+        } catch (error) {
+          console.warn("[useTvlGrowthSeries] oracle overlay failed", error);
+        }
+      })
+      .catch((error) => {
+        console.error("[useTvlGrowthSeries] failed", error);
+        if (!cancelled) setSeries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [period]);
+
+  return { series, loading };
+}
+
+export function useWadGrowthSeries(period: AnalyticsTimePeriod) {
+  const [series, setSeries] = useState<WadGrowthPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const hasDataRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasDataRef.current) setLoading(true);
+
+    fetchWadGrowthForPeriod(period)
+      .then((points) => {
+        if (cancelled) return;
+        hasDataRef.current = true;
+        setSeries(points);
+      })
+      .catch((error) => {
+        console.error("[useWadGrowthSeries] failed", error);
+        if (!cancelled) setSeries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [period]);
+
+  return { series, loading };
+}

--- a/src/services/__tests__/analyticsActivityCache.test.ts
+++ b/src/services/__tests__/analyticsActivityCache.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDeposits = vi.fn();
+const getWithdrawals = vi.fn();
+const getBorrows = vi.fn();
+const getRepays = vi.fn();
+const fetchOracleMarketUsdLookupForRefs = vi.fn();
+
+vi.mock("@/services/dorkfiAPIService", () => ({
+  dorkfiAPIService: {
+    getDeposits: (...args: unknown[]) => getDeposits(...args),
+    getWithdrawals: (...args: unknown[]) => getWithdrawals(...args),
+    getBorrows: (...args: unknown[]) => getBorrows(...args),
+    getRepays: (...args: unknown[]) => getRepays(...args),
+  },
+}));
+
+vi.mock("@/services/analyticsProtocolTvl", () => ({
+  fetchOracleMarketUsdLookupForRefs: (...args: unknown[]) =>
+    fetchOracleMarketUsdLookupForRefs(...args),
+}));
+
+describe("analyticsActivityCache", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    getDeposits.mockReset();
+    getWithdrawals.mockReset();
+    getBorrows.mockReset();
+    getRepays.mockReset();
+    fetchOracleMarketUsdLookupForRefs.mockReset();
+    fetchOracleMarketUsdLookupForRefs.mockResolvedValue(new Map());
+
+    const { __resetAnalyticsActivityCacheForTests } = await import(
+      "@/services/analyticsActivityCache"
+    );
+    __resetAnalyticsActivityCacheForTests();
+  });
+
+  it("dedupes concurrent deposit fetches and reuses cache", async () => {
+    getDeposits.mockResolvedValue({
+      success: true,
+      data: {
+        deposits: [
+          {
+            timestamp: Date.parse("2024-04-01T12:00:00Z"),
+            round: 1,
+            amount: "1000000",
+            depositValueUSD: "1000000000000",
+          },
+          {
+            timestamp: Date.parse("2024-04-01T18:00:00Z"),
+            round: 2,
+            amount: "1000000",
+            depositValueUSD: "2000000000000",
+          },
+        ],
+      },
+    });
+
+    const {
+      fetchActivityDailySeries,
+      fetchActivitySeriesForPeriod,
+    } = await import("@/services/analyticsActivityCache");
+
+    const [a, b] = await Promise.all([
+      fetchActivityDailySeries("deposits"),
+      fetchActivityDailySeries("deposits"),
+    ]);
+
+    expect(getDeposits).toHaveBeenCalledTimes(1);
+    expect(a).toEqual([{ date: "2024-04-01", amount: 3 }]);
+    expect(b).toEqual(a);
+
+    const now = Date.parse("2024-04-05T12:00:00Z");
+    const sliced = await fetchActivitySeriesForPeriod("deposits", "7d", now);
+    expect(getDeposits).toHaveBeenCalledTimes(1);
+    expect(sliced).toEqual(a);
+  });
+
+  it("builds liquidity flows from shared deposit/withdrawal caches", async () => {
+    getDeposits.mockResolvedValue({
+      success: true,
+      data: {
+        deposits: [
+          {
+            timestamp: Date.parse("2024-04-01T12:00:00Z"),
+            round: 1,
+            amount: "1000000",
+            depositValueUSD: "5000000000000",
+          },
+        ],
+      },
+    });
+    getWithdrawals.mockResolvedValue({
+      success: true,
+      data: {
+        withdrawals: [
+          {
+            timestamp: Date.parse("2024-04-01T15:00:00Z"),
+            round: 2,
+            amount: "1000000",
+            withdrawValueUSD: "2000000000000",
+          },
+        ],
+      },
+    });
+
+    const {
+      fetchLiquidityFlowSeries,
+      fetchActivityDailySeries,
+    } = await import("@/services/analyticsActivityCache");
+
+    const flows = await fetchLiquidityFlowSeries("90d");
+    expect(flows).toEqual([
+      {
+        date: "2024-04-01",
+        inflow: 5,
+        outflow: -2,
+        netflow: 3,
+      },
+    ]);
+
+    await fetchActivityDailySeries("deposits");
+    await fetchActivityDailySeries("withdrawals");
+    expect(getDeposits).toHaveBeenCalledTimes(1);
+    expect(getWithdrawals).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/analyticsActivityCache.ts
+++ b/src/services/analyticsActivityCache.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared 90d activity series cache for Analytics charts.
+ * Deposits / withdrawals / borrows / repays each fetch once; charts slice by period.
+ */
+
+import { dorkfiAPIService } from "@/services/dorkfiAPIService";
+import {
+  fetchOracleMarketUsdLookupForRefs,
+} from "@/services/analyticsProtocolTvl";
+import {
+  activityRowToUsd,
+  analyticsValueToUsd,
+  pickWithdrawValueUsd,
+} from "@/utils/analyticsActivityUsd";
+import {
+  aggregateEventsByDay,
+  mergeDailyFlows,
+  type FlowDataPoint,
+} from "@/utils/analyticsActivityFlows";
+import {
+  ANALYTICS_DAY_MS,
+  ANALYTICS_MAX_LOOKBACK_DAYS,
+  sliceDailySeriesByPeriod,
+  type AnalyticsTimePeriod,
+} from "@/utils/analyticsTimePeriod";
+
+export type AnalyticsActivityKind =
+  | "deposits"
+  | "withdrawals"
+  | "borrows"
+  | "repays";
+
+export interface DailyUsdPoint {
+  date: string;
+  amount: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+
+type CacheEntry = {
+  points: DailyUsdPoint[];
+  fetchedAt: number;
+};
+
+const cache = new Map<AnalyticsActivityKind, CacheEntry>();
+const inFlight = new Map<AnalyticsActivityKind, Promise<DailyUsdPoint[]>>();
+
+function isFresh(entry: CacheEntry): boolean {
+  return Date.now() - entry.fetchedAt < CACHE_TTL_MS;
+}
+
+function lookbackWindow(now = Date.now()): { startTime: number; endTime: number } {
+  return {
+    startTime: now - ANALYTICS_MAX_LOOKBACK_DAYS * ANALYTICS_DAY_MS,
+    endTime: now,
+  };
+}
+
+function dailyRecordToPoints(daily: Record<string, number>): DailyUsdPoint[] {
+  return Object.entries(daily)
+    .map(([date, amount]) => ({ date, amount }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+async function loadDeposits(): Promise<DailyUsdPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const response = await dorkfiAPIService.getDeposits(
+    startTime,
+    endTime,
+    10000
+  );
+  if (!response.success || !response.data?.deposits?.length) return [];
+  const daily = aggregateEventsByDay(response.data.deposits, (deposit) =>
+    analyticsValueToUsd(deposit.depositValueUSD, deposit.amount)
+  );
+  return dailyRecordToPoints(daily);
+}
+
+async function loadWithdrawals(): Promise<DailyUsdPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const response = await dorkfiAPIService.getWithdrawals(
+    startTime,
+    endTime,
+    10000
+  );
+  if (!response.success || !response.data?.withdrawals?.length) return [];
+
+  const withdrawals = response.data.withdrawals;
+  const marketUsdLookup = await fetchOracleMarketUsdLookupForRefs(
+    withdrawals.map((withdrawal) => ({
+      network: withdrawal.network,
+      marketId: withdrawal.marketId,
+      appId: withdrawal.appId,
+    }))
+  ).catch((error) => {
+    console.warn(
+      "[analyticsActivityCache] oracle market USD lookup failed",
+      error
+    );
+    return new Map();
+  });
+
+  const daily = aggregateEventsByDay(withdrawals, (withdrawal) =>
+    activityRowToUsd(
+      {
+        amount: withdrawal.amount,
+        valueUsd: pickWithdrawValueUsd(withdrawal),
+        network: withdrawal.network,
+        marketId: withdrawal.marketId,
+      },
+      marketUsdLookup
+    )
+  );
+  return dailyRecordToPoints(daily);
+}
+
+async function loadBorrows(): Promise<DailyUsdPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const response = await dorkfiAPIService.getBorrows(
+    startTime,
+    endTime,
+    10000
+  );
+  if (!response.success || !response.data?.borrows?.length) return [];
+  const daily = aggregateEventsByDay(response.data.borrows, (borrow) =>
+    analyticsValueToUsd(borrow.borrowValueUSD, borrow.amount)
+  );
+  return dailyRecordToPoints(daily);
+}
+
+async function loadRepays(): Promise<DailyUsdPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const response = await dorkfiAPIService.getRepays(
+    startTime,
+    endTime,
+    10000
+  );
+  if (!response.success || !response.data?.repays?.length) return [];
+  const daily = aggregateEventsByDay(response.data.repays, (repay) =>
+    analyticsValueToUsd(repay.repayValueUSD, repay.amount)
+  );
+  return dailyRecordToPoints(daily);
+}
+
+const LOADERS: Record<
+  AnalyticsActivityKind,
+  () => Promise<DailyUsdPoint[]>
+> = {
+  deposits: loadDeposits,
+  withdrawals: loadWithdrawals,
+  borrows: loadBorrows,
+  repays: loadRepays,
+};
+
+/** Fetch (or reuse) the full 90d daily USD series for an activity kind. */
+export async function fetchActivityDailySeries(
+  kind: AnalyticsActivityKind
+): Promise<DailyUsdPoint[]> {
+  const existing = cache.get(kind);
+  if (existing && isFresh(existing)) return existing.points;
+
+  const pending = inFlight.get(kind);
+  if (pending) return pending;
+
+  const promise = LOADERS[kind]()
+    .then((points) => {
+      cache.set(kind, { points, fetchedAt: Date.now() });
+      return points;
+    })
+    .finally(() => {
+      inFlight.delete(kind);
+    });
+
+  inFlight.set(kind, promise);
+  return promise;
+}
+
+export async function fetchActivitySeriesForPeriod(
+  kind: AnalyticsActivityKind,
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): Promise<DailyUsdPoint[]> {
+  const series = await fetchActivityDailySeries(kind);
+  return sliceDailySeriesByPeriod(series, period, now);
+}
+
+export async function fetchLiquidityFlowSeries(
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): Promise<FlowDataPoint[]> {
+  const [deposits, withdrawals] = await Promise.all([
+    fetchActivityDailySeries("deposits"),
+    fetchActivityDailySeries("withdrawals"),
+  ]);
+  const inflowByDay: Record<string, number> = {};
+  const outflowByDay: Record<string, number> = {};
+  for (const point of deposits) inflowByDay[point.date] = point.amount;
+  for (const point of withdrawals) outflowByDay[point.date] = point.amount;
+  return sliceDailySeriesByPeriod(
+    mergeDailyFlows(inflowByDay, outflowByDay),
+    period,
+    now
+  );
+}
+
+export async function fetchLoansFlowSeries(
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): Promise<FlowDataPoint[]> {
+  const [borrows, repays] = await Promise.all([
+    fetchActivityDailySeries("borrows"),
+    fetchActivityDailySeries("repays"),
+  ]);
+  const inflowByDay: Record<string, number> = {};
+  const outflowByDay: Record<string, number> = {};
+  for (const point of borrows) inflowByDay[point.date] = point.amount;
+  for (const point of repays) outflowByDay[point.date] = point.amount;
+  return sliceDailySeriesByPeriod(
+    mergeDailyFlows(inflowByDay, outflowByDay),
+    period,
+    now
+  );
+}
+
+/** Test helper — clears memory cache / in-flight map. */
+export function __resetAnalyticsActivityCacheForTests(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/src/services/analyticsGrowthCache.ts
+++ b/src/services/analyticsGrowthCache.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared 90d growth series cache for TVL / WAD Analytics charts.
+ */
+
+import { dorkfiAPIService } from "@/services/dorkfiAPIService";
+import {
+  fetchLiveProtocolSnapshot,
+  peekLiveProtocolSnapshot,
+} from "@/services/analyticsLiveSnapshot";
+import {
+  fetchOracleBasedProtocolTotals,
+  peekCachedOracleProtocolTotals,
+} from "@/services/analyticsProtocolTvl";
+import {
+  overlayLiveTvlOnSeries,
+  tvlFromGrowthDataPoint,
+} from "@/utils/analyticsProtocolTvl";
+import {
+  ANALYTICS_DAY_MS,
+  ANALYTICS_MAX_LOOKBACK_DAYS,
+  sliceDailySeriesByPeriod,
+  type AnalyticsTimePeriod,
+} from "@/utils/analyticsTimePeriod";
+
+export interface TvlGrowthPoint {
+  date: string;
+  total: number;
+  weth: number;
+  usdc: number;
+  usdt: number;
+  wbtc: number;
+}
+
+export interface WadGrowthPoint {
+  date: string;
+  supply: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+
+type CacheEntry<T> = {
+  points: T[];
+  fetchedAt: number;
+};
+
+let tvlCache: CacheEntry<TvlGrowthPoint> | null = null;
+let wadCache: CacheEntry<WadGrowthPoint> | null = null;
+let tvlInFlight: Promise<TvlGrowthPoint[]> | null = null;
+let wadInFlight: Promise<WadGrowthPoint[]> | null = null;
+
+function isFresh(fetchedAt: number): boolean {
+  return Date.now() - fetchedAt < CACHE_TTL_MS;
+}
+
+function lookbackWindow(now = Date.now()): { startTime: number; endTime: number } {
+  return {
+    startTime: now - ANALYTICS_MAX_LOOKBACK_DAYS * ANALYTICS_DAY_MS,
+    endTime: now,
+  };
+}
+
+async function loadTvlGrowth(): Promise<TvlGrowthPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const livePeek = peekLiveProtocolSnapshot();
+  const oraclePeek = peekCachedOracleProtocolTotals();
+  const [response, live] = await Promise.all([
+    dorkfiAPIService.getTVLGrowth(startTime, endTime, "day"),
+    livePeek
+      ? Promise.resolve(livePeek)
+      : fetchLiveProtocolSnapshot().catch(() => null),
+  ]);
+
+  if (!response.success || !response.data?.dataPoints?.length) {
+    return [];
+  }
+
+  let transformed: TvlGrowthPoint[] = response.data.dataPoints
+    .map((point: { tvl?: number; value?: number; timestamp: number }) => {
+      const tvlValue = tvlFromGrowthDataPoint(point);
+      return {
+        date: new Date(point.timestamp).toISOString().split("T")[0],
+        total: tvlValue,
+        weth: tvlValue * 0.35,
+        usdc: tvlValue * 0.28,
+        usdt: tvlValue * 0.22,
+        wbtc: tvlValue * 0.15,
+      };
+    })
+    .filter((point) => point.total >= 0);
+
+  const overlayTvl = oraclePeek?.tvl ?? live?.tvl;
+  if (overlayTvl) {
+    transformed = overlayLiveTvlOnSeries(transformed, overlayTvl);
+  }
+
+  if (!oraclePeek?.tvl) {
+    void fetchOracleBasedProtocolTotals()
+      .then((oracleTotals) => {
+        if (!oracleTotals?.tvl || !tvlCache) return;
+        tvlCache = {
+          points: overlayLiveTvlOnSeries(tvlCache.points, oracleTotals.tvl),
+          fetchedAt: tvlCache.fetchedAt,
+        };
+      })
+      .catch((error) => {
+        console.warn("[analyticsGrowthCache] oracle overlay failed", error);
+      });
+  }
+
+  return transformed;
+}
+
+async function loadWadGrowth(): Promise<WadGrowthPoint[]> {
+  const { startTime, endTime } = lookbackWindow();
+  const response = await dorkfiAPIService.getWADSupplyGrowth(
+    startTime,
+    endTime,
+    "day"
+  );
+
+  if (!response.success || !response.data?.dataPoints?.length) {
+    return [];
+  }
+
+  return response.data.dataPoints
+    .map((point: { supply?: string | number; value?: string | number; timestamp: number }) => {
+      const rawValue = parseFloat(String(point.supply ?? point.value ?? "0"));
+      return {
+        date: new Date(point.timestamp).toISOString().split("T")[0],
+        supply: rawValue / 1e6,
+      };
+    })
+    .filter((point) => point.supply >= 0);
+}
+
+export async function fetchTvlGrowthDailySeries(): Promise<TvlGrowthPoint[]> {
+  if (tvlCache && isFresh(tvlCache.fetchedAt)) return tvlCache.points;
+  if (tvlInFlight) return tvlInFlight;
+
+  tvlInFlight = loadTvlGrowth()
+    .then((points) => {
+      tvlCache = { points, fetchedAt: Date.now() };
+      return points;
+    })
+    .finally(() => {
+      tvlInFlight = null;
+    });
+
+  return tvlInFlight;
+}
+
+export async function fetchTvlGrowthForPeriod(
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): Promise<TvlGrowthPoint[]> {
+  const series = await fetchTvlGrowthDailySeries();
+  return sliceDailySeriesByPeriod(series, period, now);
+}
+
+export async function fetchWadGrowthDailySeries(): Promise<WadGrowthPoint[]> {
+  if (wadCache && isFresh(wadCache.fetchedAt)) return wadCache.points;
+  if (wadInFlight) return wadInFlight;
+
+  wadInFlight = loadWadGrowth()
+    .then((points) => {
+      wadCache = { points, fetchedAt: Date.now() };
+      return points;
+    })
+    .finally(() => {
+      wadInFlight = null;
+    });
+
+  return wadInFlight;
+}
+
+export async function fetchWadGrowthForPeriod(
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): Promise<WadGrowthPoint[]> {
+  const series = await fetchWadGrowthDailySeries();
+  return sliceDailySeriesByPeriod(series, period, now);
+}
+
+/** Apply oracle TVL overlay to the cached series (if present). */
+export function overlayCachedTvlGrowth(liveTvl: number): TvlGrowthPoint[] | null {
+  if (!tvlCache || !(liveTvl > 0)) return null;
+  const points = overlayLiveTvlOnSeries(tvlCache.points, liveTvl);
+  tvlCache = { points, fetchedAt: tvlCache.fetchedAt };
+  return points;
+}
+
+export function __resetAnalyticsGrowthCacheForTests(): void {
+  tvlCache = null;
+  wadCache = null;
+  tvlInFlight = null;
+  wadInFlight = null;
+}

--- a/src/services/analyticsLiveSnapshot.ts
+++ b/src/services/analyticsLiveSnapshot.ts
@@ -1,0 +1,71 @@
+/**
+ * Fast live TVL / borrowed snapshot from analytics API endpoints.
+ * Shared by KPI cards and TVL chart last-point overlay — no market hydrate.
+ */
+
+import { dorkfiAPIService } from "@/services/dorkfiAPIService";
+
+const CACHE_TTL_MS = 60_000;
+
+export interface LiveProtocolSnapshot {
+  tvl: number;
+  borrowed: number;
+  fetchedAt: number;
+}
+
+let cached: LiveProtocolSnapshot | null = null;
+let inFlight: Promise<LiveProtocolSnapshot | null> | null = null;
+
+function isFresh(snapshot: LiveProtocolSnapshot): boolean {
+  return (
+    Date.now() - snapshot.fetchedAt < CACHE_TTL_MS &&
+    Number.isFinite(snapshot.tvl) &&
+    snapshot.tvl > 0
+  );
+}
+
+export function peekLiveProtocolSnapshot(): LiveProtocolSnapshot | null {
+  if (cached && isFresh(cached)) return cached;
+  return null;
+}
+
+export async function fetchLiveProtocolSnapshot(): Promise<LiveProtocolSnapshot | null> {
+  const peek = peekLiveProtocolSnapshot();
+  if (peek) return peek;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    const [tvlResponse, borrowedResponse] = await Promise.allSettled([
+      dorkfiAPIService.getTVL(),
+      dorkfiAPIService.getTotalBorrowed(),
+    ]);
+
+    const tvl =
+      tvlResponse.status === "fulfilled" && tvlResponse.value.success
+        ? tvlResponse.value.data?.totalTVL || 0
+        : 0;
+    const borrowed =
+      borrowedResponse.status === "fulfilled" && borrowedResponse.value.success
+        ? borrowedResponse.value.data?.totalBorrowed || 0
+        : 0;
+
+    if (!(tvl > 0) && !(borrowed > 0)) return null;
+
+    const snapshot: LiveProtocolSnapshot = {
+      tvl,
+      borrowed,
+      fetchedAt: Date.now(),
+    };
+    cached = snapshot;
+    return snapshot;
+  })().finally(() => {
+    inFlight = null;
+  });
+
+  return inFlight;
+}
+
+export function __resetLiveProtocolSnapshotForTests(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/src/services/analyticsProtocolTvl.ts
+++ b/src/services/analyticsProtocolTvl.ts
@@ -1,8 +1,10 @@
 /**
- * Protocol TVL / borrowed using the same oracle overlay as Markets
- * (`buildMarketInfoFromRawMarketData` + `usdPerTokenFromPortfolioMarketRow`).
- * Amounts come from the bulk market-data API; USD prices come from the oracle
- * contract instead of stale `get_market.price`.
+ * Protocol TVL / borrowed for Analytics.
+ *
+ * Two price paths:
+ * - Fast: bulk `/market-data` prices only (no per-market oracle RPC) — used by
+ *   activity charts (withdrawals need USD conversion).
+ * - Oracle: Markets-accurate overlay for KPI refine after first paint.
  */
 
 import {
@@ -30,24 +32,42 @@ import {
 import { runWithConcurrency } from "@/utils/runWithConcurrency";
 
 const ORACLE_TVL_CACHE_TTL_MS = 60_000;
-const ORACLE_REFINE_CONCURRENCY = 6;
+const HYDRATE_CONCURRENCY = 8;
 const SESSION_CACHE_KEY = "dorkfi:analytics:oracle-protocol-totals";
 
 export interface OracleBasedProtocolTotals extends ProtocolUsdTotals {
   fetchedAt: number;
 }
 
+type HydrateMode = "fast" | "oracle";
+
 let cachedTotals: OracleBasedProtocolTotals | null = null;
-let inFlight: Promise<OracleBasedProtocolTotals | null> | null = null;
-let cachedHydratedMarkets: { markets: MarketInfo[]; fetchedAt: number } | null =
+let oracleTotalsInFlight: Promise<OracleBasedProtocolTotals | null> | null =
   null;
-let hydrateInFlight: Promise<MarketInfo[] | null> | null = null;
+let bulkTotalsInFlight: Promise<OracleBasedProtocolTotals | null> | null = null;
+
+let cachedFastMarkets: { markets: MarketInfo[]; fetchedAt: number } | null =
+  null;
+let cachedOracleMarkets: { markets: MarketInfo[]; fetchedAt: number } | null =
+  null;
+let fastHydrateInFlight: Promise<MarketInfo[] | null> | null = null;
+let oracleHydrateInFlight: Promise<MarketInfo[] | null> | null = null;
 
 function isFreshTotals(totals: OracleBasedProtocolTotals): boolean {
   return (
     Number.isFinite(totals.fetchedAt) &&
     Date.now() - totals.fetchedAt < ORACLE_TVL_CACHE_TTL_MS &&
     totals.tvl > 0
+  );
+}
+
+function isFreshMarkets(entry: {
+  markets: MarketInfo[];
+  fetchedAt: number;
+}): boolean {
+  return (
+    Date.now() - entry.fetchedAt < ORACLE_TVL_CACHE_TTL_MS &&
+    entry.markets.length > 0
   );
 }
 
@@ -96,8 +116,10 @@ function marketUsdPerToken(market: MarketInfo): number {
 }
 
 async function hydrateNetworkMarkets(
-  networkId: NetworkId
+  networkId: NetworkId,
+  mode: HydrateMode
 ): Promise<MarketInfo[]> {
+  const applyOracle = mode === "oracle";
   const tokens = getAllTokensWithDisplayInfo(networkId);
   let bulkMap: Map<string, MarketData> | null = null;
   try {
@@ -135,27 +157,28 @@ async function hydrateNetworkMarkets(
   }
 
   const markets: MarketInfo[] = [];
-  await runWithConcurrency(jobs, ORACLE_REFINE_CONCURRENCY, async (job) => {
+  await runWithConcurrency(jobs, HYDRATE_CONCURRENCY, async (job) => {
     try {
       const marketInfo = await buildMarketInfoFromRawMarketData(
         job.raw,
         job.poolId,
         job.marketId,
         networkId,
-        { applyOracle: true }
+        { applyOracle }
       );
       if (marketInfo) markets.push(marketInfo);
     } catch (error) {
       console.warn(
-        `[analyticsProtocolTvl] oracle build failed ${networkId}/${job.poolId}/${job.marketId}`,
+        `[analyticsProtocolTvl] ${mode} build failed ${networkId}/${job.poolId}/${job.marketId}`,
         error
       );
     }
   });
 
-  if (missingKeys.length > 0) {
+  // Gap-fill only for oracle path — fetchMarketsByKeys applies oracle pricing.
+  if (applyOracle && missingKeys.length > 0) {
     const gapFilled = await fetchMarketsByKeys(missingKeys, {
-      concurrency: ORACLE_REFINE_CONCURRENCY,
+      concurrency: HYDRATE_CONCURRENCY,
     });
     markets.push(...gapFilled);
   }
@@ -163,30 +186,56 @@ async function hydrateNetworkMarkets(
   return markets;
 }
 
-async function fetchHydratedAnalyticsMarkets(): Promise<MarketInfo[] | null> {
-  if (
-    cachedHydratedMarkets &&
-    Date.now() - cachedHydratedMarkets.fetchedAt < ORACLE_TVL_CACHE_TTL_MS &&
-    cachedHydratedMarkets.markets.length > 0
-  ) {
-    return cachedHydratedMarkets.markets;
-  }
-  if (hydrateInFlight) return hydrateInFlight;
+async function fetchHydratedAnalyticsMarkets(
+  mode: HydrateMode
+): Promise<MarketInfo[] | null> {
+  if (mode === "fast") {
+    if (cachedFastMarkets && isFreshMarkets(cachedFastMarkets)) {
+      return cachedFastMarkets.markets;
+    }
+    // Prefer oracle cache if already warm — prices are at least as good.
+    if (cachedOracleMarkets && isFreshMarkets(cachedOracleMarkets)) {
+      return cachedOracleMarkets.markets;
+    }
+    if (fastHydrateInFlight) return fastHydrateInFlight;
 
-  hydrateInFlight = (async () => {
+    fastHydrateInFlight = (async () => {
+      const networks = getEnabledNetworks().filter(isAlgorandCompatibleNetwork);
+      const perNetwork = await Promise.all(
+        networks.map((networkId) => hydrateNetworkMarkets(networkId, "fast"))
+      );
+      const markets = perNetwork.flat();
+      if (markets.length === 0) return null;
+      cachedFastMarkets = { markets, fetchedAt: Date.now() };
+      return markets;
+    })().finally(() => {
+      fastHydrateInFlight = null;
+    });
+
+    return fastHydrateInFlight;
+  }
+
+  if (cachedOracleMarkets && isFreshMarkets(cachedOracleMarkets)) {
+    return cachedOracleMarkets.markets;
+  }
+  if (oracleHydrateInFlight) return oracleHydrateInFlight;
+
+  oracleHydrateInFlight = (async () => {
     const networks = getEnabledNetworks().filter(isAlgorandCompatibleNetwork);
     const perNetwork = await Promise.all(
-      networks.map((networkId) => hydrateNetworkMarkets(networkId))
+      networks.map((networkId) => hydrateNetworkMarkets(networkId, "oracle"))
     );
     const markets = perNetwork.flat();
     if (markets.length === 0) return null;
-    cachedHydratedMarkets = { markets, fetchedAt: Date.now() };
+    cachedOracleMarkets = { markets, fetchedAt: Date.now() };
+    // Oracle results also satisfy fast consumers.
+    cachedFastMarkets = cachedOracleMarkets;
     return markets;
   })().finally(() => {
-    hydrateInFlight = null;
+    oracleHydrateInFlight = null;
   });
 
-  return hydrateInFlight;
+  return oracleHydrateInFlight;
 }
 
 export function buildAnalyticsMarketUsdLookup(
@@ -207,18 +256,78 @@ export function buildAnalyticsMarketUsdLookup(
   return lookup;
 }
 
-/** Oracle USD/token + decimals keyed by `network|marketId`. */
+/**
+ * Fast USD/token lookup from bulk market-data prices (no oracle RPC).
+ * Prefer this for activity charts so withdrawals aren't blocked on N oracle calls.
+ */
 export async function fetchAnalyticsMarketUsdLookup(): Promise<
   Map<string, AnalyticsMarketUsdQuote>
 > {
-  const markets = await fetchHydratedAnalyticsMarkets();
+  const markets = await fetchHydratedAnalyticsMarkets("fast");
   return buildAnalyticsMarketUsdLookup(markets ?? []);
 }
 
-async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {
-  const markets = await fetchHydratedAnalyticsMarkets();
-  if (!markets || markets.length === 0) return null;
+/**
+ * Oracle-priced USD lookup for a specific set of markets (e.g. withdrawal rows).
+ * Much cheaper than hydrating every configured market when only ~20 ids appear in activity.
+ */
+export async function fetchOracleMarketUsdLookupForRefs(
+  refs: Array<{
+    network?: string;
+    marketId?: string | number;
+    poolId?: string | number;
+    appId?: string | number;
+  }>
+): Promise<Map<string, AnalyticsMarketUsdQuote>> {
+  // Reuse full oracle cache when already warm.
+  if (cachedOracleMarkets && isFreshMarkets(cachedOracleMarkets)) {
+    return buildAnalyticsMarketUsdLookup(cachedOracleMarkets.markets);
+  }
 
+  const keys: UserPositionMarketKey[] = [];
+  const seen = new Set<string>();
+
+  for (const ref of refs) {
+    const networkId = ref.network as NetworkId | undefined;
+    const marketId = String(ref.marketId ?? "").trim();
+    if (!networkId || !marketId || !isAlgorandCompatibleNetwork(networkId)) {
+      continue;
+    }
+
+    let poolId = String(ref.poolId ?? ref.appId ?? "").trim();
+    if (!poolId) {
+      const token = getAllTokensWithDisplayInfo(networkId).find((t) => {
+        const id = String(
+          t.underlyingContractId ||
+            t.underlyingAssetId ||
+            t.originalContractId ||
+            ""
+        ).trim();
+        return id === marketId;
+      });
+      poolId = token?.poolId != null ? String(token.poolId) : "";
+    }
+    if (!poolId) continue;
+
+    const dedupe = `${networkId}|${poolId}|${marketId}`;
+    if (seen.has(dedupe)) continue;
+    seen.add(dedupe);
+    keys.push({ networkId, poolId, marketId });
+  }
+
+  if (keys.length === 0) {
+    return fetchAnalyticsMarketUsdLookup();
+  }
+
+  const markets = await fetchMarketsByKeys(keys, {
+    concurrency: HYDRATE_CONCURRENCY,
+  });
+  return buildAnalyticsMarketUsdLookup(markets);
+}
+
+function totalsFromMarkets(
+  markets: MarketInfo[]
+): OracleBasedProtocolTotals | null {
   const totals = sumProtocolUsdTotals(
     markets.map((market) => ({
       totalDeposits: market.totalDeposits,
@@ -227,11 +336,34 @@ async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTo
     }))
   );
   if (!(totals.tvl > 0)) return null;
-
   return {
     ...totals,
     fetchedAt: Date.now(),
   };
+}
+
+/**
+ * Protocol totals from bulk market-data prices (no oracle RPC).
+ * Use for a fast KPI refine before the slower oracle path finishes.
+ */
+export async function fetchBulkBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {
+  if (bulkTotalsInFlight) return bulkTotalsInFlight;
+
+  bulkTotalsInFlight = (async () => {
+    const markets = await fetchHydratedAnalyticsMarkets("fast");
+    if (!markets || markets.length === 0) return null;
+    return totalsFromMarkets(markets);
+  })().finally(() => {
+    bulkTotalsInFlight = null;
+  });
+
+  return bulkTotalsInFlight;
+}
+
+async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {
+  const markets = await fetchHydratedAnalyticsMarkets("oracle");
+  if (!markets || markets.length === 0) return null;
+  return totalsFromMarkets(markets);
 }
 
 /**
@@ -241,9 +373,9 @@ async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTo
 export async function fetchOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {
   const peek = peekCachedOracleProtocolTotals();
   if (peek) return peek;
-  if (inFlight) return inFlight;
+  if (oracleTotalsInFlight) return oracleTotalsInFlight;
 
-  inFlight = computeOracleBasedProtocolTotals()
+  oracleTotalsInFlight = computeOracleBasedProtocolTotals()
     .then((result) => {
       if (result) {
         cachedTotals = result;
@@ -252,8 +384,19 @@ export async function fetchOracleBasedProtocolTotals(): Promise<OracleBasedProto
       return result;
     })
     .finally(() => {
-      inFlight = null;
+      oracleTotalsInFlight = null;
     });
 
-  return inFlight;
+  return oracleTotalsInFlight;
+}
+
+/** Test helper */
+export function __resetAnalyticsProtocolTvlCacheForTests(): void {
+  cachedTotals = null;
+  oracleTotalsInFlight = null;
+  bulkTotalsInFlight = null;
+  cachedFastMarkets = null;
+  cachedOracleMarkets = null;
+  fastHydrateInFlight = null;
+  oracleHydrateInFlight = null;
 }

--- a/src/services/dorkfiAPIService.ts
+++ b/src/services/dorkfiAPIService.ts
@@ -1252,6 +1252,7 @@ class DorkFiAPIService {
         round: number;
         amount?: string;
         marketId?: string;
+        appId?: number | string;
         withdrawValueUSD?: string;
         withdrawalValueUSD?: string;
         network?: string;

--- a/src/utils/__tests__/analyticsTimePeriod.test.ts
+++ b/src/utils/__tests__/analyticsTimePeriod.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  periodToDays,
+  sliceDailySeriesByPeriod,
+  sumDailyAmounts,
+} from "@/utils/analyticsTimePeriod";
+
+describe("analyticsTimePeriod", () => {
+  it("maps period tokens to day counts", () => {
+    expect(periodToDays("7d")).toBe(7);
+    expect(periodToDays("30d")).toBe(30);
+    expect(periodToDays("90d")).toBe(90);
+  });
+
+  it("returns the full series for 90d", () => {
+    const series = [
+      { date: "2024-01-01", amount: 1 },
+      { date: "2024-03-01", amount: 2 },
+    ];
+    expect(sliceDailySeriesByPeriod(series, "90d")).toEqual(series);
+  });
+
+  it("slices to the selected lookback window", () => {
+    const now = Date.parse("2024-04-10T12:00:00Z");
+    const series = [
+      { date: "2024-01-01", amount: 1 },
+      { date: "2024-03-20", amount: 2 },
+      { date: "2024-04-05", amount: 3 },
+      { date: "2024-04-09", amount: 4 },
+    ];
+
+    expect(sliceDailySeriesByPeriod(series, "7d", now)).toEqual([
+      { date: "2024-04-05", amount: 3 },
+      { date: "2024-04-09", amount: 4 },
+    ]);
+    expect(sliceDailySeriesByPeriod(series, "30d", now)).toEqual([
+      { date: "2024-03-20", amount: 2 },
+      { date: "2024-04-05", amount: 3 },
+      { date: "2024-04-09", amount: 4 },
+    ]);
+  });
+
+  it("sums daily amounts", () => {
+    expect(
+      sumDailyAmounts([
+        { amount: 10 },
+        { amount: 2.5 },
+        { amount: 0 },
+      ])
+    ).toBe(12.5);
+  });
+});

--- a/src/utils/analyticsTimePeriod.ts
+++ b/src/utils/analyticsTimePeriod.ts
@@ -1,0 +1,41 @@
+export type AnalyticsTimePeriod = "7d" | "30d" | "90d";
+
+/** Always fetch this window once; charts slice client-side for 7d/30d. */
+export const ANALYTICS_MAX_LOOKBACK_DAYS = 90;
+
+export const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
+
+export function periodToDays(period: AnalyticsTimePeriod): number {
+  if (period === "7d") return 7;
+  if (period === "30d") return 30;
+  return 90;
+}
+
+export function periodStartMs(
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): number {
+  return now - periodToDays(period) * ANALYTICS_DAY_MS;
+}
+
+/**
+ * Keep daily points whose UTC date is on/after the period start day.
+ * Expects `date` as `YYYY-MM-DD`.
+ */
+export function sliceDailySeriesByPeriod<T extends { date: string }>(
+  series: T[],
+  period: AnalyticsTimePeriod,
+  now = Date.now()
+): T[] {
+  if (period === "90d") return series;
+  const startDate = new Date(periodStartMs(period, now))
+    .toISOString()
+    .split("T")[0];
+  return series.filter((point) => point.date >= startDate);
+}
+
+export function sumDailyAmounts(
+  series: Array<{ amount: number }>
+): number {
+  return series.reduce((sum, point) => sum + point.amount, 0);
+}


### PR DESCRIPTION
## Summary
- Closes [#599](https://github.com/DorkFi/dorkfi-app/issues/599) — Optimize Analytics page load times for historical metrics
- Introduce shared 90d caches for activity (deposits/withdrawals/borrows/repays), TVL/WAD growth, and live snapshots so charts and KPIs stop refetching independently
- Slice cached series client-side for `7d` / `30d` / `90d` toggles without blanking charts or re-hitting the API
- Parallelize/shared-fetch TVL and related protocol totals; keep per-section loading states so independent charts can render as data arrives

## Test plan
- [x] Open Analytics and confirm TVL, Total Borrows, Net Liquidity Flows, and Withdrawals populate without a long full-page block
- [x] Switch `7d` → `30d` → `90d` on activity/TVL/WAD charts and confirm no full refetch flicker (reuse cached 90d window)
- [x] Confirm chart values and KPI totals still match expected calculations
- [x] Spot-check Algorand and Voi-backed metrics still load
- [x] Verify skeleton/loading states still show on first load only


Made with [Cursor](https://cursor.com)