### PR TITLE
fix(portfolio): overlay Algorand display USD from Tinyman (#601)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useWallet } from "@txnlab/use-wallet-react";
 import { useNetwork } from "@/contexts/NetworkContext";
 import NFTMintModal from "./NFTMintModal";
@@ -18,6 +18,13 @@ import algorandService from "@/services/algorandService";
 import { getNetworkConfig } from "@/config";
 import { LENDING_USER_HEALTH_ROUND_LOOKBACK } from "@/constants/lendingUserHealthIndexer";
 import algosdk from "algosdk";
+import { useDisplayAssetUsdMap } from "@/hooks/useDisplayAssetUsdMap";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import { overlayUsdWithDisplayPrice } from "@/utils/displayUsdPerToken";
+import {
+  collectAlgorandMainnetDisplayAsaIds,
+  resolveAsaIdForDisplayUsd,
+} from "@/utils/resolveAsaIdForDisplayUsd";
 
 interface DashboardProps {
   onTabChange?: (value: string) => void;
@@ -26,6 +33,17 @@ interface DashboardProps {
 const Dashboard = ({ onTabChange }: DashboardProps) => {
   const { activeAccount } = useWallet();
   const { currentNetwork } = useNetwork();
+  const algorandDisplayAsaIds = useMemo(
+    () =>
+      currentNetwork === "algorand-mainnet"
+        ? collectAlgorandMainnetDisplayAsaIds()
+        : [],
+    [currentNetwork]
+  );
+  const displayUsdByAsaId = useDisplayAssetUsdMap(
+    algorandDisplayAsaIds,
+    currentNetwork === "algorand-mainnet"
+  );
 
   // Real user data state
   const [userGlobalData, setUserGlobalData] = useState<{
@@ -94,32 +112,45 @@ const Dashboard = ({ onTabChange }: DashboardProps) => {
     netAPY: calculateNetAPY(userAssets.assets),
   };
 
-  // Calculate market stats from real market data
-  const marketStats = {
-    totalValueLocked: marketData.reduce((sum, market) => {
-      const deposits = parseFloat(market.totalDeposits || "0");
-      const price = parseFloat(market.price || "0");
-      // Convert price from scaled format (divide by 10^6 as done in PreFi)
-      const scaledPrice = price / Math.pow(10, 6);
-      return sum + deposits * scaledPrice;
-    }, 0),
-    totalBorrowed: marketData.reduce((sum, market) => {
-      const borrows = parseFloat(market.totalBorrows || "0");
-      const price = parseFloat(market.price || "0");
-      // Convert price from scaled format (divide by 10^6 as done in PreFi)
-      const scaledPrice = price / Math.pow(10, 6);
-      return sum + borrows * scaledPrice;
-    }, 0),
-    availableLiquidity: marketData.reduce((sum, market) => {
-      const deposits = parseFloat(market.totalDeposits || "0");
-      const borrows = parseFloat(market.totalBorrows || "0");
-      const price = parseFloat(market.price || "0");
-      // Convert price from scaled format (divide by 10^6 as done in PreFi)
-      const scaledPrice = price / Math.pow(10, 6);
-      return sum + (deposits - borrows) * scaledPrice;
-    }, 0),
-    activeUsers: activeUsersCount,
-  };
+  // Calculate market stats from real market data (DEX USD when available)
+  const marketStats = useMemo(() => {
+    const usdForMarket = (market: MarketInfo) => {
+      const protocolUsd = usdPerTokenFromPortfolioMarketRow(
+        market,
+        market.decimals || 6,
+        { displaySymbol: market.symbol }
+      );
+      const asaId = resolveAsaIdForDisplayUsd({
+        networkId: market.networkId || currentNetwork,
+        poolId: market.poolId,
+        marketId: market.marketId,
+        displaySymbol: market.symbol,
+      });
+      return overlayUsdWithDisplayPrice(
+        protocolUsd,
+        asaId != null ? displayUsdByAsaId.get(asaId) : undefined
+      );
+    };
+    return {
+      totalValueLocked: marketData.reduce((sum, market) => {
+        const deposits = parseFloat(market.totalDeposits || "0");
+        return sum + (Number.isFinite(deposits) ? deposits * usdForMarket(market) : 0);
+      }, 0),
+      totalBorrowed: marketData.reduce((sum, market) => {
+        const borrows = parseFloat(market.totalBorrows || "0");
+        return sum + (Number.isFinite(borrows) ? borrows * usdForMarket(market) : 0);
+      }, 0),
+      availableLiquidity: marketData.reduce((sum, market) => {
+        const deposits = parseFloat(market.totalDeposits || "0");
+        const borrows = parseFloat(market.totalBorrows || "0");
+        const net =
+          (Number.isFinite(deposits) ? deposits : 0) -
+          (Number.isFinite(borrows) ? borrows : 0);
+        return sum + net * usdForMarket(market);
+      }, 0),
+      activeUsers: activeUsersCount,
+    };
+  }, [marketData, displayUsdByAsaId, currentNetwork, activeUsersCount]);
 
   const [nftMintModalOpen, setNFTMintModalOpen] = useState(false);
   // In real app, these would be from user/session

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -125,6 +125,12 @@ import {
 } from "@/utils/modalPrefetch";
 import { buildMarketHoverHandlers } from "@/utils/modalHoverHandlers";
 import { resolveUsdPerTokenFromMarketInfo } from "@/utils/assetDecimals";
+import { overlayUsdWithDisplayPrice } from "@/utils/displayUsdPerToken";
+import {
+  collectAlgorandMainnetDisplayAsaIds,
+  resolveAsaIdForDisplayUsd,
+} from "@/utils/resolveAsaIdForDisplayUsd";
+import { useDisplayAssetUsdMap } from "@/hooks/useDisplayAssetUsdMap";
 
 const MAX_CLAIMS_PER_TX = 3;
 
@@ -173,7 +179,8 @@ function resolveMarketRowTokenDecimals(
 /** Map on-demand market row → PremiumMarketModal `MarketData` (USD fields in whole dollars like the markets table). */
 function normalizeMarketData(
   md: Record<string, unknown>,
-  networkId?: NetworkId
+  networkId?: NetworkId,
+  dexUsdByAsaId?: Map<number, number>
 ) {
   const totalSupplyUSD = Number(md.totalSupplyUSD ?? 0);
   const totalBorrowUSD = Number(md.totalBorrowUSD ?? 0);
@@ -221,6 +228,23 @@ function normalizeMarketData(
       price = totalSupplyUSD / 1_000_000 / supplyTokensHuman;
     }
   }
+
+  const asaId = resolveAsaIdForDisplayUsd({
+    networkId,
+    poolId: md.poolId != null ? String(md.poolId) : null,
+    marketId: String(
+      md.marketId ??
+        (md.marketInfo as { marketId?: unknown } | undefined)?.marketId ??
+        ""
+    ),
+    configKey: md.configSymbol != null ? String(md.configSymbol) : null,
+    displaySymbol: String(md.asset ?? md.symbol ?? ""),
+  });
+  const dexUsd =
+    asaId != null && networkId === "algorand-mainnet"
+      ? dexUsdByAsaId?.get(asaId)
+      : undefined;
+  price = overlayUsdWithDisplayPrice(price, dexUsd);
 
   const utilization = Number(md.utilization ?? 0);
 
@@ -555,6 +579,17 @@ const MarketsTable = () => {
   const { activeAccount, signTransactions, activeWallet } = useWallet();
 
   const { currentNetwork, switchNetwork } = useNetwork();
+  const algorandDisplayAsaIds = useMemo(
+    () =>
+      currentNetwork === "algorand-mainnet"
+        ? collectAlgorandMainnetDisplayAsaIds()
+        : [],
+    [currentNetwork]
+  );
+  const displayUsdByAsaId = useDisplayAssetUsdMap(
+    algorandDisplayAsaIds,
+    currentNetwork === "algorand-mainnet"
+  );
 
   const enabledNetworks = getEnabledNetworks();
   const showMarketsLiquidityToolbar =
@@ -3090,7 +3125,11 @@ const MarketsTable = () => {
         marketRowKey
       );
       const tokenPrice = marketForPrice
-        ? normalizeMarketData(marketForPrice, currentNetwork as NetworkId).price
+        ? normalizeMarketData(
+            marketForPrice,
+            currentNetwork as NetworkId,
+            displayUsdByAsaId
+          ).price
         : 0;
       const balanceUSD = balance * tokenPrice;
 
@@ -3402,7 +3441,11 @@ const MarketsTable = () => {
       portfolioHealthFactor: number | null,
       maxWithdrawUnderlying: number | null
     ): MarketDetailUserPosition => {
-      const norm = normalizeMarketData(row, currentNetwork as NetworkId);
+      const norm = normalizeMarketData(
+        row,
+        currentNetwork as NetworkId,
+        displayUsdByAsaId
+      );
       const price =
         norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
       const assetData = getAssetData(asset, poolId, detailModal.marketRowKey);
@@ -3548,7 +3591,11 @@ const MarketsTable = () => {
             if (maxWithdrawResult?.maxWithdrawUnderlying == null) return;
             setDetailModalUserPosition((prev) => {
               if (!prev) return prev;
-              const norm = normalizeMarketData(row, currentNetwork as NetworkId);
+              const norm = normalizeMarketData(
+                row,
+                currentNetwork as NetworkId,
+                displayUsdByAsaId
+              );
               const price =
                 norm.price > 0 && Number.isFinite(norm.price) ? norm.price : 0;
               const dep =
@@ -4047,7 +4094,8 @@ const MarketsTable = () => {
             rawMarket={detailModal.marketData}
             marketData={normalizeMarketData(
               detailModal.marketData,
-              currentNetwork as NetworkId
+              currentNetwork as NetworkId,
+              displayUsdByAsaId
             )}
             userPosition={detailModalUserPosition ?? undefined}
             userPositionLoadState={detailModalUserPositionLoad}

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -105,6 +105,9 @@ import {
 } from "@/components/portfolio/PortfolioPositionsFilterBar";
 import PortfolioPositionsCardHeader from "@/components/portfolio/PortfolioPositionsCardHeader";
 import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import { overlayPositionsDisplayUsd } from "@/utils/overlayPositionDisplayUsd";
+import { collectAlgorandMainnetDisplayAsaIds } from "@/utils/resolveAsaIdForDisplayUsd";
+import { useDisplayAssetUsdMap } from "@/hooks/useDisplayAssetUsdMap";
 import { formatNftHolderClaimableDisplayFromAgent } from "@/utils/nftHolderClaimAgentDisplay";
 import { spendableAlgoHumanFromAccount } from "@/utils/algorandWalletBalance";
 import { portfolioWalletBalanceCacheKey } from "@/utils/portfolioWalletBalanceCacheKey";
@@ -281,50 +284,7 @@ function folksUnderlyingUsdFallbackSamePool(
   });
 }
 
-/** When wBTC/goBTC market price is missing, reuse a same-pool BTC-family market with a valid price. */
-function btcFamilyUsdFallbackSamePool(
-  marketRows: unknown[],
-  networkId: NetworkId,
-  poolId: string,
-  currentUnderlyingMarketId: string
-): number {
-  const tokens = getAllTokensWithDisplayInfo(networkId);
-  const preferred = tokens.filter((t) => {
-    if (String(t.poolId) !== String(poolId)) return false;
-    if (
-      String(t.underlyingContractId ?? "") === String(currentUnderlyingMarketId)
-    ) {
-      return false;
-    }
-    const key = String(t.configKey ?? t.originalSymbol ?? t.symbol).toUpperCase();
-    return key === "GOBTC" || key === "WBTC" || key === "BTC";
-  });
-  // Prefer goBTC / fWBTC (Folks) rows — fresher BTC oracle feed on Pool A
-  const ordered = [...preferred].sort((a, b) => {
-    const score = (t: (typeof preferred)[number]) => {
-      const id = String(t.underlyingContractId ?? "");
-      if (id === "3575837891") return 0;
-      const key = String(t.configKey ?? t.originalSymbol ?? "").toUpperCase();
-      if (key === "GOBTC") return 1;
-      return 2;
-    };
-    return score(a) - score(b);
-  });
-  for (const ref of ordered) {
-    if (!ref.underlyingContractId) continue;
-    const m = marketRowForPortfolioPosition(marketRows, {
-      marketId: ref.underlyingContractId,
-      poolId,
-      displaySymbol: ref.symbol,
-    });
-    const usd = usdPerTokenFromPortfolioMarketRow(m, ref.decimals, {
-      displaySymbol: ref.symbol,
-    });
-    if (usd > 0) return usd;
-  }
-  return 0;
-}
-
+/** Folks f-asset rows show underlying balance; if their market row has no usable price, use native ALGO same pool. */
 function resolvePortfolioPositionUsdPerToken(options: {
   market: unknown;
   tokenDecimals: number;
@@ -369,25 +329,6 @@ function resolvePortfolioPositionUsdPerToken(options: {
     options.marketId
   ) {
     tokenPrice = folksUnderlyingUsdFallbackSamePool(
-      options.marketRows,
-      options.networkId,
-      String(options.poolId),
-      String(options.marketId)
-    );
-    if (tokenPrice > 0) {
-      return resolveWithLastGoodPortfolioUsd(tokenPrice, cacheKey);
-    }
-  }
-
-  const sym = String(
-    options.configKey ?? options.originalSymbol ?? options.displaySymbol ?? ""
-  ).toUpperCase();
-  if (
-    (sym === "WBTC" || sym === "GOBTC" || sym === "BTC") &&
-    options.poolId != null &&
-    options.marketId
-  ) {
-    tokenPrice = btcFamilyUsdFallbackSamePool(
       options.marketRows,
       options.networkId,
       String(options.poolId),
@@ -886,11 +827,18 @@ const Portfolio = () => {
     []
   );
 
+  const algorandDisplayAsaIds = useMemo(
+    () => collectAlgorandMainnetDisplayAsaIds(),
+    []
+  );
+  const displayUsdByAsaId = useDisplayAssetUsdMap(algorandDisplayAsaIds, true);
+
   const { attachChainPollRow, mergeDeposit, mergeBorrow } =
     usePortfolioVisibleChainLive({
       address: displayAddress,
       marketData,
       formatPriceFromContract,
+      displayUsdByAsaId,
     });
 
   // POST `/market-data/...` when a supply/borrow position modal opens (fresh API snapshot for that market).
@@ -1394,7 +1342,7 @@ const Portfolio = () => {
             return; // Skip zero balances
           }
 
-          // Get token price (oracle-aware; Folks/BTC family fallbacks — never invent $1)
+          // Protocol/oracle USD for this market only; DEX overlay applied after transform.
           const tokenPrice = resolvePortfolioPositionUsdPerToken({
             market,
             tokenDecimals: token.decimals,
@@ -1625,7 +1573,7 @@ const Portfolio = () => {
             return; // Skip zero balances
           }
 
-          // Get token price (oracle-aware; Folks/BTC family fallbacks — never invent $1)
+          // Protocol/oracle USD for this market only; DEX overlay applied after transform.
           const tokenPrice = resolvePortfolioPositionUsdPerToken({
             market,
             tokenDecimals: token.decimals,
@@ -1734,11 +1682,17 @@ const Portfolio = () => {
     hasComputedData && transformedDepositsAndBorrows.borrows.length > 0
       ? transformedDepositsAndBorrows.borrows
       : userPositions.filter((pos) => pos.type === "borrow");
-  const deposits = rawDeposits.filter(
-    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  const deposits = overlayPositionsDisplayUsd(
+    rawDeposits.filter(
+      (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+    ),
+    displayUsdByAsaId
   );
-  const borrows = rawBorrows.filter(
-    (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+  const borrows = overlayPositionsDisplayUsd(
+    rawBorrows.filter(
+      (pos) => !isExcludedPortfolioPositionRow(pos as ItemWithNetwork)
+    ),
+    displayUsdByAsaId
   );
 
   const hasBothPositionTypes =
@@ -1856,21 +1810,19 @@ const Portfolio = () => {
     finalBorrowsCount: borrows.length,
   });
 
-  // Calculate totals - prioritize computed global values from API, then fallback to local calculations
-  const totalCollateral =
-    user?.computed?.globalCollateralValue !== undefined
-      ? Number(user.computed.globalCollateralValue)
-      : userGlobalData?.totalCollateralValue ||
-      deposits.reduce((sum, deposit) => sum + deposit.value, 0);
+  // Display totals from live per-asset USD × balances (not stale pool book).
+  const totalCollateral = deposits.reduce(
+    (sum, deposit) => sum + (deposit.value || 0),
+    0
+  );
 
   console.log({
   });
 
-  const totalBorrowed =
-    user?.computed?.globalBorrowValue !== undefined
-      ? Number(user.computed.globalBorrowValue)
-      : userGlobalData?.totalBorrowValue ||
-      borrows.reduce((sum, borrow) => sum + borrow.value, 0);
+  const totalBorrowed = borrows.reduce(
+    (sum, borrow) => sum + (borrow.value || 0),
+    0
+  );
 
   // Calculate weighted liquidation threshold based on borrowed assets only
   // This is more accurate because liquidation risk only applies to markets with active debt
@@ -2056,9 +2008,22 @@ const Portfolio = () => {
                   BigInt(poolGlobalData.totalBorrowValue) / BigInt(1e12)
                 ) || 0;
 
+              const posCollateral = deposits
+                .filter((d) => String(d.poolId ?? "") === String(deposit.poolId))
+                .reduce((sum, d) => sum + (d.value || 0), 0);
+              const posBorrow = borrows
+                .filter((b) => String(b.poolId ?? "") === String(deposit.poolId))
+                .reduce((sum, b) => sum + (b.value || 0), 0);
+              if (posCollateral > 0 || posBorrow > 0) {
+                poolCollateralValueUSD = posCollateral;
+                poolBorrowsUSD = posBorrow;
+              }
+
               riskRatio =
-                (poolCollateralValueUSD * liquidationFactorNum) /
-                poolBorrowsUSD;
+                poolBorrowsUSD > 0
+                  ? (poolCollateralValueUSD * liquidationFactorNum) /
+                    poolBorrowsUSD
+                  : riskRatio;
             } catch (error) {
               console.warn(
                 `Error parsing global user data for pool ${deposit.poolId}:`,
@@ -2084,7 +2049,7 @@ const Portfolio = () => {
       })
       .filter((asset) => asset.isAtRisk && asset.poolBorrowsUSD >= 0.01)
       .sort((a, b) => a.riskRatio - b.riskRatio); // Sort by risk ratio (most risky first)
-  }, [deposits, marketData, totalBorrowed, user?.globalUserData]);
+  }, [deposits, borrows, marketData, totalBorrowed, user?.globalUserData]);
 
   // Portfolio health matches lending pool _calculate_user_health(collateral, borrow, liquidation_threshold).
   // Prefer each pool's get_global_user-style totals from `user.globalUserData`; portfolio HF = worst (min) HF
@@ -2148,6 +2113,17 @@ const Portfolio = () => {
           );
         } catch {
           continue;
+        }
+
+        const posCollateral = deposits
+          .filter((d) => String(d.poolId ?? "") === poolId)
+          .reduce((sum, d) => sum + (d.value || 0), 0);
+        const posBorrow = borrows
+          .filter((b) => String(b.poolId ?? "") === poolId)
+          .reduce((sum, b) => sum + (b.value || 0), 0);
+        if (posCollateral > 0 || posBorrow > 0) {
+          collateral = posCollateral;
+          borrow = posBorrow;
         }
 
         const lt = minLtForPool(poolId);
@@ -2303,21 +2279,24 @@ const Portfolio = () => {
     }
 
     for (const agg of byKey.values()) {
-      if (agg.fromGud) continue;
-      agg.collateral = deposits
+      const posCollateral = deposits
         .filter(
           (d) =>
             String(d.poolId ?? "") === agg.poolId &&
             String((d as ItemWithNetwork).network ?? "") === agg.network
         )
         .reduce((sum, d) => sum + (d.value || 0), 0);
-      agg.borrow = borrows
+      const posBorrow = borrows
         .filter(
           (b) =>
             String(b.poolId ?? "") === agg.poolId &&
             String((b as ItemWithNetwork).network ?? "") === agg.network
         )
         .reduce((sum, b) => sum + (b.value || 0), 0);
+      if (posCollateral > 0 || posBorrow > 0) {
+        agg.collateral = posCollateral;
+        agg.borrow = posBorrow;
+      }
     }
 
     const rows: Array<{

--- a/src/components/analytics/KPIGrid.tsx
+++ b/src/components/analytics/KPIGrid.tsx
@@ -32,7 +32,7 @@ const KPIGrid = () => {
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Total value of assets deposited, priced from the live price oracle (same source as Markets)</p>
+            <p>Total value of assets deposited, priced from live DEX USD when available (same source as Portfolio)</p>
           </TooltipContent>
         </Tooltip>
 

--- a/src/hooks/useDisplayAssetUsdMap.ts
+++ b/src/hooks/useDisplayAssetUsdMap.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchTinymanAssetUsdMap } from "@/services/tinymanAssetUsd";
+import { DISPLAY_USD_POLL_MS } from "@/utils/displayUsdPerToken";
+
+/**
+ * Polls Tinyman USD for the given Algorand ASA ids.
+ * Keeps last good values across refreshes.
+ */
+export function useDisplayAssetUsdMap(
+  asaIds: readonly number[],
+  enabled: boolean = true
+): Map<number, number> {
+  const [map, setMap] = useState<Map<number, number>>(() => new Map());
+  const key = useMemo(
+    () =>
+      [...new Set(asaIds.filter((id) => Number.isFinite(id) && id >= 0))]
+        .sort((a, b) => a - b)
+        .join(","),
+    [asaIds]
+  );
+
+  useEffect(() => {
+    if (!enabled || key === "") {
+      return;
+    }
+    let cancelled = false;
+    const ids = key.split(",").map(Number);
+
+    const load = async () => {
+      try {
+        const next = await fetchTinymanAssetUsdMap(ids);
+        if (cancelled || next.size === 0) return;
+        setMap((prev) => {
+          const merged = new Map(prev);
+          for (const [id, usd] of next) merged.set(id, usd);
+          return merged;
+        });
+      } catch {
+        // keep last good map
+      }
+    };
+
+    void load();
+    const interval = window.setInterval(() => void load(), DISPLAY_USD_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [enabled, key]);
+
+  return map;
+}

--- a/src/hooks/useOnDemandMarketData.ts
+++ b/src/hooks/useOnDemandMarketData.ts
@@ -46,6 +46,9 @@ import { useFolksMainnetWbtcNttPoolLiveApyPercent } from "@/hooks/useFolksMainne
 import { useFolksMainnetWethNttPoolLiveApyPercent } from "@/hooks/useFolksMainnetWethNttPoolLiveApyPercent";
 import { resolveTokenIconBadgeUrl } from "@/utils/tokenImageUtils";
 import { withRpcReadCache, getRpcReadCache } from "@/utils/rpcReadCache";
+import { useDisplayAssetUsdMap } from "@/hooks/useDisplayAssetUsdMap";
+import { collectAlgorandMainnetDisplayAsaIds } from "@/utils/resolveAsaIdForDisplayUsd";
+import { overlayOnDemandMarketsRecord } from "@/utils/overlayOnDemandMarketUsd";
 
 export interface OnDemandMarketData {
   asset: string;
@@ -409,6 +412,15 @@ export const useOnDemandMarketData = ({
    */
   const marketsDataEpochRef = useRef(0);
   const algorandMainnetMarkets = currentNetwork === "algorand-mainnet";
+  const algorandDisplayAsaIds = useMemo(
+    () =>
+      algorandMainnetMarkets ? collectAlgorandMainnetDisplayAsaIds() : [],
+    [algorandMainnetMarkets]
+  );
+  const displayUsdByAsaId = useDisplayAssetUsdMap(
+    algorandDisplayAsaIds,
+    algorandMainnetMarkets
+  );
   const tinymanLiveIntrinsicApyPct = useTinymanLiquidStakingLiveApyPercent(
     algorandMainnetMarkets
   );
@@ -1253,14 +1265,24 @@ export const useOnDemandMarketData = ({
     [autoLoad, loadMarketData]
   );
 
+  const marketsDataForDisplay = useMemo(
+    () =>
+      overlayOnDemandMarketsRecord(
+        marketsData,
+        currentNetwork,
+        displayUsdByAsaId
+      ),
+    [marketsData, currentNetwork, displayUsdByAsaId]
+  );
+
   // Convert markets data to array format (include _sortKey for stable tie-breaking)
   const marketDataArray = useMemo(() => {
-    return Object.entries(marketsData).map(([key, market]) => ({
+    return Object.entries(marketsDataForDisplay).map(([key, market]) => ({
       ...market,
       isLoading: loadingMarkets.has(key),
       _sortKey: key,
     }));
-  }, [marketsData, loadingMarkets]);
+  }, [marketsDataForDisplay, loadingMarkets]);
 
   /** Lending pool app ids in order: A = [0], B = [1], D = [2] when present. */
   const lendingPools = useMemo(() => {
@@ -1524,7 +1546,7 @@ export const useOnDemandMarketData = ({
     hydrateMarkets,
     isLoading: loadingMarkets.size > 0,
     isLoadingVisible,
-    marketsData,
+    marketsData: marketsDataForDisplay,
     wadMintMarket,
     newMarketsCount,
     rewardMarketsCount,

--- a/src/hooks/usePortfolioVisibleChainLive.ts
+++ b/src/hooks/usePortfolioVisibleChainLive.ts
@@ -25,6 +25,9 @@ import {
   resolveWithLastGoodPortfolioUsd,
 } from "@/utils/portfolioUsdCache";
 import { marketRowForPortfolioPosition } from "@/utils/marketRowForPortfolioPosition";
+import { overlayUsdWithDisplayPrice } from "@/utils/displayUsdPerToken";
+import { overlayPositionDisplayUsd } from "@/utils/overlayPositionDisplayUsd";
+import { resolveAsaIdForDisplayUsd } from "@/utils/resolveAsaIdForDisplayUsd";
 
 export type PortfolioChainLiveOverride = {
   balance?: number;
@@ -106,6 +109,24 @@ function resolvePollToken(
 }
 
 type PollToken = NonNullable<ReturnType<typeof resolvePollToken>>;
+
+function applyDisplayUsdForPollToken(
+  networkId: NetworkId,
+  token: PollToken,
+  protocolUsd: number,
+  dexUsdByAsaId: Map<number, number> | undefined
+): number {
+  const asaId = resolveAsaIdForDisplayUsd({
+    networkId,
+    poolId: token.poolId,
+    marketId: token.underlyingContractId,
+    configKey: token.configKey,
+    originalSymbol: token.originalSymbol,
+    displaySymbol: token.symbol,
+  });
+  const dexUsd = asaId != null ? dexUsdByAsaId?.get(asaId) : undefined;
+  return overlayUsdWithDisplayPrice(protocolUsd, dexUsd);
+}
 
 function tokenConfigForPollToken(
   networkId: NetworkId,
@@ -284,6 +305,8 @@ export function usePortfolioVisibleChainLive(opts: {
   marketData: unknown[];
   pollIntervalMs?: number;
   enabled?: boolean;
+  /** Per-ASA DEX USD for display; never reused across wrappers. */
+  displayUsdByAsaId?: Map<number, number>;
   formatPriceFromContract: (
     contractPrice: string | number,
     tokenDecimals: number
@@ -300,6 +323,8 @@ export function usePortfolioVisibleChainLive(opts: {
       import.meta.env.VITE_PORTFOLIO_CHAIN_POLL !== "0",
   } = opts;
   void opts.formatPriceFromContract;
+  const displayUsdByAsaIdRef = useRef(opts.displayUsdByAsaId);
+  displayUsdByAsaIdRef.current = opts.displayUsdByAsaId;
 
   const useApiUserData =
     import.meta.env.VITE_PORTFOLIO_CHAIN_USE_API_USER_DATA !== "false" &&
@@ -366,15 +391,20 @@ export function usePortfolioVisibleChainLive(opts: {
         poolId: token.poolId,
         displaySymbol: token.symbol,
       });
-      const tp = resolveWithLastGoodPortfolioUsd(
-        usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
-          displaySymbol: token.symbol,
-        }),
-        portfolioUsdCacheKey(
-          String(networkId),
-          String(token.poolId),
-          String(token.underlyingContractId)
-        )
+      const tp = applyDisplayUsdForPollToken(
+        networkId,
+        token,
+        resolveWithLastGoodPortfolioUsd(
+          usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
+            displaySymbol: token.symbol,
+          }),
+          portfolioUsdCacheKey(
+            String(networkId),
+            String(token.poolId),
+            String(token.underlyingContractId)
+          )
+        ),
+        displayUsdByAsaIdRef.current
       );
 
       try {
@@ -503,20 +533,33 @@ export function usePortfolioVisibleChainLive(opts: {
         );
       }
 
-      const tokenPrice = resolveWithLastGoodPortfolioUsd(
-        usdPerTokenFromPortfolioMarketRow(
-          group.market,
-          group.tokenDecimals,
-          {
-            displaySymbol:
-              (group.market as { symbol?: string } | null)?.symbol ?? undefined,
-          }
+      const tokenPrice = overlayUsdWithDisplayPrice(
+        resolveWithLastGoodPortfolioUsd(
+          usdPerTokenFromPortfolioMarketRow(
+            group.market,
+            group.tokenDecimals,
+            {
+              displaySymbol:
+                (group.market as { symbol?: string } | null)?.symbol ??
+                undefined,
+            }
+          ),
+          portfolioUsdCacheKey(
+            String(group.network),
+            String(group.appId),
+            String(group.marketId)
+          )
         ),
-        portfolioUsdCacheKey(
-          String(group.network),
-          String(group.appId),
-          String(group.marketId)
-        )
+        (() => {
+          const asaId = resolveAsaIdForDisplayUsd({
+            networkId: group.network,
+            poolId: String(group.appId),
+            marketId: String(group.marketId),
+          });
+          return asaId != null
+            ? displayUsdByAsaIdRef.current?.get(asaId)
+            : undefined;
+        })()
       );
 
       let groupDepositMinted: bigint | null = null;
@@ -613,16 +656,21 @@ export function usePortfolioVisibleChainLive(opts: {
           poolId: token.poolId,
           displaySymbol: token.symbol,
         });
-        const tp = resolveWithLastGoodPortfolioUsd(
-        usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
-          displaySymbol: token.symbol,
-        }),
-        portfolioUsdCacheKey(
-          String(networkId),
-          String(token.poolId),
-          String(token.underlyingContractId)
-        )
-      );
+        const tp = applyDisplayUsdForPollToken(
+          networkId,
+          token,
+          resolveWithLastGoodPortfolioUsd(
+            usdPerTokenFromPortfolioMarketRow(mkt, token.decimals, {
+              displaySymbol: token.symbol,
+            }),
+            portfolioUsdCacheKey(
+              String(networkId),
+              String(token.poolId),
+              String(token.underlyingContractId)
+            )
+          ),
+          displayUsdByAsaIdRef.current
+        );
 
         try {
           if (row.kind === "deposit") {
@@ -768,7 +816,7 @@ export function usePortfolioVisibleChainLive(opts: {
       );
       const o = overrides[key];
       if (!o || (o.balance === undefined && o.value === undefined)) return row;
-      return {
+      const merged: PositionRow = {
         ...row,
         balance: o.balance ?? row.balance,
         value: o.value ?? row.value,
@@ -781,6 +829,10 @@ export function usePortfolioVisibleChainLive(opts: {
             }
           : {}),
       };
+      return overlayPositionDisplayUsd(
+        merged,
+        displayUsdByAsaIdRef.current ?? new Map()
+      );
     },
     [overrides]
   );
@@ -798,7 +850,7 @@ export function usePortfolioVisibleChainLive(opts: {
       );
       const o = overrides[key];
       if (!o || (o.balance === undefined && o.value === undefined)) return row;
-      return {
+      const merged: PositionRow = {
         ...row,
         balance: o.balance ?? row.balance,
         value: o.value ?? row.value,
@@ -812,6 +864,10 @@ export function usePortfolioVisibleChainLive(opts: {
             }
           : {}),
       };
+      return overlayPositionDisplayUsd(
+        merged,
+        displayUsdByAsaIdRef.current ?? new Map()
+      );
     },
     [overrides]
   );

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -1,8 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { fetchMarketInfo } from '@/services/lendingService';
 import { getAllTokensWithDisplayInfo } from '@/config';
 import { useNetwork } from '@/contexts/NetworkContext';
 import { resolveUsdPerTokenFromMarketInfo } from '@/utils/assetDecimals';
+import { overlayUsdWithDisplayPrice } from '@/utils/displayUsdPerToken';
+import { resolveAsaIdForDisplayUsd } from '@/utils/resolveAsaIdForDisplayUsd';
+import { useDisplayAssetUsdMap } from '@/hooks/useDisplayAssetUsdMap';
 import { withRpcReadCache } from '@/utils/rpcReadCache';
 
 interface UseTokenPriceResult {
@@ -70,18 +73,33 @@ async function fetchTokenPriceUsd(
 }
 
 export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseTokenPriceResult => {
-  const [price, setPrice] = useState<number>(0);
+  const [protocolPrice, setProtocolPrice] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const { currentNetwork } = useNetwork();
+  const networkToUse = networkId || currentNetwork;
+
+  const asaId = useMemo(() => {
+    if (!tokenSymbol || networkToUse !== "algorand-mainnet") return null;
+    return resolveAsaIdForDisplayUsd({
+      networkId: networkToUse,
+      configKey: tokenSymbol,
+      displaySymbol: tokenSymbol,
+    });
+  }, [tokenSymbol, networkToUse]);
+
+  const asaIds = useMemo(() => (asaId != null ? [asaId] : []), [asaId]);
+  const dexUsdByAsaId = useDisplayAssetUsdMap(
+    asaIds,
+    asaId != null
+  );
 
   const fetchPrice = useCallback(async () => {
     if (!tokenSymbol) {
-      setPrice(0);
+      setProtocolPrice(0);
       return;
     }
 
-    const networkToUse = networkId || currentNetwork;
     if (!networkToUse) {
       setError('No network specified');
       return;
@@ -98,7 +116,7 @@ export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseToken
         () => fetchTokenPriceUsd(tokenSymbol, networkToUse),
         TOKEN_PRICE_CACHE_TTL_MS
       );
-      setPrice(marketPrice);
+      setProtocolPrice(marketPrice);
     } catch (err) {
       console.error(`Error fetching market price for ${tokenSymbol}:`, err);
       setError(err instanceof Error ? err.message : 'Failed to fetch market price');
@@ -116,11 +134,11 @@ export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseToken
         'DAI': 1.0
       };
 
-      setPrice(mockPrices[tokenSymbol] || 1.0);
+      setProtocolPrice(mockPrices[tokenSymbol] || 1.0);
     } finally {
       setIsLoading(false);
     }
-  }, [tokenSymbol, networkId, currentNetwork]);
+  }, [tokenSymbol, networkToUse]);
 
   useEffect(() => {
     fetchPrice();
@@ -129,6 +147,11 @@ export const useTokenPrice = (tokenSymbol: string, networkId?: string): UseToken
   const refetch = useCallback(() => {
     fetchPrice();
   }, [fetchPrice]);
+
+  const price = overlayUsdWithDisplayPrice(
+    protocolPrice,
+    asaId != null ? dexUsdByAsaId.get(asaId) : undefined
+  );
 
   return {
     price,

--- a/src/services/analyticsProtocolTvl.ts
+++ b/src/services/analyticsProtocolTvl.ts
@@ -1,8 +1,7 @@
 /**
- * Protocol TVL / borrowed using the same oracle overlay as Markets
- * (`buildMarketInfoFromRawMarketData` + `usdPerTokenFromPortfolioMarketRow`).
- * Amounts come from the bulk market-data API; USD prices come from the oracle
- * contract instead of stale `get_market.price`.
+ * Protocol TVL / borrowed using display USD (Tinyman DEX when available,
+ * otherwise this market's own oracle) × human deposit/borrow amounts.
+ * Amounts come from the bulk market-data API.
  */
 
 import {
@@ -20,7 +19,13 @@ import {
   type MarketInfo,
   type UserPositionMarketKey,
 } from "@/services/lendingService";
+import { fetchTinymanAssetUsdMap } from "@/services/tinymanAssetUsd";
 import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import { overlayUsdWithDisplayPrice, isDisplayUsdNetwork } from "@/utils/displayUsdPerToken";
+import {
+  collectAlgorandMainnetDisplayAsaIds,
+  resolveAsaIdForDisplayUsd,
+} from "@/utils/resolveAsaIdForDisplayUsd";
 import {
   analyticsMarketUsdKey,
   sumProtocolUsdTotals,
@@ -93,6 +98,32 @@ function marketUsdPerToken(market: MarketInfo): number {
   return usdPerTokenFromPortfolioMarketRow(market, market.decimals || 6, {
     displaySymbol: market.symbol,
   });
+}
+
+function marketDisplayUsdPerToken(
+  market: MarketInfo,
+  dexUsdByAsaId: Map<number, number>
+): number {
+  const protocolUsd = marketUsdPerToken(market);
+  if (!isDisplayUsdNetwork(market.networkId) || dexUsdByAsaId.size === 0) {
+    return protocolUsd;
+  }
+  const asaId = resolveAsaIdForDisplayUsd({
+    networkId: market.networkId,
+    poolId: market.poolId,
+    marketId: market.marketId,
+    displaySymbol: market.symbol,
+  });
+  const dexUsd = asaId != null ? dexUsdByAsaId.get(asaId) : undefined;
+  return overlayUsdWithDisplayPrice(protocolUsd, dexUsd);
+}
+
+async function fetchDisplayUsdByAsaId(): Promise<Map<number, number>> {
+  try {
+    return await fetchTinymanAssetUsdMap(collectAlgorandMainnetDisplayAsaIds());
+  } catch {
+    return new Map();
+  }
 }
 
 async function hydrateNetworkMarkets(
@@ -190,11 +221,13 @@ async function fetchHydratedAnalyticsMarkets(): Promise<MarketInfo[] | null> {
 }
 
 export function buildAnalyticsMarketUsdLookup(
-  markets: MarketInfo[]
+  markets: MarketInfo[],
+  dexUsdByAsaId?: Map<number, number>
 ): Map<string, AnalyticsMarketUsdQuote> {
   const lookup = new Map<string, AnalyticsMarketUsdQuote>();
+  const dex = dexUsdByAsaId ?? new Map<number, number>();
   for (const market of markets) {
-    const usdPerToken = marketUsdPerToken(market);
+    const usdPerToken = marketDisplayUsdPerToken(market, dex);
     if (!(usdPerToken > 0)) continue;
     const key = analyticsMarketUsdKey(market.networkId, market.marketId);
     if (!lookup.has(key)) {
@@ -207,23 +240,29 @@ export function buildAnalyticsMarketUsdLookup(
   return lookup;
 }
 
-/** Oracle USD/token + decimals keyed by `network|marketId`. */
+/** Display USD/token + decimals keyed by `network|marketId`. */
 export async function fetchAnalyticsMarketUsdLookup(): Promise<
   Map<string, AnalyticsMarketUsdQuote>
 > {
-  const markets = await fetchHydratedAnalyticsMarkets();
-  return buildAnalyticsMarketUsdLookup(markets ?? []);
+  const [markets, dexUsdByAsaId] = await Promise.all([
+    fetchHydratedAnalyticsMarkets(),
+    fetchDisplayUsdByAsaId(),
+  ]);
+  return buildAnalyticsMarketUsdLookup(markets ?? [], dexUsdByAsaId);
 }
 
 async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {
-  const markets = await fetchHydratedAnalyticsMarkets();
+  const [markets, dexUsdByAsaId] = await Promise.all([
+    fetchHydratedAnalyticsMarkets(),
+    fetchDisplayUsdByAsaId(),
+  ]);
   if (!markets || markets.length === 0) return null;
 
   const totals = sumProtocolUsdTotals(
     markets.map((market) => ({
       totalDeposits: market.totalDeposits,
       totalBorrows: market.totalBorrows,
-      usdPerToken: marketUsdPerToken(market),
+      usdPerToken: marketDisplayUsdPerToken(market, dexUsdByAsaId),
     }))
   );
   if (!(totals.tvl > 0)) return null;
@@ -235,7 +274,7 @@ async function computeOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTo
 }
 
 /**
- * Live protocol TVL and borrowed (oracle USD × human deposit/borrow amounts).
+ * Live protocol TVL and borrowed (display USD × human deposit/borrow amounts).
  * Dedupes concurrent callers and caches for {@link ORACLE_TVL_CACHE_TTL_MS}.
  */
 export async function fetchOracleBasedProtocolTotals(): Promise<OracleBasedProtocolTotals | null> {

--- a/src/services/lendingService.ts
+++ b/src/services/lendingService.ts
@@ -477,19 +477,6 @@ export type FetchMarketInfoContractMethod = "sync_market" | "get_market";
 
 const ORACLE_PRICE_CACHE_TTL_MS = 60_000;
 
-/**
- * On Pool A, fWBTC's price-oracle feed tracks spot BTC; goBTC's own oracle entry can lag.
- * When resolving goBTC display price, also consider these reference market contract IDs.
- */
-const ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS: Partial<
-  Record<string, string[]>
-> = {
-  "3333688282": ["3575837891"],
-};
-
-/** Symbols that can use the Pool A fWBTC oracle feed when their own entry is stale/missing. */
-const BTC_ORACLE_REFERENCE_SYMBOLS = new Set(["GOBTC", "WBTC", "BTC"]);
-
 async function readOracleUsdPerToken(
   networkId: NetworkId,
   oracleKey: string,
@@ -585,20 +572,8 @@ async function applyOraclePriceToMarketInfo(
     );
   };
 
-  // Primary keys first — avoid BTC-ref RPCs when the market's own feed is live.
-  let candidates = await collectFromKeys(oracleKeys);
-
-  const sym = marketInfo.symbol.toUpperCase();
-  const btcRefMarkets =
-    ALGORAND_POOL_BTC_ORACLE_REFERENCE_MARKETS[marketInfo.poolId];
-  if (
-    candidates.length === 0 &&
-    btcRefMarkets &&
-    BTC_ORACLE_REFERENCE_SYMBOLS.has(sym)
-  ) {
-    const refKeys = btcRefMarkets.filter((id) => !oracleKeys.includes(id));
-    candidates = await collectFromKeys(refKeys);
-  }
+  // This market's own oracle keys only — never another wrapper's feed.
+  const candidates = await collectFromKeys(oracleKeys);
 
   if (candidates.length === 0) return;
 

--- a/src/services/tinymanAssetUsd.ts
+++ b/src/services/tinymanAssetUsd.ts
@@ -1,0 +1,49 @@
+import { withRpcReadCache } from "@/utils/rpcReadCache";
+import { runWithConcurrency } from "@/utils/runWithConcurrency";
+import { isPositiveUsd } from "@/utils/displayUsdPerToken";
+
+const TINYMAN_ASSET_USD_URL =
+  "https://mainnet.analytics.tinyman.org/api/v1/assets";
+const FETCH_TTL_MS = 25_000;
+const FETCH_CONCURRENCY = 8;
+const FETCH_TIMEOUT_MS = 8_000;
+
+async function fetchTinymanAssetUsd(asaId: number): Promise<number | null> {
+  return withRpcReadCache(
+    `tinymanAssetUsd:${asaId}`,
+    async () => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(`${TINYMAN_ASSET_USD_URL}/${asaId}/`, {
+          signal: ctrl.signal,
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as { price_in_usd?: unknown };
+        const usd = Number.parseFloat(String(data.price_in_usd ?? ""));
+        return isPositiveUsd(usd) ? usd : null;
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    FETCH_TTL_MS,
+    { shouldCache: (v) => v != null && isPositiveUsd(v) }
+  );
+}
+
+/** Live Tinyman USD for each ASA. Failed ids are omitted — never invented. */
+export async function fetchTinymanAssetUsdMap(
+  asaIds: readonly number[]
+): Promise<Map<number, number>> {
+  const unique = [
+    ...new Set(asaIds.filter((id) => Number.isFinite(id) && id >= 0)),
+  ];
+  const out = new Map<number, number>();
+  await runWithConcurrency(unique, FETCH_CONCURRENCY, async (asaId) => {
+    const usd = await fetchTinymanAssetUsd(asaId);
+    if (isPositiveUsd(usd)) out.set(asaId, usd);
+  });
+  return out;
+}

--- a/src/utils/__tests__/displayUsdPerToken.test.ts
+++ b/src/utils/__tests__/displayUsdPerToken.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDisplayUsdNetwork,
+  overlayUsdWithDisplayPrice,
+  parseAsaIdForDisplay,
+  resolveDisplayUsdPerToken,
+  scaleUsdAmountWithDisplayPrice,
+} from "@/utils/displayUsdPerToken";
+
+describe("parseAsaIdForDisplay", () => {
+  it("uses this asset's DEX USD when present", () => {
+    expect(
+      resolveDisplayUsdPerToken({ dexUsd: 76_124, protocolUsd: 60_725 })
+    ).toBe(76_124);
+  });
+
+  it("falls back to this market's protocol USD when DEX is missing", () => {
+    expect(
+      resolveDisplayUsdPerToken({ dexUsd: null, protocolUsd: 60_725 })
+    ).toBe(60_725);
+  });
+
+  it("returns 0 when both sources are invalid", () => {
+    expect(resolveDisplayUsdPerToken({ dexUsd: 0, protocolUsd: NaN })).toBe(0);
+  });
+
+  it("never prefers a zero DEX over protocol", () => {
+    expect(
+      resolveDisplayUsdPerToken({ dexUsd: 0, protocolUsd: 72_793 })
+    ).toBe(72_793);
+  });
+});
+
+describe("parseAsaIdForDisplay", () => {
+  it("accepts ALGO (0) and goBTC", () => {
+    expect(parseAsaIdForDisplay("0")).toBe(0);
+    expect(parseAsaIdForDisplay("386192725")).toBe(386192725);
+  });
+
+  it("rejects non-numeric ids", () => {
+    expect(parseAsaIdForDisplay("goBTC")).toBeNull();
+    expect(parseAsaIdForDisplay("")).toBeNull();
+  });
+});
+
+describe("overlayUsdWithDisplayPrice", () => {
+  it("keeps goBTC and wBTC independent", () => {
+    const goBtc = overlayUsdWithDisplayPrice(60_725, 76_124);
+    const wBtc = overlayUsdWithDisplayPrice(75_440, 72_793);
+    expect(goBtc).toBe(76_124);
+    expect(wBtc).toBe(72_793);
+    expect(goBtc).not.toBe(wBtc);
+  });
+});
+
+describe("scaleUsdAmountWithDisplayPrice", () => {
+  it("reprices goBTC TVL from this asset's DEX, not wBTC", () => {
+    const protocolTvl = 0.536955 * 60_725;
+    const overlayed = scaleUsdAmountWithDisplayPrice(
+      protocolTvl,
+      60_725,
+      76_124
+    );
+    expect(overlayed).toBeCloseTo(0.536955 * 76_124, 5);
+    expect(overlayed).not.toBeCloseTo(0.536955 * 72_793, 0);
+  });
+
+  it("keeps protocol USD when DEX is missing", () => {
+    expect(scaleUsdAmountWithDisplayPrice(1_000, 60_725, null)).toBe(1_000);
+  });
+});
+
+describe("isDisplayUsdNetwork", () => {
+  it("is Algorand mainnet only", () => {
+    expect(isDisplayUsdNetwork("algorand-mainnet")).toBe(true);
+    expect(isDisplayUsdNetwork("voi-mainnet")).toBe(false);
+    expect(isDisplayUsdNetwork("algorand-testnet")).toBe(false);
+    expect(isDisplayUsdNetwork(null)).toBe(false);
+  });
+});

--- a/src/utils/__tests__/overlayOnDemandMarketUsd.test.ts
+++ b/src/utils/__tests__/overlayOnDemandMarketUsd.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { overlayOnDemandMarketDisplayUsd } from "@/utils/overlayOnDemandMarketUsd";
+
+describe("overlayOnDemandMarketDisplayUsd", () => {
+  it("scales goBTC market TVL from its own DEX USD", () => {
+    const row = overlayOnDemandMarketDisplayUsd(
+      {
+        asset: "goBTC",
+        configSymbol: "goBTC",
+        poolId: "3333688282",
+        totalSupplyUSD: 0.536955 * 60_725 * 1_000_000,
+        totalBorrowUSD: 0,
+        supplyCapUSD: 1 * 60_725 * 1_000_000,
+        marketInfo: {
+          decimals: 8,
+          marketId: "3211820549",
+          oracleUsdPerToken: 60_725,
+          price: "1",
+          symbol: "goBTC",
+        },
+      },
+      "algorand-mainnet",
+      new Map([
+        [386192725, 76_124],
+        [1058926737, 72_793],
+      ])
+    );
+    expect(row.totalSupplyUSD / 1_000_000).toBeCloseTo(0.536955 * 76_124, 2);
+    expect(row.supplyCapUSD / 1_000_000).toBeCloseTo(76_124, 2);
+  });
+
+  it("does not overlay VOI market TVL from Tinyman ALGO", () => {
+    const row = overlayOnDemandMarketDisplayUsd(
+      {
+        asset: "VOI",
+        configSymbol: "VOI",
+        poolId: "41760711",
+        totalSupplyUSD: 1000,
+        totalBorrowUSD: 0,
+        supplyCapUSD: 1000,
+        marketInfo: {
+          decimals: 6,
+          marketId: "41877720",
+          oracleUsdPerToken: 0.012,
+          price: "1",
+          symbol: "VOI",
+        },
+      },
+      "voi-mainnet",
+      new Map([[0, 0.0914]])
+    );
+    expect(row.totalSupplyUSD).toBe(1000);
+  });
+});

--- a/src/utils/__tests__/overlayPositionDisplayUsd.test.ts
+++ b/src/utils/__tests__/overlayPositionDisplayUsd.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { overlayPositionsDisplayUsd } from "@/utils/overlayPositionDisplayUsd";
+import { resolveAsaIdForDisplayUsd } from "@/utils/resolveAsaIdForDisplayUsd";
+
+describe("resolveAsaIdForDisplayUsd", () => {
+  it("resolves goBTC and wBTC to different ASAs", () => {
+    const goBtc = resolveAsaIdForDisplayUsd({
+      networkId: "algorand-mainnet",
+      poolId: "3333688282",
+      marketId: "3211820549",
+      configKey: "goBTC",
+      displaySymbol: "goBTC",
+    });
+    const wBtc = resolveAsaIdForDisplayUsd({
+      networkId: "algorand-mainnet",
+      poolId: "3333688282",
+      marketId: "3211827406",
+      configKey: "wBTC",
+      displaySymbol: "wBTC",
+    });
+    expect(goBtc).toBe(386192725);
+    expect(wBtc).toBe(1058926737);
+    expect(goBtc).not.toBe(wBtc);
+  });
+
+  it("does not resolve VOI native to ALGO ASA 0", () => {
+    expect(
+      resolveAsaIdForDisplayUsd({
+        networkId: "voi-mainnet",
+        poolId: "41760711",
+        marketId: "41877720",
+        configKey: "VOI",
+        displaySymbol: "VOI",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("overlayPositionsDisplayUsd", () => {
+  it("revalues goBTC from its own DEX map entry, not wBTC", () => {
+    const dex = new Map<number, number>([
+      [386192725, 76_124],
+      [1058926737, 72_793],
+    ]);
+    const [goBtc] = overlayPositionsDisplayUsd(
+      [
+        {
+          asset: "goBTC",
+          configSymbol: "goBTC",
+          network: "algorand-mainnet",
+          poolId: "3333688282",
+          marketId: "3211820549",
+          balance: 0.5,
+          tokenPrice: 60_725,
+          value: 0.5 * 60_725,
+        },
+      ],
+      dex
+    );
+    expect(goBtc.tokenPrice).toBe(76_124);
+    expect(goBtc.value).toBeCloseTo(0.5 * 76_124, 5);
+  });
+
+  it("does not reprice a VOI position from Tinyman ALGO (ASA 0)", () => {
+    const dex = new Map<number, number>([[0, 0.0914]]);
+    const protocol = 0.012;
+    const [voi] = overlayPositionsDisplayUsd(
+      [
+        {
+          asset: "VOI",
+          configSymbol: "VOI",
+          network: "voi-mainnet",
+          poolId: "41760711",
+          marketId: "41877720",
+          balance: 1000,
+          tokenPrice: protocol,
+          value: 1000 * protocol,
+        },
+      ],
+      dex
+    );
+    expect(voi.tokenPrice).toBe(protocol);
+    expect(voi.value).toBe(1000 * protocol);
+  });
+
+  it("overlays Algorand rows in a mixed list without touching VOI", () => {
+    const dex = new Map<number, number>([
+      [0, 0.0914],
+      [386192725, 76_124],
+    ]);
+    const [goBtc, voi] = overlayPositionsDisplayUsd(
+      [
+        {
+          asset: "goBTC",
+          configSymbol: "goBTC",
+          network: "algorand-mainnet",
+          poolId: "3333688282",
+          marketId: "3211820549",
+          balance: 0.5,
+          tokenPrice: 60_725,
+          value: 0.5 * 60_725,
+        },
+        {
+          asset: "VOI",
+          configSymbol: "VOI",
+          network: "voi-mainnet",
+          poolId: "41760711",
+          marketId: "41877720",
+          balance: 1000,
+          tokenPrice: 0.012,
+          value: 12,
+        },
+      ],
+      dex
+    );
+    expect(goBtc.tokenPrice).toBe(76_124);
+    expect(voi.tokenPrice).toBe(0.012);
+    expect(voi.value).toBe(12);
+  });
+});

--- a/src/utils/displayUsdPerToken.ts
+++ b/src/utils/displayUsdPerToken.ts
@@ -1,0 +1,64 @@
+/**
+ * Display USD per token: each ASA/market is priced independently.
+ * Never copy another wrapper's feed (goBTC ≠ wBTC ≠ fWBTC ≠ BTC).
+ */
+
+export const DISPLAY_USD_POLL_MS = 30_000;
+
+/** Tinyman display overlay is Algorand mainnet only (not VOI, not testnet). */
+export const DISPLAY_USD_NETWORK_ID = "algorand-mainnet";
+
+export function isDisplayUsdNetwork(
+  networkId: string | null | undefined
+): boolean {
+  return networkId === DISPLAY_USD_NETWORK_ID;
+}
+
+export function isPositiveUsd(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Prefer this asset's DEX USD; otherwise this market's own protocol/oracle USD.
+ * Does not accept a substitute from a different asset.
+ */
+export function resolveDisplayUsdPerToken(args: {
+  dexUsd?: number | null;
+  protocolUsd?: number | null;
+}): number {
+  if (isPositiveUsd(args.dexUsd)) return args.dexUsd;
+  if (isPositiveUsd(args.protocolUsd)) return args.protocolUsd;
+  return 0;
+}
+
+export function parseAsaIdForDisplay(raw: unknown): number | null {
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  if (!/^\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+export function overlayUsdWithDisplayPrice(
+  protocolUsdPerToken: number,
+  dexUsd: number | undefined | null
+): number {
+  return resolveDisplayUsdPerToken({
+    dexUsd,
+    protocolUsd: protocolUsdPerToken,
+  });
+}
+
+/** Revalue a USD amount when display USD/token differs from protocol USD/token. */
+export function scaleUsdAmountWithDisplayPrice(
+  protocolUsdAmount: number,
+  protocolUsdPerToken: number,
+  dexUsd: number | undefined | null
+): number {
+  if (!Number.isFinite(protocolUsdAmount)) return protocolUsdAmount;
+  const next = overlayUsdWithDisplayPrice(protocolUsdPerToken, dexUsd);
+  if (!(protocolUsdPerToken > 0) || !(next > 0) || next === protocolUsdPerToken) {
+    return protocolUsdAmount;
+  }
+  return protocolUsdAmount * (next / protocolUsdPerToken);
+}

--- a/src/utils/overlayOnDemandMarketUsd.ts
+++ b/src/utils/overlayOnDemandMarketUsd.ts
@@ -1,0 +1,100 @@
+import type { NetworkId } from "@/config";
+import { usdPerTokenFromPortfolioMarketRow } from "@/utils/assetDecimals";
+import {
+  isDisplayUsdNetwork,
+  scaleUsdAmountWithDisplayPrice,
+} from "@/utils/displayUsdPerToken";
+import { resolveAsaIdForDisplayUsd } from "@/utils/resolveAsaIdForDisplayUsd";
+
+type MarketUsdRow = {
+  asset: string;
+  configSymbol?: string;
+  poolId?: string;
+  totalSupplyUSD: number;
+  totalBorrowUSD: number;
+  supplyCapUSD: number;
+  marketInfo?: {
+    decimals?: number;
+    marketId?: string | number;
+    price?: string;
+    oracleUsdPerToken?: number;
+    symbol?: string;
+  };
+};
+
+export function overlayOnDemandMarketDisplayUsd<T extends MarketUsdRow>(
+  row: T,
+  networkId: NetworkId | string,
+  dexUsdByAsaId: Map<number, number>
+): T {
+  if (!isDisplayUsdNetwork(networkId) || dexUsdByAsaId.size === 0) {
+    return row;
+  }
+  const protocolUsd = usdPerTokenFromPortfolioMarketRow(
+    row.marketInfo,
+    row.marketInfo?.decimals || 6,
+    { displaySymbol: row.asset }
+  );
+  if (!(protocolUsd > 0)) return row;
+
+  const asaId = resolveAsaIdForDisplayUsd({
+    networkId,
+    poolId: row.poolId,
+    marketId:
+      row.marketInfo?.marketId != null ? String(row.marketInfo.marketId) : null,
+    configKey: row.configSymbol,
+    displaySymbol: row.asset,
+  });
+  const dexUsd = asaId != null ? dexUsdByAsaId.get(asaId) : undefined;
+
+  const nextSupply = scaleUsdAmountWithDisplayPrice(
+    row.totalSupplyUSD,
+    protocolUsd,
+    dexUsd
+  );
+  const nextBorrow = scaleUsdAmountWithDisplayPrice(
+    row.totalBorrowUSD,
+    protocolUsd,
+    dexUsd
+  );
+  const nextCap = scaleUsdAmountWithDisplayPrice(
+    row.supplyCapUSD,
+    protocolUsd,
+    dexUsd
+  );
+  if (
+    nextSupply === row.totalSupplyUSD &&
+    nextBorrow === row.totalBorrowUSD &&
+    nextCap === row.supplyCapUSD
+  ) {
+    return row;
+  }
+  return {
+    ...row,
+    totalSupplyUSD: nextSupply,
+    totalBorrowUSD: nextBorrow,
+    supplyCapUSD: nextCap,
+  };
+}
+
+export function overlayOnDemandMarketsRecord<T extends MarketUsdRow>(
+  marketsData: Record<string, T>,
+  networkId: NetworkId | string,
+  dexUsdByAsaId: Map<number, number>
+): Record<string, T> {
+  if (!isDisplayUsdNetwork(networkId) || dexUsdByAsaId.size === 0) {
+    return marketsData;
+  }
+  let changed = false;
+  const next: Record<string, T> = {};
+  for (const [key, row] of Object.entries(marketsData)) {
+    const overlayed = overlayOnDemandMarketDisplayUsd(
+      row,
+      networkId,
+      dexUsdByAsaId
+    );
+    next[key] = overlayed;
+    if (overlayed !== row) changed = true;
+  }
+  return changed ? next : marketsData;
+}

--- a/src/utils/overlayPositionDisplayUsd.ts
+++ b/src/utils/overlayPositionDisplayUsd.ts
@@ -1,0 +1,64 @@
+import {
+  isDisplayUsdNetwork,
+  overlayUsdWithDisplayPrice,
+} from "@/utils/displayUsdPerToken";
+import { resolveAsaIdForDisplayUsd } from "@/utils/resolveAsaIdForDisplayUsd";
+
+type PositionLike = {
+  value?: number;
+  tokenPrice?: number;
+  balance?: number;
+  network?: string;
+  poolId?: string;
+  marketId?: string;
+  configSymbol?: string;
+  originalSymbol?: string;
+  asset?: string;
+  accruedInterest?: number;
+  accruedInterestValue?: number;
+  interest?: number;
+};
+
+export function overlayPositionDisplayUsd<T extends PositionLike>(
+  position: T,
+  dexUsdByAsaId: Map<number, number>
+): T {
+  if (!isDisplayUsdNetwork(position.network)) {
+    return position;
+  }
+  const asaId = resolveAsaIdForDisplayUsd({
+    networkId: position.network,
+    poolId: position.poolId,
+    marketId: position.marketId,
+    configKey: position.configSymbol,
+    originalSymbol: position.originalSymbol,
+    displaySymbol: position.asset,
+  });
+  const dexUsd = asaId != null ? dexUsdByAsaId.get(asaId) : undefined;
+  const nextPrice = overlayUsdWithDisplayPrice(
+    position.tokenPrice ?? 0,
+    dexUsd
+  );
+  if (!(nextPrice > 0) || nextPrice === position.tokenPrice) {
+    return position;
+  }
+  const balance = position.balance ?? 0;
+  const interest = position.accruedInterest ?? position.interest;
+  return {
+    ...position,
+    tokenPrice: nextPrice,
+    value: balance * nextPrice,
+    accruedInterestValue:
+      interest != null && Number.isFinite(interest)
+        ? interest * nextPrice
+        : position.accruedInterestValue,
+  };
+}
+
+export function overlayPositionsDisplayUsd<T extends PositionLike>(
+  positions: T[],
+  dexUsdByAsaId: Map<number, number>
+): T[] {
+  if (dexUsdByAsaId.size === 0) return positions;
+  return positions.map((p) => overlayPositionDisplayUsd(p, dexUsdByAsaId));
+}

--- a/src/utils/resolveAsaIdForDisplayUsd.ts
+++ b/src/utils/resolveAsaIdForDisplayUsd.ts
@@ -1,0 +1,94 @@
+import {
+  asTokenConfig,
+  getAllTokensWithDisplayInfo,
+  getTokenConfig,
+  type NetworkId,
+} from "@/config";
+import {
+  isDisplayUsdNetwork,
+  parseAsaIdForDisplay,
+} from "@/utils/displayUsdPerToken";
+
+export function collectAlgorandMainnetDisplayAsaIds(): number[] {
+  const ids = new Set<number>();
+  for (const token of getAllTokensWithDisplayInfo("algorand-mainnet")) {
+    const id = parseAsaIdForDisplay(token.underlyingAssetId);
+    if (id != null) ids.add(id);
+  }
+  return [...ids].sort((a, b) => a - b);
+}
+
+/**
+ * Algorand mainnet ASA id for this market only (matched by pool + market contract).
+ * Returns null on VOI / other networks so Tinyman ALGO (ASA 0) cannot reprice them.
+ */
+export function resolveAsaIdForDisplayUsd(args: {
+  networkId: string | null | undefined;
+  poolId?: string | null;
+  marketId?: string | null;
+  configKey?: string | null;
+  originalSymbol?: string | null;
+  displaySymbol?: string | null;
+}): number | null {
+  const networkId = args.networkId as NetworkId | undefined;
+  if (!isDisplayUsdNetwork(networkId)) return null;
+
+  const poolStr =
+    args.poolId != null && String(args.poolId).trim() !== ""
+      ? String(args.poolId).trim()
+      : "";
+  const marketStr =
+    args.marketId != null && String(args.marketId).trim() !== ""
+      ? String(args.marketId).trim()
+      : "";
+
+  try {
+    const tokens = getAllTokensWithDisplayInfo(networkId);
+    const match = tokens.find((t) => {
+      if (poolStr && String(t.poolId ?? "") !== poolStr) return false;
+      if (marketStr) {
+        return String(t.underlyingContractId ?? "") === marketStr;
+      }
+      const key = args.configKey ?? args.originalSymbol ?? args.displaySymbol;
+      if (!key) return false;
+      return (
+        t.configKey === key ||
+        t.originalSymbol === key ||
+        t.symbol === key
+      );
+    });
+    const fromDisplay = parseAsaIdForDisplay(match?.underlyingAssetId);
+    if (fromDisplay != null) return fromDisplay;
+  } catch {
+    // unknown network in tests
+  }
+
+  const lookupKeys = [
+    args.configKey,
+    args.originalSymbol,
+    args.displaySymbol,
+  ].filter((k): k is string => !!k && k.trim() !== "");
+
+  for (const key of lookupKeys) {
+    try {
+      const raw = getTokenConfig(networkId, key);
+      if (!raw) continue;
+      if (Array.isArray(raw)) {
+        const byMarket =
+          marketStr !== ""
+            ? raw.find((c) => String(c.contractId ?? "").trim() === marketStr)
+            : undefined;
+        const row = byMarket ?? asTokenConfig(raw, poolStr || undefined);
+        const id = parseAsaIdForDisplay(row?.assetId);
+        if (id != null) return id;
+      } else {
+        const id = parseAsaIdForDisplay(raw.assetId);
+        if (id != null) return id;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Overlay Algorand mainnet display USD from each ASA's own Tinyman price (else that market's protocol/oracle), so Portfolio/Markets/Analytics/modals no longer show goBTC at a stale ~$60.7k book (~$32.6k on the investigation wallet vs ~$40.7k live).
- Stop substituting another BTC-family oracle (fWBTC/wBTC) onto goBTC.
- Gate the overlay to Algorand mainnet only so VOI native (asset 0) cannot inherit Tinyman ALGO USD.

## Test plan
- [ ] Unit tests: `npx vitest run src/utils/__tests__/displayUsdPerToken.test.ts src/utils/__tests__/overlayOnDemandMarketUsd.test.ts src/utils/__tests__/overlayPositionDisplayUsd.test.ts`
- [ ] Markets (Algorand): goBTC Total Supply is live Tinyman (~$62k / ~0.82), not protocol TVL ~$49.8k; wBTC stays on its own ASA; USDC stays ~$1
- [ ] Portfolio (connected Algorand wallet with goBTC): row USD ≈ `balance ×` Tinyman goBTC; header collateral moves with it
- [ ] Portfolio with a VOI position: VOI USD unchanged (not ALGO Tinyman)
- [ ] Footer Global Portfolio Data · Net Value still uses `get_global_user` (protocol book; DOR-487)
- [ ] VOI Markets tab: no Tinyman overlay / no pricing regressions

Fixes #601


Made with [Cursor](https://cursor.com)