### PR TITLE
fix(rpc): point Algorand mainnet algod at Nodely after v5 upgrade.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3276,8 +3276,10 @@ const algorandMainnetProdConfig: NetworkConfig = {
   walletNetworkId: "mainnet",
   name: "Algorand Mainnet",
   networkType: "avm",
-  rpcUrl: "https://mainnet-api.algorand.dork.fi",
-  rpcPublicUrl: "https://mainnet-api.algorand.dork.fi",
+  // Nodely public algod (v5). mainnet-api.algorand.dork.fi proxies to a local
+  // node that is down after the Algorand v5.0 consensus upgrade.
+  rpcUrl: "https://mainnet-api.4160.nodely.dev",
+  rpcPublicUrl: "https://mainnet-api.4160.nodely.dev",
   rpcPort: 443,
   rpcToken: undefined, // Public endpoint, no token required
   indexerUrl: "https://mainnet-idx.4160.nodely.dev",

--- a/src/services/algorandService.ts
+++ b/src/services/algorandService.ts
@@ -36,7 +36,7 @@ const NETWORK_CONFIGS: Record<
 > = {
   mainnet: {
     algodToken: "",
-    algodServer: "https://mainnet-api.algorand.dork.fi",
+    algodServer: "https://mainnet-api.4160.nodely.dev",
     algodPort: 443,
     indexerToken: "",
     indexerServer: "https://mainnet-idx.4160.nodely.dev",


### PR DESCRIPTION
The dork.fi algod proxy is down on the local node after the Algorand v5.0 consensus upgrade, which blocks wallet reads and transactions.